### PR TITLE
fabric_generator: Fix broken VHDL fabric generation

### DIFF
--- a/FABulous/fabric_generator/fabric_gen.py
+++ b/FABulous/fabric_generator/fabric_gen.py
@@ -420,6 +420,7 @@ class FabricGenerator:
             self.writer.addPreprocElse()
         self.writer.addNewLine()
         self.writer.addNewLine()
+        self.writer.addLogicStart()
         self.writer.addComment("instantiate frame latches", end="")
         for i in configMemList:
             counter = 0
@@ -494,12 +495,15 @@ class FabricGenerator:
         # we pass the NumberOfConfigBits as a comment in the beginning of the file.
         # This simplifies it to generate the configuration port only if needed later when building the fabric where we are only working with the VHDL files
 
-        # VHDL header
+        # Generate header
         self.writer.addComment(f"NumberOfConfigBits: {noConfigBits}")
         self.writer.addHeader(f"{tile.name}_switch_matrix")
-        self.writer.addParameterStart(indentLevel=1)
-        self.writer.addParameter("NoConfigBits", "integer", noConfigBits, indentLevel=2)
-        self.writer.addParameterEnd(indentLevel=1)
+        if noConfigBits > 0:
+            self.writer.addParameterStart(indentLevel=1)
+            self.writer.addParameter(
+                "NoConfigBits", "integer", noConfigBits, indentLevel=2
+            )
+            self.writer.addParameterEnd(indentLevel=1)
         self.writer.addPortStart(indentLevel=1)
 
         # normal wire input
@@ -2224,7 +2228,6 @@ class FabricGenerator:
         self.writer.addConnectionVector("LocalWriteData", 31)
         self.writer.addConnectionScalar("LocalWriteStrobe")
         self.writer.addConnectionVector("RowSelect", "RowSelectWidth-1")
-        self.writer.addConnectionScalar("resten")
 
         if isinstance(self.writer, VHDLWriter):
             basePath = Path(self.writer.outFileName).parent


### PR DESCRIPTION
fabric_gen:
  - Fix: Add missing `begin` / LogicStart in ConfigMem generation.
  - Generate NoConfigBits Parameter in Tiles only if it has config bits.
  - Remove unused/typo signal `resten` in top wrapper generation.

file_parser:
  - Fix: Add individually_declared setting also in VHDL bel port parsing, since individual declared VHDL bel ports were detected and connected as vectors, which resulted in port mismatches.