### PR TITLE
workflows: Run build_docs also on dev branch PRs

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -2,9 +2,9 @@ name: "Docs Build Check"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, FABulous2.0-development ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, FABulous2.0-development ]
 
 jobs:
   docs:


### PR DESCRIPTION
We want to add a dev version to read the docs server, so the build_docs workflow should also run on every PR on FABulous2.0-development. 