### PR TITLE
Add reusable workflow and add Makefile based test

### DIFF
--- a/.github/actions/prepare_FABulous_container/action.yaml
+++ b/.github/actions/prepare_FABulous_container/action.yaml
@@ -1,0 +1,62 @@
+name: Prepare FABulous workflow
+description: Composite action to prepare a container with everything needed to run FABulous
+
+inputs:
+  python_version:
+    description: 'Python version to use'
+    required: false
+    default: '3.12'
+  additional_system_packages:
+    description: 'Additional ubunut packages to install'
+    required: false
+    default: ''
+  additional_python_packages:
+    description: 'Additional python packages to install'
+    required: false
+    default: ''
+  install_GHDL:
+    description: 'Install GHDL'
+    required: false
+    default: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python_version }}
+    - name: Set up OSS CAD suite
+      uses: YosysHQ/setup-oss-cad-suite@v2
+    - name: Install GHDL mcode nightly
+      # GHDL mcode is required to test our fabric.
+      # The oss-cad-suite action installs GHDL, but with the LLVM backend, which is much slower for our simulation
+      if: ${{ inputs.install_GHDL == true }}
+      uses: ghdl/setup-ghdl@v1
+      with:
+        version: nightly
+        backend: mcode
+        investigate: true
+    - name: Install additional ubunutu packages
+      if: ${{ inputs.additional_system_packages != '' }}
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ${{ inputs.additional_system_packages }}
+    - name: Upgrade pip
+      shell: bash
+      run: |
+        python3 -m pip install --upgrade pip
+    - name: Install additional python packages
+      if: ${{ inputs.additional_python_packages != '' }}
+      shell: bash
+      run: |
+        pip3 install ${{ inputs.additional_python_packages }}
+    - name: Install FABulous requirements.txt
+      shell: bash
+      run: |
+        if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
+    - name: Install FABulous requirements
+      shell: bash
+      run: |
+        pip3 install -e .

--- a/.github/workflows/fabric_gen.yml
+++ b/.github/workflows/fabric_gen.yml
@@ -1,36 +1,25 @@
-name: Test fabric_gen.py
+name: Test FABulous
 
 on: [push, pull_request]
 
 jobs:
-  build_and_run:
+  run_verilog_simulation_CLI:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.12"
-      - name: Set up OSS CAD suite
-        uses: YosysHQ/setup-oss-cad-suite@v2
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install flake8 pytest
-          if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
-      - name: Lint with flake8
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 FABulous/**/*.py --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 FABulous/**/*.py --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Install FABulous
-        run: |
-          pip3 install -e .
-      - name: Run fabric generator flow and simulation
+      - uses: ./.github/actions/prepare_FABulous_container
+      - name: Run fabric generator flow and simulation with FABulous CLI
         run: |
           FABulous -c demo
           FABulous demo -fs ./demo/FABulous.tcl
+
+  run_verilog_simulation_makefile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/prepare_FABulous_container
+      - name: Run fabric generator flow and simulation with FABulous makefile
+        run: |
+          FABulous -c demo
+          cd demo/Test
+          make FAB_sim

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Test/Makefile
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Test/Makefile
@@ -21,7 +21,7 @@ endif
 
 sim: build_test_design run_simulation clean
 
-FAB_sim: run_FABulous_demo copy_files run_simulation clean
+FAB_sim: build_demo_fabric build_test_design run_simulation clean
 
 full_sim: run_FABulous_demo build_test_design run_simulation_emulation clean
 
@@ -38,6 +38,10 @@ run_FABulous_demo:
 	mv -f ${DESIGN}.hex ${BUILD_DIR}/
 	mv -f ${DESIGN}.fst ${BUILD_DIR}/
 	cp -fu ${USER_DESIGN_DIR}/* ${BUILD_DIR}
+
+build_demo_fabric: mkdir_build
+	# Builds the default fabric
+	FABulous ${FAB_PROJ_ROOT} -ts ./build_fabulous_fabric.tcl
 
 run_yosys: mkdir_build
 	yosys -p "synth_fabulous -top ${TOP_WRAPPER} -json ${BUILD_DIR}/${DESIGN}.json" ${USER_DESIGN_VERILOG} ${TOP_WRAPPER_VERILOG}

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Test/build_fabulous_fabric.tcl
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Test/build_fabulous_fabric.tcl
@@ -1,0 +1,4 @@
+# Just build the default fabric
+load_fabric
+run_FABulous_fabric
+exit


### PR DESCRIPTION
Add a reusable workflow to prepare the workflow environment.
Make use of the reusable workflow.

Add a new workflow job, which runs our simulation based on the
Makefile flow. This makes the tests less dependent on the CLI
and test both workflows.