### PR TITLE
fix:fabric_gen: Bel port names with numbers get cut off

### DIFF
--- a/FABulous/fabric_generator/fabric_gen.py
+++ b/FABulous/fabric_generator/fabric_gen.py
@@ -1110,19 +1110,18 @@ class FabricGenerator:
             signal = []
             userclk_pair = None
 
-            # Internal ports
-            for port in bel.inputs + bel.outputs:
+            # internal + external ports
+            for port in (
+                bel.inputs + bel.outputs + bel.externalInput + bel.externalOutput
+            ):
                 port_name = port.removeprefix(bel.prefix)
-                if r := re.match(r"([a-zA-Z_]+)(\d*)", port_name):
-                    portname, number = r.groups()
-                    port_dict[portname].append((port, number))
-
-            # External ports
-            for port in bel.externalInput + bel.externalOutput:
-                port_name = port.removeprefix(bel.prefix)
-                if r := re.match(r"([a-zA-Z_]+)(\d*)", port_name):
-                    portname, number = r.groups()
-                    port_dict[portname].append((port, number))
+                if r := re.search(r"\d+$", port_name):
+                    number = r.group()
+                    portname = port_name.removesuffix(number)
+                else:
+                    portname = port_name
+                    number = ""
+                port_dict[portname].append((port, number))
 
             # Shared ports
             for port in bel.sharedPort:


### PR DESCRIPTION
Bel ports like C0_A and C1_B get cut off during instantiation, since the rgex that was used to connect the ports as vector, matched any number in a port name.

This was fixed by replacing the initial regex with one that only matches trailing numbers in a port name and cutting off the number afterward.

Also, the handling for internal and external ports got combined, since they are handled the same.