### PR TITLE
Fixing changes after #291

### DIFF
--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -125,7 +125,10 @@ def main():
 
     setup_global_env_vars(args)
 
-    projectDir = Path(args.project_dir).absolute()
+    if p := os.getenv("FAB_PROJ_DIR"):
+        projectDir = Path(p).absolute()
+    else:
+        projectDir = Path(args.project_dir).absolute()
 
     args.top = projectDir.stem
 

--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -127,21 +127,21 @@ def main():
 
     projectDir = Path(args.project_dir).absolute()
 
-    if not projectDir.exists():
-        logger.error(f"The directory provided does not exist: {projectDir}")
-        exit(-1)
-
     args.top = projectDir.stem
 
     if args.createProject:
         create_project(projectDir, args.writer)
         exit(0)
 
+    if not projectDir.exists():
+        logger.error(f"The directory provided does not exist: {projectDir}")
+        exit(1)
+
     if not (projectDir / ".FABulous").exists():
         logger.error(
             "The directory provided is not a FABulous project as it does not have a .FABulous folder"
         )
-        exit(-1)
+        exit(1)
     else:
         setup_project_env_vars(args)
 

--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -125,10 +125,7 @@ def main():
 
     setup_global_env_vars(args)
 
-    if p := os.getenv("FAB_PROJ_DIR"):
-        projectDir = Path(p).absolute()
-    else:
-        projectDir = Path(args.project_dir).absolute()
+    projectDir = Path(os.getenv("FAB_PROJ_DIR", args.project_dir))
 
     args.top = projectDir.stem
 

--- a/FABulous/FABulous_CLI/FABulous_CLI.py
+++ b/FABulous/FABulous_CLI/FABulous_CLI.py
@@ -198,14 +198,16 @@ class FABulous_CLI(Cmd):
         )
 
         if not TCLScript.is_dir() and TCLScript.exists():
-            self._startup_commands.append(f"run_tcl {TCLScript}")
+            self._startup_commands.append(f"run_tcl {Path(TCLScript).absolute()}")
             self._startup_commands.append("exit")
         elif not TCLScript.is_dir() and not TCLScript.exists():
             logger.error(f"Cannot find {TCLScript}")
             exit(1)
 
         if not FABulousScript.is_dir() and FABulousScript.exists():
-            self._startup_commands.append(f"run_script {FABulousScript}")
+            self._startup_commands.append(
+                f"run_script {Path(FABulousScript).absolute()}"
+            )
             self._startup_commands.append("exit")
         elif not FABulousScript.is_dir() and not FABulousScript.exists():
             logger.error(f"Cannot find {FABulousScript}")

--- a/FABulous/FABulous_CLI/FABulous_CLI.py
+++ b/FABulous/FABulous_CLI/FABulous_CLI.py
@@ -34,10 +34,10 @@ from cmd2 import (
 )
 from loguru import logger
 
-from FABulous.FABulous_CLI import cmd_synthesis
 from FABulous.fabric_generator.code_generation_Verilog import VerilogWriter
 from FABulous.fabric_generator.code_generation_VHDL import VHDLWriter
 from FABulous.FABulous_API import FABulous_API
+from FABulous.FABulous_CLI import cmd_synthesis
 from FABulous.FABulous_CLI.helper import (
     allow_blank,
     check_if_application_exists,
@@ -97,6 +97,7 @@ class FABulous_CLI(Cmd):
     prompt: str = "FABulous> "
     fabulousAPI: FABulous_API
     projectDir: Path
+    enteringDir: Path
     top: str
     allTile: list[str]
     csvFile: Path
@@ -107,6 +108,7 @@ class FABulous_CLI(Cmd):
         self,
         writerType: str | None,
         projectDir: Path,
+        enteringDir: Path,
         FABulousScript: Path = Path(),
         TCLScript: Path = Path(),
     ):
@@ -129,6 +131,7 @@ class FABulous_CLI(Cmd):
             allow_cli_args=False,
             startup_script=str(FABulousScript) if not FABulousScript.is_dir() else "",
         )
+        self.enteringDir = enteringDir
 
         if writerType == "verilog":
             self.fabulousAPI = FABulous_API(VerilogWriter())
@@ -211,6 +214,7 @@ class FABulous_CLI(Cmd):
     def do_exit(self, *ignored):
         """Exits the FABulous shell and logs info message."""
         logger.info("Exiting FABulous shell")
+        os.chdir(self.enteringDir)
         return True
 
     do_quit = do_exit
@@ -271,6 +275,7 @@ class FABulous_CLI(Cmd):
                 logger.error(
                     "No argument is given and the csv file is set or the file does not exist"
                 )
+                return
         else:
             self.fabulousAPI.loadFabric(args.file)
             self.csvFile = args.file

--- a/FABulous/FABulous_CLI/cmd_synthesis.py
+++ b/FABulous/FABulous_CLI/cmd_synthesis.py
@@ -96,7 +96,6 @@ The following commands are executed by when executing the synthesis command:
         write_json <file-name>
 """
 
-
 synthesis_parser = Cmd2ArgumentParser(description=HELP)
 synthesis_parser.add_argument(
     "files",
@@ -246,7 +245,7 @@ def do_synthesis(self, args):
         if resolvePath.exists():
             paths.append(resolvePath)
         else:
-            logger.error(f"{resolvePath} does not exits")
+            logger.error(f"{resolvePath} does not exists")
             return
 
     json_file = paths[0].with_suffix(".json")

--- a/FABulous/FABulous_CLI/helper.py
+++ b/FABulous/FABulous_CLI/helper.py
@@ -61,7 +61,10 @@ def setup_global_env_vars(args: argparse.Namespace) -> None:
         logger.info(f"FAB_ROOT set to {fabulousRoot}")
 
     # Load the .env file and make env variables available globally
-    fabDir = Path(os.getenv("FAB_ROOT"))
+    if p := os.getenv("FAB_ROOT"):
+        fabDir = Path(p)
+    else:
+        raise Exception("FAB_ROOT environment variable not set")
     if args.globalDotEnv:
         gde = Path(args.globalDotEnv)
         if gde.is_file():
@@ -99,7 +102,11 @@ def setup_project_env_vars(args: argparse.Namespace) -> None:
         Command line arguments
     """
     # Load the .env file and make env variables available globally
-    fabDir = Path(os.getenv("FAB_PROJ_DIR")).joinpath(".FABulous")
+    if p := os.getenv("FAB_PROJ_DIR"):
+        fabDir = Path(p) / ".FABulous"
+    else:
+        raise Exception("FAB_PROJ_DIR environment variable not set")
+
     if args.projectDotEnv:
         pde = Path(args.projectDotEnv)
         if pde.exists() and pde.is_file():

--- a/FABulous/fabric_generator/utilities.py
+++ b/FABulous/fabric_generator/utilities.py
@@ -692,8 +692,8 @@ def PrintCSV_FileInfo(CSV_FileName):
 
 def ExpandListPorts(port, PortList):
     # a leading '[' tells us that we have to expand the list
-    if re.search("\[", port):
-        if not re.search("\]", port):
+    if re.search(r"\[", port):
+        if not re.search(r"\]", port):
             logger.error("Error in function ExpandListPorts: cannot find closing ]")
             raise ValueError
         # port.find gives us the first occurrence index in a string
@@ -703,7 +703,7 @@ def ExpandListPorts(port, PortList):
         # right_index is the position of the ']' so we need everything after that
         after_right_index = port[(right_index + 1) :]
         ExpandList = []
-        ExpandList = re.split("\|", port[left_index + 1 : right_index])
+        ExpandList = re.split(r"\|", port[left_index + 1 : right_index])
         for entry in ExpandList:
             ExpandListItem = before_left_index + entry + after_right_index
             ExpandListPorts(ExpandListItem, PortList)


### PR DESCRIPTION
When entering the shell, now will move the current working directory to the project directory, and when exit will move the user back to the original point. 

This will make all relative paths always work relative to the current FABulous project. 

Some other minor migration to `pathlib`.

Typo fix. 