### PR TITLE
Add support for SystemVerilog in BELs

### DIFF
--- a/FABulous/fabric_generator/file_parser.py
+++ b/FABulous/fabric_generator/file_parser.py
@@ -499,7 +499,7 @@ def parseTiles(fileName: Path) -> tuple[list[Tile], list[tuple[str, str]]]:
                 belFilePath = filePathParent.joinpath(temp[1])
                 if temp[1].endswith(".vhdl"):
                     bels.append(parseBelFile(belFilePath, temp[2], "vhdl"))
-                elif temp[1].endswith(".v"):
+                elif temp[1].endswith(".v") or temp[1].endswith(".sv"):
                     bels.append(parseBelFile(belFilePath, temp[2], "verilog"))
                 else:
                     raise ValueError(
@@ -625,7 +625,7 @@ def parseSupertiles(fileName: Path, tileDic: dict[str, Tile]) -> list[SuperTile]
                 belFilePath = filePath.joinpath(line[1])
                 if line[1].endswith(".vhdl"):
                     bels.append(parseBelFile(belFilePath, line[2], "vhdl"))
-                elif line[1].endswith(".v"):
+                elif line[1].endswith(".v") or line[1].endswith(".sv"):
                     bels.append(parseBelFile(belFilePath, line[2], "verilog"))
                 else:
                     raise ValueError(
@@ -842,7 +842,7 @@ def parseBelFile(
         runCmd = [
             "yosys",
             "-qp"
-            f"read_verilog {filename}; proc -noopt; write_json -compat-int {json_file}",
+            f"read_verilog -sv {filename}; proc -noopt; write_json -compat-int {json_file}",
         ]
         try:
             subprocess.run(runCmd, check=True)


### PR DESCRIPTION
This PR allows BELs to be written in SystemVerilog.

At first I thought of adding a separate entry for `"systemverilog"`, but since Verilog is a subset of SystemVerilog, it is safe and sane to treat both cases the same.

This enables using the SV support in yosys and thus the use of e.g. `always_comb` and `always_ff` to avoid shooting yourself in the foot.

Let me know if you agree with these changes.