### PR TITLE
Fix FrameData wiring for NULL tiles at the border

### DIFF
--- a/fabric_generator/fabric_gen.py
+++ b/fabric_generator/fabric_gen.py
@@ -1437,7 +1437,7 @@ class FabricGenerator:
             self.writer.addComment("CONFout is from tile entity")
 
         if self.fabric.configBitMode == ConfigBitMode.FRAME_BASED:
-            for y in range(1, len(self.fabric.tile)-1):
+            for y in range(len(self.fabric.tile)):
                 self.writer.addAssignVector(
                     f"Tile_Y{y}_FrameData", "FrameData", f"FrameBitsPerRow*({y}+1)-1", f"FrameBitsPerRow*{y}")
             for x in range(len(self.fabric.tile[0])):
@@ -1616,6 +1616,12 @@ class FabricGenerator:
                                 portsPairs.append(
                                     (f"{pre}FrameData", f"Tile_Y{y}_FrameData"))
 
+                            # For the second column, directly connect the tiles
+                            # to FrameData if the previous tile was NULL
+                            elif x == 1 and self.fabric.tile[y][0] == None:
+                                portsPairs.append(
+                                    (f"{pre}FrameData", f"Tile_Y{y}_FrameData"))
+
                             elif (x+i-1, y+j) not in superTileLoc:
                                 portsPairs.append(
                                     (f"{pre}FrameData", f"Tile_X{x+i-1}Y{y+j}_FrameData_O"))
@@ -1640,7 +1646,9 @@ class FabricGenerator:
                             portsPairs.append(
                                 (f"{pre}FrameStrobe", f"Tile_X{x}_FrameStrobe"))
 
-                        elif y + 1 < self.fabric.numberOfRows and self.fabric.tile[y+1][x] == None:
+                        # For the second last row, directly connect the tiles
+                        # to FrameStrobe if the previous tile was NULL
+                        elif y == self.fabric.numberOfRows - 2 and self.fabric.tile[self.fabric.numberOfRows-1][x] == None:
                             portsPairs.append(
                                 (f"{pre}FrameStrobe", f"Tile_X{x}_FrameStrobe"))
 


### PR DESCRIPTION
The current demo fabric looks somewhat like this:

```

-> NULL|term|term|...
-> W_IO|LUT |LUT |...
-> W_IO|LUT |LUT |...
-> W_IO|LUT |LUT |...
-> NULL|term|term|...
    ^    ^    ^
    |    |    |
```

FrameData and FrameStrobe are wired from tile to tile. The horizontal arrows show how FrameData is wired and the vertical arrows show how FrameStrobe is wired. NULL tiles are omitted, therefore FrameData and FrameStrobe are not passed on.

This is a problem because, for example, the lower left NULL tile does not pass on its FrameStrobe to the W_IOs above and it does not pass its FrameStrobe to the termination tiles to its right.

What has been done on current master to prevent this problem? For FrameStrobe: if the previous tile is NULL, skip it and connect directly to the next tile. For the termination tiles nothing has been done since they have no configuration bits.

*But* if you want to create a fabric where the termination tiles contain a switch matrix or you want IO tiles in the first and last row this approach no longer works.

Therefore, this PR makes two changes:

1. Allow for FrameData generation for the first and last row.
2. For tiles in the second column, if the previous tile was NULL, connect `Tile_Y{y}_FrameData` directly to it.

This allows for tiles that need config bits in the first and last row, e.g. N_IO and S_IO.

---

There is another problem with the current workaround: It was only intended as a solution for for NULL tiles around the border of the fabric. If there is a NULL tile anywhere else, the next tile will get connected to the FrameStrobe of the *column* and not to the previous non-NULL tile.

```
NULL|term|term|...
W_IO|LUT |LUT |...
NULL|LUT |LUT |...
W_IO|LUT |LUT |...
NULL|term|term|...
 ^    ^    ^
 |    |    |
```

In this case the second W_IO tile won't be connected to the FrameStrobe of the W_IO two tiles before it, but both W_IO tiles will get connected to the FrameStrobe of the *column*. This is logically correct, but the FrameStrobe of the *column* will have a higher fanout which is not wanted.

For this reason, I have changed the current solution to only apply for tiles in the second column (FrameData) and tiles in the second last row (FrameStrobe).

A proper solution would allow for a variable amount of NULL tiles between tiles and still connect the FrameStrobe to the previous non-NULL tile.