### PR TITLE
feat: Add version number and checks

### DIFF
--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -221,7 +221,7 @@ def main():
             )
             exit(1)
 
-    project_version = Version(os.getenv("VERSION", "1.0.0"))
+    project_version = Version(os.getenv("FAB_PROJ_VERSION", "1.0.0"))
     package_version = Version(version("FABulous-FPGA"))
     if package_version < project_version:
         logger.error(

--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -225,10 +225,15 @@ def main():
     package_version = Version(version("FABulous-FPGA"))
     if project_version < package_version:
         logger.error(
-            f"Version mismatch! FABulous-FPGA version: {package_version}, Project version: {project_version}\n"
-            'Please run "FABulous project_dir --update-project-version" to update the project version.'
+            f"Version incompatible! FABulous-FPGA version: {package_version}, Project version: {project_version}\n"
+            r'Please run "FABulous \<project_dir\> --update-project-version" to update the project version.'
         )
         exit(1)
+    if project_version.major != package_version.major:
+        logger.error(
+            f"Major version mismatch! FABulous-FPGA major version: {package_version.major}, Project major version: {project_version.major}\n"
+            "This may lead to compatibility issues. Please ensure the project is compatible with the current FABulous-FPGA version."
+        )
 
     fab_CLI = FABulous_CLI(
         os.getenv("FAB_PROJ_LANG"),

--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -221,9 +221,9 @@ def main():
             )
             exit(1)
 
-    project_version = Version(os.getenv("VERSION", "0.0.0"))
+    project_version = Version(os.getenv("VERSION", "1.0.0"))
     package_version = Version(version("FABulous-FPGA"))
-    if project_version < package_version:
+    if package_version < project_version:
         logger.error(
             f"Version incompatible! FABulous-FPGA version: {package_version}, Project version: {project_version}\n"
             r'Please run "FABulous \<project_dir\> --update-project-version" to update the project version.'

--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -226,7 +226,7 @@ def main():
     if project_version < package_version:
         logger.error(
             f"Version mismatch! FABulous-FPGA version: {package_version}, Project version: {project_version}\n"
-            'Please run "FABulous <project_dir> --update-project-version" to update the project version.'
+            'Please run "FABulous project_dir --update-project-version" to update the project version.'
         )
         exit(1)
 

--- a/FABulous/FABulous_CLI/FABulous_CLI.py
+++ b/FABulous/FABulous_CLI/FABulous_CLI.py
@@ -328,6 +328,7 @@ class FABulous_CLI(Cmd):
         """
         # if no argument is given will use the one set by set_fabric_csv
         # else use the argument
+
         logger.info("Loading fabric")
         if args.file == Path():
             if self.csvFile.exists():

--- a/FABulous/FABulous_CLI/helper.py
+++ b/FABulous/FABulous_CLI/helper.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import sys
 import tarfile
+from importlib.metadata import version
 from pathlib import Path
 from typing import Literal
 
@@ -167,6 +168,12 @@ def setup_project_env_vars(args: argparse.Namespace) -> None:
         )
         os.environ["FAB_PROJ_LANG"] = args.writer
 
+    # string comparison
+    if os.environ["VERSION"] < version("FABulous-FPGA"):
+        logger.warning(
+            f"Version mismatch! FABulous-FPGA version: {version('FABulous-FPGA')}, Project version: {os.environ.get('VERSION')}"
+        )
+
 
 def create_project(project_dir: Path, lang: Literal["verilog", "vhdl"] = "verilog"):
     """Creates a FABulous project containing all required files by copying the common
@@ -226,6 +233,7 @@ def create_project(project_dir: Path, lang: Literal["verilog", "vhdl"] = "verilo
 
     with open(os.path.join(project_dir, ".FABulous/.env"), "w") as env_file:
         env_file.write(f"FAB_PROJ_LANG={lang}\n")
+        env_file.write(f"VERSION={version('FABulous-FPGA')}")
 
     logger.info(f"New FABulous project created in {project_dir} with {lang} language.")
 

--- a/FABulous/FABulous_CLI/helper.py
+++ b/FABulous/FABulous_CLI/helper.py
@@ -228,7 +228,8 @@ def create_project(project_dir: Path, lang: Literal["verilog", "vhdl"] = "verilo
 
     with open(os.path.join(project_dir, ".FABulous/.env"), "w") as env_file:
         env_file.write(f"FAB_PROJ_LANG={lang}\n")
-        env_file.write(f"VERSION={version('FABulous-FPGA')}")
+        env_file.write(f"FAB_PROJ_VERSION={version('FABulous-FPGA')}")
+        env_file.write(f"FAB_PROJ_VERSION_CREATED={version('FABulous-FPGA')}")
 
     logger.info(f"New FABulous project created in {project_dir} with {lang} language.")
 
@@ -508,7 +509,7 @@ def install_oss_cad_suite(destination_folder: Path, update: bool = False):
 def update_project_version(project_dir: Path) -> bool:
     env_file = project_dir / ".FABulous" / ".env"
 
-    project_version = get_key(env_file, "VERSION")
+    project_version = get_key(env_file, "FAB_PROJ_VERSION")
 
     if project_version is None:
         logger.error("VERSION not found in .env file.")
@@ -522,5 +523,5 @@ def update_project_version(project_dir: Path) -> bool:
         )
         return False
 
-    set_key(env_file, "VERSION", str(package_version))
+    set_key(env_file, "FAB_PROJ_VERSION", str(package_version))
     return True

--- a/FABulous/FABulous_CLI/helper.py
+++ b/FABulous/FABulous_CLI/helper.py
@@ -226,10 +226,10 @@ def create_project(project_dir: Path, lang: Literal["verilog", "vhdl"] = "verilo
         new_content = re.sub(r"\{HDL_SUFFIX\}", new_suffix, content)
         file_path.write_text(new_content)
 
-    with open(os.path.join(project_dir, ".FABulous/.env"), "w") as env_file:
-        env_file.write(f"FAB_PROJ_LANG={lang}\n")
-        env_file.write(f"FAB_PROJ_VERSION={version('FABulous-FPGA')}")
-        env_file.write(f"FAB_PROJ_VERSION_CREATED={version('FABulous-FPGA')}")
+    env_file = project_dir / ".FABulous" / ".env"
+    set_key(env_file, "FAB_PROJ_LANG", lang)
+    set_key(env_file, "FAB_PROJ_VERSION", version("FABulous-FPGA"))
+    set_key(env_file, "FAB_PROJ_VERSION_CREATED", version("FABulous-FPGA"))
 
     logger.info(f"New FABulous project created in {project_dir} with {lang} language.")
 

--- a/docs/source/Usage.rst
+++ b/docs/source/Usage.rst
@@ -191,18 +191,20 @@ Global environment variables always start with ``FAB_``` and are used to configu
 To add a global .env file, create a file named ``.env`` in the root directory of the FABulous repository or use the ``--globalDotEnv`` command line argument when running FABulous.
 The following global environment variables are available:
 
-=================== =============================================== ===========================================================================
-Variable Name        Description                                     Default Value
-=================== =============================================== ===========================================================================
-FAB_ROOT            The root directory of the FABulous repository   The directory where the FABulous repository is located
-FAB_FABULATOR_ROOT  The root directory of the FABulator repository  <None>
-FAB_YOSYS_PATH      Path to Yosys binary                            yosys  (Uses global Yosys installation)
-FAB_NEXTPNR_PATH    Path to Nextpnr binary                          nextpnr-generic  (Uses global Nextpnr installation)
-FAB_IVERILOG_PATH   Path to Icarus Verilog binary                   iverilog  (Uses global Icarus Verilog installation)
-FAB_VVP_PATH        Path to Verilog VVP binary                      vvp  (Uses global Verilog VVP installation)
-FAB_PROJ_DIR        The root directory of the FABulous project      The directory where the FABulous project is located, given by command line
-FAB_OSS_CAD_SUITE   Path to the oss-cad-suite installation          <None>
-=================== =============================================== ===========================================================================
+========================= =================================================== ===========================================================================
+Variable Name              Description                                        Default Value
+========================= =================================================== ===========================================================================
+FAB_ROOT                  The root directory of the FABulous repository       The directory where the FABulous repository is located
+FAB_FABULATOR_ROOT        The root directory of the FABulator repository      <None>
+FAB_YOSYS_PATH            Path to Yosys binary                                yosys  (Uses global Yosys installation)
+FAB_NEXTPNR_PATH          Path to Nextpnr binary                              nextpnr-generic  (Uses global Nextpnr installation)
+FAB_IVERILOG_PATH         Path to Icarus Verilog binary                       iverilog  (Uses global Icarus Verilog installation)
+FAB_VVP_PATH              Path to Verilog VVP binary                          vvp  (Uses global Verilog VVP installation)
+FAB_PROJ_DIR              The root directory of the FABulous project          The directory where the FABulous project is located, given by command line
+FAB_OSS_CAD_SUITE         Path to the oss-cad-suite installation              <None>
+FAB_PROJ_VERSION_CREATED  The version of FABulous used to create the project  Same as the version of FABulous-FPGA package installed
+FAB_PROJ_VERSION          The current project version                         Same as the version of FABulous-FPGA package installed
+========================= =================================================== ===========================================================================
 
 Project Specific Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/CLI_test/test_arguments.py
+++ b/tests/CLI_test/test_arguments.py
@@ -382,7 +382,7 @@ def test_create_project_with_invalid_writer(tmp_path, monkeypatch):
     assert exc_info.value.code != 0
 
 
-def test_project_directory_priority_order(tmp_path, monkeypatch, mocker):
+def test_project_directory_priority_order(tmp_path, monkeypatch):
     """Test that project directory priority order is followed:
     1. User provided argument (highest priority)
     2. Environment variables (FAB_PROJ_DIR)
@@ -400,6 +400,7 @@ def test_project_directory_priority_order(tmp_path, monkeypatch, mocker):
         project_dir.mkdir()
         (project_dir / ".FABulous").mkdir()
         (project_dir / ".FABulous" / ".env").write_text("FAB_PROJ_LANG=verilog\n")
+        (project_dir / ".FABulous" / ".env").write_text("VERSION=1.0.0\n")
 
     # Test 1: User provided argument should take highest priority over environment variable
     monkeypatch.setenv("FAB_PROJ_DIR", str(env_var_dir))

--- a/tests/CLI_test/test_helper.py
+++ b/tests/CLI_test/test_helper.py
@@ -15,7 +15,8 @@ def test_create_project(tmp_path):
     # Check if .env file exists and contains correct content
     env_file = project_dir / ".FABulous" / ".env"
     assert env_file.exists()
-    assert env_file.read_text() == "FAB_PROJ_LANG=verilog\n"
+    assert "FAB_PROJ_LANG=verilog" in env_file.read_text()
+    assert "VERSION=" in env_file.read_text()
 
     # Check if template files were copied
     assert any(project_dir.glob("**/*.v")), "No Verilog files found in project directory"
@@ -33,7 +34,8 @@ def test_create_project_vhdl(tmp_path):
     # Check if .env file exists and contains correct content
     env_file = project_dir / ".FABulous" / ".env"
     assert env_file.exists()
-    assert env_file.read_text() == "FAB_PROJ_LANG=vhdl\n"
+    assert "FAB_PROJ_LANG=vhdl" in env_file.read_text()
+    assert "VERSION=" in env_file.read_text()
 
     # Check if template files were copied
     assert any(project_dir.glob("**/*.vhdl")), "No VHDL files found in project directory"

--- a/tests/CLI_test/test_helper.py
+++ b/tests/CLI_test/test_helper.py
@@ -15,8 +15,10 @@ def test_create_project(tmp_path):
     # Check if .env file exists and contains correct content
     env_file = project_dir / ".FABulous" / ".env"
     assert env_file.exists()
-    assert "FAB_PROJ_LANG=verilog" in env_file.read_text()
+    assert "FAB_PROJ_LANG='verilog'" in env_file.read_text()
     assert "VERSION=" in env_file.read_text()
+    assert "FAB_PROJ_VERSION=" in env_file.read_text()
+    assert "FAB_PROJ_VERSION_CREATED=" in env_file.read_text()
 
     # Check if template files were copied
     assert any(project_dir.glob("**/*.v")), "No Verilog files found in project directory"
@@ -34,8 +36,9 @@ def test_create_project_vhdl(tmp_path):
     # Check if .env file exists and contains correct content
     env_file = project_dir / ".FABulous" / ".env"
     assert env_file.exists()
-    assert "FAB_PROJ_LANG=vhdl" in env_file.read_text()
-    assert "VERSION=" in env_file.read_text()
+    assert "FAB_PROJ_LANG='vhdl'" in env_file.read_text()
+    assert "FAB_PROJ_VERSION=" in env_file.read_text()
+    assert "FAB_PROJ_VERSION_CREATED=" in env_file.read_text()
 
     # Check if template files were copied
     assert any(project_dir.glob("**/*.vhdl")), "No VHDL files found in project directory"
@@ -54,13 +57,13 @@ def test_update_project_version_success(tmp_path, monkeypatch):
     env_dir = tmp_path / "proj" / ".FABulous"
     env_dir.mkdir(parents=True)
     env_file = env_dir / ".env"
-    env_file.write_text("VERSION=1.2.3\n")
+    env_file.write_text("FAB_PROJ_VERSION=1.2.3\n")
 
     # Patch version() to return compatible version
     monkeypatch.setattr("FABulous.FABulous_CLI.helper.version", lambda _: "1.2.4")
 
     assert update_project_version(tmp_path / "proj") is True
-    assert "VERSION='1.2.4'" in env_file.read_text()
+    assert "FAB_PROJ_VERSION='1.2.4'" in env_file.read_text()
 
 
 def test_update_project_version_missing_version(tmp_path):
@@ -76,9 +79,8 @@ def test_update_project_version_major_mismatch(tmp_path, monkeypatch):
     env_dir = tmp_path / "proj" / ".FABulous"
     env_dir.mkdir(parents=True)
     env_file = env_dir / ".env"
-    env_file.write_text("VERSION=1.2.3\n")
+    env_file.write_text("FAB_PROJ_VERSION=1.2.3\n")
 
     monkeypatch.setattr("FABulous.FABulous_CLI.helper.version", lambda _: "2.0.0")
 
     assert update_project_version(tmp_path / "proj") is False
-


### PR DESCRIPTION
Add the package version when creating a project. If the project version is less than the starting version, add a warning during package setup. 

It can further improve to raise errors when the project version and the package version have major version differences. But this can be done later.   