### PR TITLE
Add generative IOs

### DIFF
--- a/FABulous/fabric_definition/Gen_IO.py
+++ b/FABulous/fabric_definition/Gen_IO.py
@@ -13,9 +13,19 @@ class Gen_IO:
         prefix (str): The prefix of the GEN_IO given in the CSV file.
         pins (int): Number of IOs.
         IO (IO) : Direction of the IOs, either INPUT or OUTPUT.
-        params (Dict[str, str]): Additional parameters for GEN_IO.
+        configBit (int) : The number of accessible config bits for config access GEN_IO.
+        params : Additional parameters of GEN_IOs.
+            - configAccess (bool) : Whether the GEN_IO is config access.
+                                    Routes access to config bits, directly to TOP.
+                                    This GEN_IOs are not connected to the switchmatrix,
+                                    Can only be used as an OUTPUT.
     """
 
     prefix: str
     pins: int
     IO: IO
+    configBit: int = 0
+
+    # Paramters for GEN_IO:
+    configAccess: bool = False
+    inverted: bool = False

--- a/FABulous/fabric_definition/Gen_IO.py
+++ b/FABulous/fabric_definition/Gen_IO.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass, field
+from FABulous.fabric_definition.define import IO
+
+
+@dataclass
+class Gen_IO:
+    """
+    Contains all the information about a generated IO port (GEN_IO).
+    The information is parsed from the GEN_IO in the CSV
+    definition file. There are something to be noted.
+
+    Attributes:
+        prefix (str): The prefix of the GEN_IO given in the CSV file.
+        pins (int): Number of IOs.
+        IO (IO) : Direction of the IOs, either INPUT or OUTPUT.
+        params (Dict[str, str]): Additional parameters for GEN_IO.
+    """
+
+    prefix: str
+    pins: int
+    IO: IO

--- a/FABulous/fabric_definition/Gen_IO.py
+++ b/FABulous/fabric_definition/Gen_IO.py
@@ -19,6 +19,7 @@ class Gen_IO:
                                     Routes access to config bits, directly to TOP.
                                     This GEN_IOs are not connected to the switchmatrix,
                                     Can only be used as an OUTPUT.
+            - inverted (bool) : GEN_IO will be inverted.
     """
 
     prefix: str

--- a/FABulous/fabric_definition/Gen_IO.py
+++ b/FABulous/fabric_definition/Gen_IO.py
@@ -16,10 +16,11 @@ class Gen_IO:
     pins : int
         Number of IOs.
     IO : IO
-        Direction of the IOs, either INPUT or OUTPUT.
+        Direction of the IOs, either INPUT or OUTPUT, seen from the fabric side.
+        This means a fabric INPUT is an OUTPUT globally and vice versa.
     configBit : int
         The number of accessible config bits for config access GEN_IO.
-    configAccess (bool)
+    configAccess : bool
         Whether the GEN_IO is config access.
         Routes access to config bits, directly to TOP.
         This GEN_IOs are not connected to the switchmatrix,
@@ -27,7 +28,17 @@ class Gen_IO:
     inverted : bool
         GEN_IO will be inverted.
     clocked : bool
-        Adds a register to GEN_IO
+        Adds a register to GEN_IO.
+    clockedComb: bool
+        Creates two signals for every GEN_IO.
+        <prefix><Number>_Q: The clocked signal.
+        <prefix><Number>: The orignal cobinatorial signal.
+        If the GEN_IO is an INPUT, then there will be created
+        two signals to the top, <prefix><Number>_Q_top is the clocked input
+        signal and <prefix><Number>_top is the combinatorial input signal.
+        If the GEN_IO is an OUTPUT, then there will be two signals connected
+        to the switch matrix, <prefix><Number>_Q is the clocked output signal
+        and <prefix><Number> is the combinatorial output signal.
     """
 
     prefix: str
@@ -39,3 +50,4 @@ class Gen_IO:
     configAccess: bool = False
     inverted: bool = False
     clocked: bool = False
+    clockedComb: bool = False

--- a/FABulous/fabric_definition/Gen_IO.py
+++ b/FABulous/fabric_definition/Gen_IO.py
@@ -9,17 +9,25 @@ class Gen_IO:
     The information is parsed from the GEN_IO in the CSV
     definition file. There are something to be noted.
 
-    Attributes:
-        prefix (str): The prefix of the GEN_IO given in the CSV file.
-        pins (int): Number of IOs.
-        IO (IO) : Direction of the IOs, either INPUT or OUTPUT.
-        configBit (int) : The number of accessible config bits for config access GEN_IO.
-        params : Additional parameters of GEN_IOs.
-            - configAccess (bool) : Whether the GEN_IO is config access.
-                                    Routes access to config bits, directly to TOP.
-                                    This GEN_IOs are not connected to the switchmatrix,
-                                    Can only be used as an OUTPUT.
-            - inverted (bool) : GEN_IO will be inverted.
+    Attributes
+    ----------
+    prefix : str
+        The prefix of the GEN_IO given in the CSV file.
+    pins : int
+        Number of IOs.
+    IO : IO
+        Direction of the IOs, either INPUT or OUTPUT.
+    configBit : int
+        The number of accessible config bits for config access GEN_IO.
+    configAccess (bool)
+        Whether the GEN_IO is config access.
+        Routes access to config bits, directly to TOP.
+        This GEN_IOs are not connected to the switchmatrix,
+        Can only be used as an OUTPUT.
+    inverted : bool
+        GEN_IO will be inverted.
+    clocked : bool
+        Adds a register to GEN_IO
     """
 
     prefix: str
@@ -30,3 +38,4 @@ class Gen_IO:
     # Paramters for GEN_IO:
     configAccess: bool = False
     inverted: bool = False
+    clocked: bool = False

--- a/FABulous/fabric_definition/Tile.py
+++ b/FABulous/fabric_definition/Tile.py
@@ -69,6 +69,10 @@ class Tile:
         for b in self.bels:
             self.globalConfigBits += b.configBit
 
+        for gio in self.gen_ios:
+            if gio.configAccess:
+                self.globalConfigBits += gio.configBit
+
     def __eq__(self, __o: Any) -> bool:
         if __o is None or not isinstance(__o, Tile):
             return False

--- a/FABulous/fabric_definition/Tile.py
+++ b/FABulous/fabric_definition/Tile.py
@@ -22,7 +22,7 @@ class Tile:
         The list of ports of the tile
     matrixDir : str
         The directory of the tile matrix
-    gen_ios : (List[Gen_IO])
+    gen_ios : List[Gen_IO]
         The list of GEN_IOs of the tile
     globalConfigBits : int
         The number of config bits the tile has
@@ -38,7 +38,7 @@ class Tile:
     portsInfo: list[Port]
     bels: list[Bel]
     matrixDir: pathlib.Path
-    gen_ios = list[Gen_IO]
+    gen_ios: list[Gen_IO]
     globalConfigBits: int = 0
     withUserCLK: bool = False
     wireList: list[Wire] = field(default_factory=list)

--- a/FABulous/fabric_definition/Tile.py
+++ b/FABulous/fabric_definition/Tile.py
@@ -3,6 +3,7 @@ from enum import Enum
 from dataclasses import dataclass, field
 from FABulous.fabric_definition.define import IO, Direction, Side
 from FABulous.fabric_definition.Bel import Bel
+from FABulous.fabric_definition.Gen_IO import Gen_IO
 from FABulous.fabric_definition.Port import Port
 from FABulous.fabric_definition.Wire import Wire
 from typing import Any
@@ -21,6 +22,8 @@ class Tile:
         The list of ports of the tile
     matrixDir : str
         The directory of the tile matrix
+    gen_ios : (List[Gen_IO])
+        The list of GEN_IOs of the tile
     globalConfigBits : int
         The number of config bits the tile has
     withUserCLK : bool
@@ -35,6 +38,7 @@ class Tile:
     portsInfo: list[Port]
     bels: list[Bel]
     matrixDir: pathlib.Path
+    gen_ios = list[Gen_IO]
     globalConfigBits: int = 0
     withUserCLK: bool = False
     wireList: list[Wire] = field(default_factory=list)
@@ -48,12 +52,14 @@ class Tile:
         bels: list[Bel],
         tileDir: pathlib.Path,
         matrixDir: pathlib.Path,
+        gen_ios: list[Gen_IO],
         userCLK: bool,
         configBit: int = 0,
     ) -> None:
         self.name = name
         self.portsInfo = ports
         self.bels = bels
+        self.gen_ios = gen_ios
         self.matrixDir = matrixDir
         self.withUserCLK = userCLK
         self.globalConfigBits = configBit

--- a/FABulous/fabric_generator/code_generation_VHDL.py
+++ b/FABulous/fabric_generator/code_generation_VHDL.py
@@ -108,8 +108,20 @@ class VHDLWriter(codeGenerator):
     def addLogicEnd(self, indentLevel=0):
         self._add("\n" f"end" "\n", indentLevel)
 
+    def addRegister(self, reg, regIn, clk="CLK", inverted=False, indentLevel=0):
+        inv = "not " if inverted else ""
+        template = f"""
+process({clk})
+begin
+	if {clk}'event and {clk}='1' then
+		{reg} <= {inv}{regIn};
+	end if;
+end process;
+"""
+        self._add(template, indentLevel)
+
     def addAssignScalar(self, left, right, delay=0, indentLevel=0, inverted=False):
-        inv = "not" if inverted else ""
+        inv = "not " if inverted else ""
         if type(right) == list:
             self._add(
                 f"{left} <= {inv}{' & '.join(right)} after {delay} ps;", indentLevel
@@ -126,7 +138,7 @@ class VHDLWriter(codeGenerator):
     def addAssignVector(
         self, left, right, widthL, widthR, indentLevel=0, inverted=False
     ):
-        inv = "not" if inverted else ""
+        inv = "not " if inverted else ""
         self._add(f"{left} <= {inv}{right}( {widthL} downto {widthR} );", indentLevel)
 
     def addInstantiation(

--- a/FABulous/fabric_generator/code_generation_VHDL.py
+++ b/FABulous/fabric_generator/code_generation_VHDL.py
@@ -108,9 +108,12 @@ class VHDLWriter(codeGenerator):
     def addLogicEnd(self, indentLevel=0):
         self._add("\n" f"end" "\n", indentLevel)
 
-    def addAssignScalar(self, left, right, delay=0, indentLevel=0):
+    def addAssignScalar(self, left, right, delay=0, indentLevel=0, inverted=False):
+        inv = "not" if inverted else ""
         if type(right) == list:
-            self._add(f"{left} <= {' & '.join(right)} after {delay} ps;", indentLevel)
+            self._add(
+                f"{left} <= {inv}{' & '.join(right)} after {delay} ps;", indentLevel
+            )
         else:
             left = (
                 str(left).replace(":", " downto ").replace("[", "(").replace("]", ")")
@@ -118,10 +121,13 @@ class VHDLWriter(codeGenerator):
             right = (
                 str(right).replace(":", " downto ").replace("[", "(").replace("]", ")")
             )
-            self._add(f"{left} <= {right} after {delay} ps;", indentLevel)
+            self._add(f"{left} <= {inv}{right} after {delay} ps;", indentLevel)
 
-    def addAssignVector(self, left, right, widthL, widthR, indentLevel=0):
-        self._add(f"{left} <= {right}( {widthL} downto {widthR} );", indentLevel)
+    def addAssignVector(
+        self, left, right, widthL, widthR, indentLevel=0, inverted=False
+    ):
+        inv = "not" if inverted else ""
+        self._add(f"{left} <= {inv}{right}( {widthL} downto {widthR} );", indentLevel)
 
     def addInstantiation(
         self,

--- a/FABulous/fabric_generator/code_generation_Verilog.py
+++ b/FABulous/fabric_generator/code_generation_Verilog.py
@@ -192,14 +192,18 @@ class VerilogWriter(codeGenerator):
 """
         self._add(template, indentLevel)
 
-    def addAssignScalar(self, left, right, delay=0, indentLevel=0):
+    def addAssignScalar(self, left, right, delay=0, indentLevel=0, inverted=False):
+        inv = "~" if inverted else ""
         if type(right) == list:
-            self._add(f"assign {left} = {{{','.join(right)}}};", indentLevel)
+            self._add(f"assign {left} = {inv}{{{','.join(right)}}};", indentLevel)
         else:
-            self._add(f"assign {left} = {right};")
+            self._add(f"assign {left} = {inv}{right};")
 
-    def addAssignVector(self, left, right, widthL, widthR, indentLevel=0):
-        self._add(f"assign {left} = {right}[{widthL}:{widthR}];", indentLevel)
+    def addAssignVector(
+        self, left, right, widthL, widthR, indentLevel=0, inverted=False
+    ):
+        inv = "~" if inverted else ""
+        self._add(f"assign {left} = {inv}{right}[{widthL}:{widthR}];", indentLevel)
 
     def addPreprocIfDef(self, macro, indentLevel=0):
         self._add(f"`ifdef {macro}", indentLevel)

--- a/FABulous/fabric_generator/code_generation_Verilog.py
+++ b/FABulous/fabric_generator/code_generation_Verilog.py
@@ -192,6 +192,17 @@ class VerilogWriter(codeGenerator):
 """
         self._add(template, indentLevel)
 
+    def addRegister(self, reg, regIn, clk="CLK", inverted=False, indentLevel=0):
+        inv = "~" if inverted else ""
+        template = f"""
+reg {reg};
+always @ (posedge {clk})
+begin
+    {reg} <= {inv}{regIn};
+end
+"""
+        self._add(template, indentLevel)
+
     def addAssignScalar(self, left, right, delay=0, indentLevel=0, inverted=False):
         inv = "~" if inverted else ""
         if type(right) == list:

--- a/FABulous/fabric_generator/code_generator.py
+++ b/FABulous/fabric_generator/code_generator.py
@@ -513,6 +513,26 @@ class codeGenerator(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def addRegister(self, reg, regIn, clk="CLK", inverted=False, indentLevel=0):
+        """
+        Add a register.
+
+        Parameters
+        ----------
+        reg : str
+            The name of the register.
+        regIn : str
+            The input signal of the register.
+        clk : str, optional
+            The clock signal of the register. Defaults to "CLK".
+        inverted : bool, optional
+            Invert the input signal. Defaults to False.
+        indentLevel : int, optional
+            The level of indentation. Defaults to 0.
+        """
+        pass
+
+    @abc.abstractmethod
     def addAssignScalar(self, left, right, delay=0, indentLevel=0, inverted=False):
         """
         Add a scalar assign statement.

--- a/FABulous/fabric_generator/code_generator.py
+++ b/FABulous/fabric_generator/code_generator.py
@@ -513,10 +513,10 @@ class codeGenerator(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def addAssignScalar(self, left, right, delay=0, indentLevel=0):
-        """Add a scalar assign statement.
-
-        Delay is provided but currently not used by any of the code generators.
+    def addAssignScalar(self, left, right, delay=0, indentLevel=0, inverted=False):
+        """
+        Add a scalar assign statement.
+        Delay is provided by currently not being used by any of the code generator.
         If **right** is a list, it will be concatenated.
         Verilog will concatenate with comma ','.
         VHDL will concatenate with ampersand '&' instead.
@@ -531,6 +531,8 @@ class codeGenerator(abc.ABC):
             Delay in the assignment. Defaults to 0.
         indentLevel : int, optional
             The indentation Level. Defaults to 0.
+        inverted : bool, optional
+            Invert **right**. Default False.
 
         Examples
         --------
@@ -545,8 +547,11 @@ class codeGenerator(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def addAssignVector(self, left, right, widthL, widthR, indentLevel=0):
-        """Add a vector assign statement.
+    def addAssignVector(
+        self, left, right, widthL, widthR, indentLevel=0, inverted=False
+    ):
+        """
+        Add a vector assign statement.
 
         Parameters
         ----------
@@ -560,6 +565,8 @@ class codeGenerator(abc.ABC):
             The end index of the vector. Can be a string.
         indentLevel : int, optional
             The indentation Level. Defaults to 0.
+        inverted : bool, optional
+            Invert **right**. Default False.
 
         Examples
         --------

--- a/FABulous/fabric_generator/fabric_gen.py
+++ b/FABulous/fabric_generator/fabric_gen.py
@@ -1225,7 +1225,9 @@ class FabricGenerator:
             for j in range(gio.configBit):
                 if self.fabric.configBitMode == ConfigBitMode.FRAME_BASED:
                     self.writer.addAssignScalar(
-                        f"{gio.prefix}{j}", f"ConfigBits[{belConfigBitsCounter}]"
+                        f"{gio.prefix}{j}",
+                        f"ConfigBits[{belConfigBitsCounter}]",
+                        inverted=gio.inverted,
                     )
                     belConfigBitsCounter += 1
                 elif self.fabric.configBitMode == ConfigBitMode.FLIPFLOP_CHAIN:
@@ -1242,11 +1244,15 @@ class FabricGenerator:
                 for j in range(gio.pins):
                     if gio.IO == IO.INPUT:
                         self.writer.addAssignScalar(
-                            f"{gio.prefix}{j}_top", f"{gio.prefix}{j}"
+                            f"{gio.prefix}{j}_top",
+                            f"{gio.prefix}{j}",
+                            inverted=gio.inverted,
                         )
                     elif gio.IO == IO.OUTPUT:
                         self.writer.addAssignScalar(
-                            f"{gio.prefix}{j}", f"{gio.prefix}{j}_top"
+                            f"{gio.prefix}{j}",
+                            f"{gio.prefix}{j}_top",
+                            inverted=gio.inverted,
                         )
         if tile.gen_ios:
             self.writer.addNewLine()

--- a/FABulous/fabric_generator/fabric_gen.py
+++ b/FABulous/fabric_generator/fabric_gen.py
@@ -101,13 +101,15 @@ class FabricGenerator:
                 for p in b.outputs + b.externalOutput:
                     destName.append(f"{p}")
 
-            # GEN_IO wire
+            # GEN_IO wire if its not an config access port
+            # Config access ports are not connected to the switch matrix
             for gio in tile.gen_ios:
-                for j in range(gio.pins):
-                    if gio.IO == IO.INPUT:
-                        sourceName.append(f"{gio.prefix}{j}")
-                    elif gio.IO == IO.OUTPUT:
-                        destName.append(f"{gio.prefix}{j}")
+                if not gio.configAccess:
+                    for j in range(gio.pins):
+                        if gio.IO == IO.INPUT:
+                            sourceName.append(f"{gio.prefix}{j}")
+                        elif gio.IO == IO.OUTPUT:
+                            destName.append(f"{gio.prefix}{j}")
 
             # jump wire
             for i in tile.portsInfo:
@@ -503,12 +505,16 @@ class FabricGenerator:
 
         # gen_io wire input
         # GIO output is a switch matrix input
+        # Config access ports are not connected to the switch matrix
         for gio in tile.gen_ios:
-            for j in range(gio.pins):
-                if gio.IO == IO.OUTPUT:
-                    self.writer.addPortScalar(
-                        f"{gio.prefix}{j}", IO.INPUT, indentLevel=2
-                    )
+            if not gio.configAccess:
+                for j in range(gio.pins):
+                    if gio.IO == IO.OUTPUT:
+                        self.writer.addPortScalar(
+                            f"{gio.prefix}{j}", IO.INPUT, indentLevel=2
+                        )
+                        # if gio.inverted:
+                        #     self.writer.addPortScalar(f"{gio.prefix}{j}_N", IO.INPUT, indentLevel=2)
 
         # jump wire input
         for i in tile.portsInfo:
@@ -529,12 +535,14 @@ class FabricGenerator:
 
         # gen_io wire output
         # GIO input is a switch matrix output
+        # Config access ports are not connected to the switch matrix
         for gio in tile.gen_ios:
-            for j in range(gio.pins):
-                if gio.IO == IO.INPUT:
-                    self.writer.addPortScalar(
-                        f"{gio.prefix}{j}", IO.OUTPUT, indentLevel=2
-                    )
+            if not gio.configAccess:
+                for j in range(gio.pins):
+                    if gio.IO == IO.INPUT:
+                        self.writer.addPortScalar(
+                            f"{gio.prefix}{j}", IO.OUTPUT, indentLevel=2
+                        )
 
         # jump wire output
         for i in tile.portsInfo:
@@ -846,13 +854,20 @@ class FabricGenerator:
                     )
                     externalPorts.append((f"{gio.prefix}{j}_top", IO.OUTPUT))
                 elif gio.IO == IO.OUTPUT:
-                    self.writer.addPortScalar(
-                        f"{gio.prefix}{j}", IO.OUTPUT, indentLevel=2
-                    )
-                    self.writer.addPortScalar(
-                        f"{gio.prefix}{j}_top", IO.INPUT, indentLevel=2
-                    )
-                    externalPorts.append((f"{gio.prefix}{j}_top", IO.INPUT))
+                    if not gio.configAccess:
+                        self.writer.addPortScalar(
+                            f"{gio.prefix}{j}", IO.OUTPUT, indentLevel=2
+                        )
+                        self.writer.addPortScalar(
+                            f"{gio.prefix}{j}_top", IO.INPUT, indentLevel=2
+                        )
+                        externalPorts.append((f"{gio.prefix}{j}_top", IO.INPUT))
+                    else:
+                        # if the GIO is a config access port, we need to add it to the external ports
+                        self.writer.addPortScalar(
+                            f"{gio.prefix}{j}", IO.OUTPUT, indentLevel=2
+                        )
+                        externalPorts.append((f"{gio.prefix}{j}", IO.OUTPUT))
 
         self.writer.addComment("Tile IO ports from BELs", onNewLine=True, indentLevel=1)
 
@@ -1114,7 +1129,10 @@ class FabricGenerator:
             )
 
         # BEL component instantiations
-        self.writer.addComment("BEL component instantiations", onNewLine=True)
+        if tile.bels:
+            self.writer.addNewLine()
+            self.writer.addComment("BEL component instantiations", onNewLine=True)
+
         belCounter = 0
         belConfigBitsCounter = 0
         for bel in tile.bels:
@@ -1199,17 +1217,37 @@ class FabricGenerator:
             # for the next BEL (if any) for cascading configuration chain (this information is also needed for chaining the switch matrix)
             belCounter += 1
 
-        # gen_io wire assignments
+        # gen_io config bit access
+        if any(gio.configAccess for gio in tile.gen_ios):
+            self.writer.addNewLine()
+            self.writer.addComment("gen_io config bit access", onNewLine=True)
         for gio in tile.gen_ios:
-            for j in range(gio.pins):
-                if gio.IO == IO.INPUT:
+            for j in range(gio.configBit):
+                if self.fabric.configBitMode == ConfigBitMode.FRAME_BASED:
                     self.writer.addAssignScalar(
-                        f"{gio.prefix}{j}_top", f"{gio.prefix}{j}"
+                        f"{gio.prefix}{j}", f"ConfigBits[{belConfigBitsCounter}]"
                     )
-                elif gio.IO == IO.OUTPUT:
-                    self.writer.addAssignScalar(
-                        f"{gio.prefix}{j}", f"{gio.prefix}{j}_top"
+                    belConfigBitsCounter += 1
+                elif self.fabric.configBitMode == ConfigBitMode.FLIPFLOP_CHAIN:
+                    raise ValueError(
+                        "gen_io config bit access not implemented for ConfigBitMode.FLIPFLOP_CHAIN"
                     )
+
+        # gen_io wire assignments
+        if tile.gen_ios:
+            self.writer.addNewLine()
+            self.writer.addComment("gen_io wire assignments", onNewLine=True)
+        for gio in tile.gen_ios:
+            if not gio.configAccess:
+                for j in range(gio.pins):
+                    if gio.IO == IO.INPUT:
+                        self.writer.addAssignScalar(
+                            f"{gio.prefix}{j}_top", f"{gio.prefix}{j}"
+                        )
+                    elif gio.IO == IO.OUTPUT:
+                        self.writer.addAssignScalar(
+                            f"{gio.prefix}{j}", f"{gio.prefix}{j}_top"
+                        )
         if tile.gen_ios:
             self.writer.addNewLine()
 
@@ -1241,9 +1279,10 @@ class FabricGenerator:
 
         # gen_io input wire
         for gio in tile.gen_ios:
-            for j in range(gio.pins):
-                if gio.IO == IO.OUTPUT:
-                    portsPairs.append((f"{gio.prefix}{j}", f"{gio.prefix}{j}"))
+            if not gio.configAccess:
+                for j in range(gio.pins):
+                    if gio.IO == IO.OUTPUT:
+                        portsPairs.append((f"{gio.prefix}{j}", f"{gio.prefix}{j}"))
 
         # jump input wire
         port, signal = [], []
@@ -1270,11 +1309,12 @@ class FabricGenerator:
             for p in bel.inputs:
                 portsPairs.append((p, p))
 
-        # gen_io input wire
+        # gen_io output wire
         for gio in tile.gen_ios:
-            for j in range(gio.pins):
-                if gio.IO == IO.INPUT:
-                    portsPairs.append((f"{gio.prefix}{j}", f"{gio.prefix}{j}"))
+            if not gio.configAccess:
+                for j in range(gio.pins):
+                    if gio.IO == IO.INPUT:
+                        portsPairs.append((f"{gio.prefix}{j}", f"{gio.prefix}{j}"))
 
         # jump output wire
         port, signal = [], []
@@ -1384,17 +1424,25 @@ class FabricGenerator:
                         continue
                     self.writer.addPortScalar(p[0], p[1], indentLevel=2)
             for gio in i.gen_ios:
-                for j in range(gio.pins):
-                    # Since the _top ports are the only external ports, we only add them here
-                    # But they need to be inverted direction
-                    if gio.IO == IO.INPUT:
-                        self.writer.addPortScalar(
-                            f"{gio.prefix}{j}_top", IO.INPUT, indentLevel=2
-                        )
-                    elif gio.IO == IO.OUTPUT:
-                        self.writer.addPortScalar(
-                            f"{gio.prefix}{j}_top", IO.OUTPUT, indentLevel=2
-                        )
+                if not gio.configAccess:
+                    for j in range(gio.pins):
+                        # Since the _top ports are the only external ports, we only add them here
+                        # But they need to be inverted direction
+                        # TODO: is this still true?
+                        if gio.IO == IO.INPUT:
+                            self.writer.addPortScalar(
+                                f"{gio.prefix}{j}_top", IO.INPUT, indentLevel=2
+                            )
+                        elif gio.IO == IO.OUTPUT:
+                            self.writer.addPortScalar(
+                                f"{gio.prefix}{j}_top", IO.OUTPUT, indentLevel=2
+                            )
+                else:
+                    for j in range(gio.pins):
+                        if gio.IO == IO.OUTPUT:
+                            self.writer.addPortScalar(
+                                f"{gio.prefix}{j}", IO.OUTPUT, indentLevel=2
+                            )
 
         # add userCLK port
         # self.writer.addPortScalar("userCLK", IO.INPUT, indentLevel=2)
@@ -1683,11 +1731,18 @@ class FabricGenerator:
                                     indentLevel=2,
                                 )
                             elif gio.IO == IO.OUTPUT:
-                                self.writer.addPortScalar(
-                                    f"Tile_X{x}Y{y}_{gio.prefix}{j}_top",
-                                    IO.INPUT,
-                                    indentLevel=2,
-                                )
+                                if not gio.configAccess:
+                                    self.writer.addPortScalar(
+                                        f"Tile_X{x}Y{y}_{gio.prefix}{j}_top",
+                                        IO.INPUT,
+                                        indentLevel=2,
+                                    )
+                                else:
+                                    self.writer.addPortScalar(
+                                        f"Tile_X{x}Y{y}_{gio.prefix}{j}",
+                                        IO.OUTPUT,
+                                        indentLevel=2,
+                                    )
                             self.writer.addComment("EXTERNAL", onNewLine=False)
 
         if self.fabric.configBitMode == ConfigBitMode.FRAME_BASED:
@@ -2020,13 +2075,22 @@ class FabricGenerator:
                                 portsPairs.append(("UserCLK", p[0]))
 
                     for gio in self.fabric.tile[y + j][x + i].gen_ios:
-                        for k in range(gio.pins):
-                            portsPairs.append(
-                                (
-                                    f"{gio.prefix}{k}_top",
-                                    f"Tile_X{x+i}Y{y+j}_{gio.prefix}{k}",
+                        if not gio.configAccess:
+                            for k in range(gio.pins):
+                                portsPairs.append(
+                                    (
+                                        f"{gio.prefix}{k}_top",
+                                        f"Tile_X{x+i}Y{y+j}_{gio.prefix}{k}",
+                                    )
                                 )
-                            )
+                        else:
+                            for k in range(gio.pins):
+                                portsPairs.append(
+                                    (
+                                        f"{gio.prefix}{k}",
+                                        f"Tile_X{x+i}Y{y+j}_{gio.prefix}{k}",
+                                    )
+                                )
 
                 if not superTile:
                     # for userCLK
@@ -2230,9 +2294,15 @@ class FabricGenerator:
                                     (IO.OUTPUT, f"Tile_X{x}Y{y}_{gio.prefix}{j}_top")
                                 )
                             elif gio.IO == IO.OUTPUT:
-                                externalPorts.append(
-                                    (IO.INPUT, f"Tile_X{x}Y{y}_{gio.prefix}{j}_top")
-                                )
+                                if not gio.configAccess:
+                                    externalPorts.append(
+                                        (IO.INPUT, f"Tile_X{x}Y{y}_{gio.prefix}{j}_top")
+                                    )
+                                else:
+                                    externalPorts.append(
+                                        (IO.OUTPUT, f"Tile_X{x}Y{y}_{gio.prefix}{j}")
+                                    )
+
         for iodir, name in externalPorts:
             yx, indices, port = split_port(name)
             if port not in portGroups:
@@ -2605,6 +2675,17 @@ class FabricGenerator:
                                     }
                                 curBitOffset += len(keyDict[entry])
 
+                # TODO: Ckeck how Datastrucutre is actually working, and if 1 is always needed as Vlaue!
+                for gio in tile.gen_ios:
+                    for j in range(gio.configBit):
+                        curTileMap[f"{gio.prefix}{j}"] = {
+                            encodeDict[curBitOffset + j]: "1"
+                        }
+                        curTileMapNoMask[f"{gio.prefix}{j}"] = {
+                            encodeDict[curBitOffset + j]: "1"
+                        }
+                    curBitOffset += gio.configBit
+
                 # All the generation will be working on the tile level with the tileDic
                 # This is added to propagate the updated switch matrix to each of the tile in the fabric
                 if tile.matrixDir.suffix == ".list":
@@ -2643,4 +2724,3 @@ class FabricGenerator:
                 specData["TileSpecs_No_Mask"][f"X{x}Y{y}"] = curTileMapNoMask
 
         return specData
-

--- a/FABulous/fabric_generator/file_parser.py
+++ b/FABulous/fabric_generator/file_parser.py
@@ -1,4 +1,4 @@
-import csv
+        import csv
 import re
 import subprocess
 import json
@@ -9,6 +9,7 @@ from typing import Literal, overload
 from pathlib import Path
 from FABulous.fabric_generator.utilities import expandListPorts
 from FABulous.fabric_definition.Bel import Bel
+from FABulous.fabric_definition.Gen_IO import Gen_IO
 from FABulous.fabric_definition.Port import Port
 from FABulous.fabric_definition.Tile import Tile
 from FABulous.fabric_definition.SuperTile import SuperTile
@@ -21,7 +22,6 @@ from FABulous.fabric_definition.define import (
     ConfigBitMode,
     MultiplexerStyle,
 )
-
 
 oppositeDic = {"NORTH": "SOUTH", "SOUTH": "NORTH", "EAST": "WEST", "WEST": "EAST"}
 
@@ -95,7 +95,6 @@ def parseFabricCSV(fileName: str) -> Fabric:
     tileTypes = []
     tileDefs = []
     commonWirePair: list[tuple[str, str]] = []
-
     fabricTiles = []
     tileDic = {}
 
@@ -484,6 +483,7 @@ def parseTiles(fileName: Path) -> tuple[list[Tile], list[tuple[str, str]]]:
         ports: list[Port] = []
         bels: list[Bel] = []
         matrixDir: Path | None = None
+        gen_ios: list[Gen_IO] = []
         withUserCLK = False
         configBit = 0
         for item in t:
@@ -505,6 +505,8 @@ def parseTiles(fileName: Path) -> tuple[list[Tile], list[tuple[str, str]]]:
                     raise ValueError(
                         f"Invalid file type in {belFilePath} only .vhdl and .v are supported."
                     )
+            elif temp[0] == "GEN_IO":
+                gen_ios.append(Gen_IO(temp[3], int(temp[1]), IO[temp[2]]))
             elif temp[0] == "MATRIX":
                 matrixDir = fileName.parent.joinpath(temp[1])
                 configBit = 0
@@ -563,6 +565,7 @@ def parseTiles(fileName: Path) -> tuple[list[Tile], list[tuple[str, str]]]:
                     bels=bels,
                     tileDir=fileName,
                     matrixDir=matrixDir,
+                    gen_ios=gen_ios,
                     userCLK=withUserCLK,
                     configBit=configBit,
                 )

--- a/FABulous/fabric_generator/file_parser.py
+++ b/FABulous/fabric_generator/file_parser.py
@@ -1,4 +1,4 @@
-        import csv
+import csv
 import re
 import subprocess
 import json
@@ -506,7 +506,37 @@ def parseTiles(fileName: Path) -> tuple[list[Tile], list[tuple[str, str]]]:
                         f"Invalid file type in {belFilePath} only .vhdl and .v are supported."
                     )
             elif temp[0] == "GEN_IO":
-                gen_ios.append(Gen_IO(temp[3], int(temp[1]), IO[temp[2]]))
+                configBit = 0
+                configAccess = False
+                inverted = False
+                # Additional params can be added
+                for param in temp[4:]:
+                    param = param.strip()
+                    param = param.upper()
+
+                    if param == "CONFIGACCESS":
+                        if temp[2] != "OUTPUT":
+                            raise ValueError(
+                                "CONFIGACCESS can only be used with OUTPUT"
+                            )
+                        configAccess = True
+                        configBit = int(temp[1])
+                    elif param == "INVERTED":
+                        inverted = True
+                    elif param is None or param == "":
+                        continue
+                    else:
+                        raise ValueError(f"Unknown parameter {param} in GEN_IO")
+                gen_ios.append(
+                    Gen_IO(
+                        temp[3],
+                        int(temp[1]),
+                        IO[temp[2]],
+                        configBit,
+                        configAccess,
+                        inverted,
+                    )
+                )
             elif temp[0] == "MATRIX":
                 matrixDir = fileName.parent.joinpath(temp[1])
                 configBit = 0

--- a/FABulous/fabric_generator/file_parser.py
+++ b/FABulous/fabric_generator/file_parser.py
@@ -509,6 +509,7 @@ def parseTiles(fileName: Path) -> tuple[list[Tile], list[tuple[str, str]]]:
                 configBit = 0
                 configAccess = False
                 inverted = False
+                clocked = False
                 # Additional params can be added
                 for param in temp[4:]:
                     param = param.strip()
@@ -523,10 +524,16 @@ def parseTiles(fileName: Path) -> tuple[list[Tile], list[tuple[str, str]]]:
                         configBit = int(temp[1])
                     elif param == "INVERTED":
                         inverted = True
+                    elif param == "CLOCKED":
+                        clocked = True
                     elif param is None or param == "":
                         continue
                     else:
                         raise ValueError(f"Unknown parameter {param} in GEN_IO")
+
+                    if configAccess and clocked:
+                        raise ValueError("CONFIGACCESS GEN_IO can not be clocked")
+
                 gen_ios.append(
                     Gen_IO(
                         temp[3],
@@ -535,6 +542,7 @@ def parseTiles(fileName: Path) -> tuple[list[Tile], list[tuple[str, str]]]:
                         configBit,
                         configAccess,
                         inverted,
+                        clocked,
                     )
                 )
             elif temp[0] == "MATRIX":

--- a/docs/source/fabric_definition.rst
+++ b/docs/source/fabric_definition.rst
@@ -703,7 +703,334 @@ FABulous defines the following coding rules for BELs:
   
   * ``SHARED_PORT``: this directive can only be used together optionally with ``EXTERNAL``. If a port is set ``EXTERNAL`` but not ``SHARED_PORT``, then , a TODO ( shared  ports flagged with this directive are not connected to the switch matrix but are exported through the tile entity to the top-level fabric wrapper.
 
-.. _bitstream:
+
+Generative IOs (GEN_IO)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The GEN_IO primitive generates a IO port at the top level and routes it to
+the switch matrix in the tile.
+
+GEN_IOs can be used as following in the fabric.csv::
+
+  GEN_IO,<Number of Pins>,<Direction>,<Prefix>,[<Parameters>]
+
+fabric.csv::
+
+  GEN_IO,2,OUTPUT,A_O,,,,,,,,,,,,,,
+  GEN_IO,2,INPUT,A_I,,,,,,,,,,,,,,
+
+This will generate four IOs, two input (A_I0, A_I1) and two output (A_O0, A_O1)
+IOs, which can be accessed in the tile through the switch matrix.
+This will also generate four external ports, (A_I0_top, A_I1_top,
+A_O0_top, A_O1_top) which are routed to the top level and are connected
+to the equivalent tile ports.
+
+
+GEN_IO Parameters
+*****************
+
+* **CONFIGACCESS**: This flag will generate config access bits for the tile.
+  Config access bits are simply config bit from the configuration bitstream,
+  that are routed to the top level. They can be used to configure external
+  IPs or devices through the bitstream. The number of config access bits
+  generated is equal to the number of pins in the GEN_IO.
+  The config access bits are routed to the top level where they can be
+  connected to external.
+
+  GEN_IO.csv::
+
+    GEN_IO,2,OUTPUT,C_,CONFIGACCESS,,,,,,,,,,,,,
+
+  Will generate 2 config access bits for this tile, that will be routed to
+  top level.
+
+* **CLOCKED**: This flag will add a register to the GEN_IO,
+  which will be clocked by the UserCLK signal.
+
+  fabric.csv::
+
+     GEN_IO,2,OUTPUT,A_O_,CLOCKED,,,,,,,,,,,,,
+
+  Will generate 2 output ports for the fabric, that are clocked.
+
+* **CLOCKED_COMB**: This flag creates two signals for every GEN_IO.
+  <prefix><Number>_Q: The clocked signal, which is clocked by UserCLK signal.
+  <prefix><Number>: The original combinatorial signal.
+  If the GEN_IO is an INPUT, then there will be
+  two signals to the top, <prefix><Number>_Q_top is the clocked input
+  signal and <prefix><Number>_top is the combinatorial input signal.
+  If the GEN_IO is an OUTPUT, then there will be two signals connected
+  to the switch matrix, <prefix><Number>_Q is the clocked output signal
+  and <prefix><Number> is the combinatorial output signal.
+
+  GEN_IO.csv::
+
+     GEN_IO,2,OUTPUT,A_O_,CLOCKED_COMB,,,,,,,,,,,,,
+
+  Will generate 4 output ports for the fabric, 2 that are clocked and
+  2 combinatorial.
+
+* **INVERTED**: This flag will invert the generated IOs.
+
+  GEN_IO.csv::
+
+     GEN_IO,2,OUTPUT,A_O_,INVERTED,,,,,,,,,,,,,
+
+  Will generate 2 output ports for the fabric, that are inverted.
+  Can be also used with CONFIGACCESS or CLOCKED:
+
+  GEN_IO.csv::
+
+     GEN_IO,2,OUTPUT,C_,CONFIGACCESS,INVERTED,,,,,,,,,,,,
+
+  Will generate 2 config access bits for this tile, which are inverted.
+
+GEN_IO Example
+**************
+
+The following example shows how to replace our current W_IO implementation in the default Fabric with GEN_IOs.
+Currently, we need three files to implement the W_IOs, the tile definition (W_IO.csv),
+the switch matrix (W_IO_switch_matrix.list) and the Verilog/VHDL file (IO_1_bidirectional_frame_config_pass.v).
+
+The defautl W_IO.csv file looks like following::
+
+  TILE,W_IO,,,,,,,,,,,,,,,,,
+  #direction,source_name,X-offset,Y-offset,destination_name,wires,,,,,,,,,,,,,
+  EAST,E1BEG,1,0,NULL,4,,,,,,,,,,,,,
+  EAST,E2BEG,1,0,NULL,8,,,,,,,,,,,,,
+  EAST,E2BEGb,1,0,NULL,8,,,,,,,,,,,,,
+  EAST,EE4BEG,4,0,NULL,4,,,,,,,,,,,,,
+  EAST,E6BEG,6,0,NULL,2,,,,,,,,,,,,,
+  WEST,NULL,-1,0,W1END,4,,,,,,,,,,,,,
+  WEST,NULL,-1,0,W2MID,8,,,,,,,,,,,,,
+  WEST,NULL,-1,0,W2END,8,,,,,,,,,,,,,
+  WEST,NULL,-4,0,WW4END,4,,,,,,,,,,,,,
+  WEST,NULL,-6,0,W6END,2,,,,,,,,,,,,,
+  JUMP,NULL,0,0,GND,1,,,,,,,,,,,,,
+  JUMP,NULL,0,0,VCC,1,,,,,,,,,,,,,
+  BEL,./IO_1_bidirectional_frame_config_pass.v,A_,,,,,,,,,,,,,,,,
+  BEL,./IO_1_bidirectional_frame_config_pass.v,B_,,,,,,,,,,,,,,,,
+  BEL,./Config_access.v,A_config_,,,,,,,,,,,,,,,,
+  BEL,./Config_access.v,B_config_,,,,,,,,,,,,,,,,
+  MATRIX,./W_IO_switch_matrix.list,,,,,,,,,,,,,,,,,
+  EndTILE,,,,,,,,,,,,,,,,,,
+
+At the top, we define our EAST/WEST connections for our connecting tiles.
+We also define the JUMP wires for the GND and VCC connections.
+The BEL statements define the Verilog/VHDL files that are used to implement the IOs.
+The MATRIX statement defines the switch matrix that is used to connect the IOs to the switch matrix.
+
+For our W_IO Tile we have two IOs, A and B, which are implemented in the IO_1_bidirectional_frame_config_pass.v file.
+Our IO_1_bidirectional_frame_config_pass.v file looks like following::
+
+  module IO_1_bidirectional_frame_config_pass (I, T, O, Q, I_top, T_top, O_top, UserCLK);//, ConfigBits);
+    //parameter NoConfigBits = 0; // has to be adjusted manually (we don't use an arithmetic parser for the value)
+    input I; // from fabric to external pin
+    input T; // tristate control
+    output O; // from external pin to fabric
+    output Q; // from external pin to fabric (registered)
+    (* FABulous, EXTERNAL *) output I_top; // EXTERNAL has to ge to top-level entity not the switch matrix
+    (* FABulous, EXTERNAL *) output T_top; // EXTERNAL has to ge to top-level entity not the switch matrix
+    (* FABulous, EXTERNAL *) input O_top; // EXTERNAL has to ge to top-level entity not the switch matrix
+    (* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK; // EXTERNAL // SHARED_PORT // the EXTERNAL keyword will send this signal all the way to top and the //SHARED Allows multiple BELs using the same port (e.g. for exporting a clock to the top)
+    (* FABulous, GLOBAL *)
+    reg Q;
+    assign O = O_top;
+    assign I_top = I;
+    assign T_top = ~T;
+
+    always @ (posedge UserCLK)
+    begin
+      Q <= O_top;
+    end
+  endmodule
+
+It implements a bidirectional IO with a tristate control and a registered output.
+The I_top, T_top, O_top and UserCLK signals are exported to the top-level entity,
+since they are declared as EXTERNAL. The I, T, O and Q signals are connected to the
+switch matrix in the tile.
+
+We also have a Config_access.v file, which is used to implement the config access bits for the tile.
+The Config_access.v file looks like following::
+
+  (* FABulous, BelMap, C_bit0=0, C_bit1=1, C_bit2=2, C_bit3=3 *)
+  module Config_access (C_bit0, C_bit1, C_bit2, C_bit3, ConfigBits);
+  	parameter NoConfigBits = 4;// has to be adjusted manually (we don't use an arithmetic parser for the value)
+  	(* FABulous, EXTERNAL *)output C_bit0; // EXTERNAL
+  	(* FABulous, EXTERNAL *)output C_bit1; // EXTERNAL
+  	(* FABulous, EXTERNAL *)output C_bit2; // EXTERNAL
+  	(* FABulous, EXTERNAL *)output C_bit3; // EXTERNAL
+  	(* FABulous, GLOBAL *)input [NoConfigBits-1:0] ConfigBits;
+  	assign C_bit0 = ConfigBits[0];
+  	assign C_bit1 = ConfigBits[1];
+  	assign C_bit2 = ConfigBits[2];
+  	assign C_bit3 = ConfigBits[3];
+  endmodule
+
+It just wires four config bits as EXTERNAL ports to the top-level entity.
+
+For reworking the W_IO with GEN_IO, we need to change the W_IO.csv file to use GEN_IOs instead our
+handcrafted IOs. To do this, we replace the BEL statements and with our GEN_IO statements.
+
+The new W_IO.csv should look something like the following::
+
+  TILE,W_IO,,,,,,,,,,,,,,,,,
+  #direction,source_name,X-offset,Y-offset,destination_name,wires,,,,,,,,,,,,,
+  EAST,E1BEG,1,0,NULL,4,,,,,,,,,,,,,
+  EAST,E2BEG,1,0,NULL,8,,,,,,,,,,,,,
+  EAST,E2BEGb,1,0,NULL,8,,,,,,,,,,,,,
+  EAST,EE4BEG,4,0,NULL,4,,,,,,,,,,,,,
+  EAST,E6BEG,6,0,NULL,2,,,,,,,,,,,,,
+  WEST,NULL,-1,0,W1END,4,,,,,,,,,,,,,
+  WEST,NULL,-1,0,W2MID,8,,,,,,,,,,,,,
+  WEST,NULL,-1,0,W2END,8,,,,,,,,,,,,,
+  WEST,NULL,-4,0,WW4END,4,,,,,,,,,,,,,
+  WEST,NULL,-6,0,W6END,2,,,,,,,,,,,,,
+  JUMP,NULL,0,0,GND,1,,,,,,,,,,,,,
+  JUMP,NULL,0,0,VCC,1,,,,,,,,,,,,,
+  GEN_IO,2,INPUT,I,,,,,,,,,,,,,,
+  GEN_IO,2,OUTPUT,O,CLOCKED_COMB,,,,,,,,,,,,,
+  GEN_IO,2,OUTPUT,T,INVERTED,,,,,,,,,,,,,
+  GEN_IO,4,OUTPUT,A_config_,CONFIGACCESS,,,,,,,,,,,,,
+  GEN_IO,4,OUTPUT,B_config_,CONFIGACCESS,,,,,,,,,,,,,
+  MATRIX,./W_IO_switch_matrix.list,,,,,,,,,,,,,,,,,
+  EndTILE,,,,,,,,,,,,,,,,,,
+
+This will generate the same number of IOs and config access bits as before, but now with the GEN_IO primitive.
+Now we just need to change the names in the switch matrix list file, since the naming scheme for the IOs has changed.
+Our generated IOs will be named I0, I1, O0, O1, T0, T1, O0_Q, O1_Q which were previously named A_I, A_O, B_I, B_O, A_T, B_T, A_Q, B_Q.
+So we just have to replace all the occurrences in the switch matrix list file.
+The ports for the config access bits are named.
+A_config_0, A_config_1, A_config_2, A_config_3, B_config_0, B_config_1, B_config_2, B_config_3.
+For the config access bits we don't need to change anything, since they are **EXTERNAL** pins, that don't connect to the switch matrix.
+
+Our previous switch matrix list file should look like the following::
+
+    # W_IO
+    # Fabric to PAD output multiplexers
+    A_[I|I|I|I|I|I|I|I],W2MID[0|1|2|3|4|5|6|7]
+    A_[I|I|I|I|I|I|I|I],W2END[0|1|2|3|4|5|6|7]
+    B_[I|I|I|I|I|I|I|I],W2MID[0|1|2|3|4|5|6|7]
+    B_[I|I|I|I|I|I|I|I],W2END[0|1|2|3|4|5|6|7]
+    A_[T|T|T|T|T|T|T|T],[W2END0|W2END1|W2END2|W2END3|W2END4|W2MID7|VCC0|GND0]
+    B_[T|T|T|T|T|T|T|T],[W2END0|W2END4|W2END5|W2END6|W2MID6|W2MID7|VCC0|GND0]
+    
+    ### # single just go back, we swap bits in vector to get more twists into the graph
+    E1BEG[0|1|2|3],W1END[3|2|1|0]
+    # Single get connected to PAD output
+    E1BEG[0|1|2|3],[A_O|A_Q|B_O|B_Q]
+    
+    # we also connect the hex wires
+    # Note that we only have 2 wires starting in each CLB (so 2x6=12 wires in the channel)
+    # we connect the combinatorial outputs in every other column and the register outputs in the remaining columns
+    E6BEG[0|1|6|7],[A_O|B_O|A_Q|B_Q]
+    E6BEG[2|3|8|9],[A_O|B_O|A_Q|B_Q]
+    E6BEG[4|5|10|11],[A_O|B_O|A_Q|B_Q]
+    E6BEG[0|1|6|7],W6END[11|10|9|8]
+    E6BEG[2|3|8|9],W6END[7|6|5|4]
+    E6BEG[4|5|10|11],W6END[3|2|1|0]
+    E6BEG[0|1|6|7],WW4END[11|10|9|8]
+    E6BEG[2|3|8|9],WW4END[7|6|5|4]
+    E6BEG[4|5|10|11],WW4END[3|2|1|0]
+    E6BEG[0|1|6|7],W1END[2|3|1|0]
+    E6BEG[2|3|8|9],WW4END[15|14|13|12]
+    E6BEG[4|5|10|11],W1END[2|3|1|0]
+    
+    # The MID are half way in so they get connected to the longest patch (S2BEG)
+    # The END are longest so get on the cascading begin (S2BEGb)
+    # on top we twist wire indexes for more entropy
+    E2BEGb[0|1|2|3|4|5|6|7],W2END[7|6|5|4|3|2|1|0]
+    E2BEGb[0|1|2|3|4|5|6|7],WW4END[7|6|5|4|3|2|1|0]
+    E2BEGb[0|1|2|3|4|5|6|7],WW4END[15|14|13|12|11|10|9|8]
+    E2BEGb[0|1|2|3|4|5|6|7],W6END[7|6|5|4|3|2|1|0]
+    
+    E2BEG[0|1|2|3|4|5|6|7],W2MID[7|6|5|4|3|2|1|0]
+    E2BEG[0|1|2|3|4|5|6|7],WW4END[7|6|5|4|3|2|1|0]
+    E2BEG[0|1|2|3|4|5|6|7],WW4END[15|14|13|12|11|10|9|8]
+    E2BEG[0|1|2|3|4|5|6|7],W6END[7|6|5|4|3|2|1|0]
+    
+    EE4BEG[0|0|0|0],[A_O|W6END0|W6END2|W6END4]
+    EE4BEG[1|1|1|1],[B_O|W6END6|W6END8|W6END10]
+    EE4BEG[2|2|2|2],[A_Q|W6END1|W6END3|W6END5]
+    EE4BEG[3|3|3|3],[B_Q|W6END7|W6END9|W6END11]
+    EE4BEG[4|4|4|4],[W2END0|W2END2|W2END4|W2END6]
+    EE4BEG[5|5|5|5],[W2END1|W2END3|W2END5|W2END7]
+    EE4BEG[6|6|6|6],[W2MID0|W2MID2|W2MID4|W2MID6]
+    EE4BEG[7|7|7|7],[W2MID1|W2MID3|W2MID5|W2MID7]
+    EE4BEG[8|8|8|8],[W6END4|W6END6|W6END8|W6END10]
+    EE4BEG[9|9|9|9],[W6END1|W6END3|W6END5|W6END7]
+    EE4BEG1[0|0|0|0],[A_O|W6END0|W6END2|W6END4]
+    EE4BEG1[1|1|1|1],[B_O|W6END6|W6END8|W6END10]
+    EE4BEG1[2|2|2|2],[A_Q|W6END1|W6END3|W6END5]
+    EE4BEG1[3|3|3|3],[B_Q|W6END7|W6END9|W6END11]
+    EE4BEG1[4|4|4|4],[W2MID0|W2MID2|W2MID4|W2MID6]
+
+After changing all connection names in the switch matrix list file, it should look like following::
+
+
+    # W_IO
+    # Fabric to PAD output multiplexers
+    [I|I|I|I|I|I|I|I]0,W2MID[0|1|2|3|4|5|6|7]
+    [I|I|I|I|I|I|I|I]0,W2END[0|1|2|3|4|5|6|7]
+    [I|I|I|I|I|I|I|I]1,W2MID[0|1|2|3|4|5|6|7]
+    [I|I|I|I|I|I|I|I]1,W2END[0|1|2|3|4|5|6|7]
+    [T|T|T|T|T|T|T|T]0,[W2END0|W2END1|W2END2|W2END3|W2END4|W2MID7|VCC0|GND0]
+    [T|T|T|T|T|T|T|T]1,[W2END0|W2END4|W2END5|W2END6|W2MID6|W2MID7|VCC0|GND0]
+    
+    ### # single just go back, we swap bits in vector to get more twists into the graph
+    E1BEG[0|1|2|3],W1END[3|2|1|0]
+    # Single get connected to PAD output
+    E1BEG[0|1|2|3],[O0|O0_Q|O1|O1_Q]
+    
+    # we also connect the hex wires
+    # Note that we only have 2 wires starting in each CLB (so 2x6=12 wires in the channel)
+    # we connect the combinatorial outputs in every other column and the register outputs in the remaining columns
+    E6BEG[0|1|6|7],[O0|O1|O0_Q|O1_Q]
+    E6BEG[2|3|8|9],[O0|O1|O0_Q|O1_Q]
+    E6BEG[4|5|10|11],[O0|01|O0_Q|O1_Q]
+    E6BEG[0|1|6|7],W6END[11|10|9|8]
+    E6BEG[2|3|8|9],W6END[7|6|5|4]
+    E6BEG[4|5|10|11],W6END[3|2|1|0]
+    E6BEG[0|1|6|7],WW4END[11|10|9|8]
+    E6BEG[2|3|8|9],WW4END[7|6|5|4]
+    E6BEG[4|5|10|11],WW4END[3|2|1|0]
+    E6BEG[0|1|6|7],W1END[2|3|1|0]
+    E6BEG[2|3|8|9],WW4END[15|14|13|12]
+    E6BEG[4|5|10|11],W1END[2|3|1|0]
+    
+    # The MID are half way in so they get connected to the longest patch (S2BEG)
+    # The END are longest so get on the cascading begin (S2BEGb)
+    # on top we twist wire indexes for more entropy
+    E2BEGb[0|1|2|3|4|5|6|7],W2END[7|6|5|4|3|2|1|0]
+    E2BEGb[0|1|2|3|4|5|6|7],WW4END[7|6|5|4|3|2|1|0]
+    E2BEGb[0|1|2|3|4|5|6|7],WW4END[15|14|13|12|11|10|9|8]
+    E2BEGb[0|1|2|3|4|5|6|7],W6END[7|6|5|4|3|2|1|0]
+    
+    E2BEG[0|1|2|3|4|5|6|7],W2MID[7|6|5|4|3|2|1|0]
+    E2BEG[0|1|2|3|4|5|6|7],WW4END[7|6|5|4|3|2|1|0]
+    E2BEG[0|1|2|3|4|5|6|7],WW4END[15|14|13|12|11|10|9|8]
+    E2BEG[0|1|2|3|4|5|6|7],W6END[7|6|5|4|3|2|1|0]
+    
+    EE4BEG[0|0|0|0],[O0_O|W6END0|W6END2|W6END4]
+    EE4BEG[1|1|1|1],[O1_O|W6END6|W6END8|W6END10]
+    EE4BEG[2|2|2|2],[O0_Q|W6END1|W6END3|W6END5]
+    EE4BEG[3|3|3|3],[O1_Q|W6END7|W6END9|W6END11]
+    EE4BEG[4|4|4|4],[W2END0|W2END2|W2END4|W2END6]
+    EE4BEG[5|5|5|5],[W2END1|W2END3|W2END5|W2END7]
+    EE4BEG[6|6|6|6],[W2MID0|W2MID2|W2MID4|W2MID6]
+    EE4BEG[7|7|7|7],[W2MID1|W2MID3|W2MID5|W2MID7]
+    EE4BEG[8|8|8|8],[W6END4|W6END6|W6END8|W6END10]
+    EE4BEG[9|9|9|9],[W6END1|W6END3|W6END5|W6END7]
+    EE4BEG1[0|0|0|0],[O0_O|W6END0|W6END2|W6END4]
+    EE4BEG1[1|1|1|1],[O1_O|W6END6|W6END8|W6END10]
+    EE4BEG1[2|2|2|2],[O0_Q|W6END1|W6END3|W6END5]
+    EE4BEG1[3|3|3|3],[O1_Q|W6END7|W6END9|W6END11]
+    EE4BEG1[4|4|4|4],[W2MID0|W2MID2|W2MID4|W2MID6]
+
+After changing the switch matrix list file, we can generate the new tile with the GEN_IOs.
+The generated tile will have the same functionality as the previous tile, but now with the GEN_IOs.
+
+-.. _bitstream:
 
 Bitstream remapping
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Adds a GEN_IO primitive to generate IOs in the top level design and
route them trough to the defined tile, where they are connected to
the switchmatrix.

GEN_IOs can be used as following in the fabric.csv:
GEN_IO,Number of Pins,Direction,Prefix

``` fabric.csv::
GEN_IO,2,OUTPUT,A_O,,,,,,,,,,,,,,
GEN_IO,2,INPUT,A_I,,,,,,,,,,,,,,
```
This will generate four IOs, two INPUT (A_I0, A_I1) and two OUTPUT(A_O0
and A_O1), which can be a accessed in the tile through the switchmatrix.
This will also generate four external ports, (A_I0_top, A_I1_top,
A_O0_top, A_O1_top) which are routed to the top level and are connected
to the equivalent tile ports.