### PR TITLE
Fix run_simulation output

### DIFF
--- a/FABulous/fabric_files/FABulous_project_template_verilog/Test/sequential_16bit_en_tb.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Test/sequential_16bit_en_tb.v
@@ -88,9 +88,11 @@ module sequential_16bit_en_tb;
         end
 `endif
         repeat (100) @(posedge CLK);
-        O_top = 28'b1; // reset
+        // Enable and reset the counter
+        O_top = 28'b0000_0000_0000_0000_0000_0000_0011;
         repeat (5) @(posedge CLK);
-        O_top = 28'b0;
+        // Deassert reset while keeping the counter enabled
+        O_top = 28'b0000_0000_0000_0000_0000_0000_0010;
         for (i = 0; i < 100; i = i + 1) begin
             @(negedge CLK);
             $display("fabric(I_top) = 0x%X gold = 0x%X, fabric(T_top) = 0x%X gold = 0x%X", I_top, I_top_gold, T_top, T_top_gold);


### PR DESCRIPTION
This fixes #305 by correctly enabling and resetting the counter in the testbench used in the `run_simulation` command.

It should be noted that this still does not match the output of the script `run_simulation.sh`, since the command simulates the user design instead of the `counter.v` test design. I will open a discussion on what we want the `run_simulation` command to actually test.

@mole99 could you check if this resolves the issue of the wrong output on your end (according to the things I mentioned above)? I ofc did check it on my end, but better safe than sorry :) 