### PR TITLE
docs: Add main requrements to docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,6 @@ pydata-sphinx-theme>=0.15.0
 sphinxcontrib-bibtex>=2.6.0
 sphinx-copybutton>=0.5.0
 sphinx-prompt>=1.9.0
+
+# include the requirements from the main repository
+-r ../requirements.txt


### PR DESCRIPTION
Sphinx autodoc also needs the main requirements installed, otherwise the readthedocs build fails.