### PR TITLE
ci: Fix incorrect tk package name

### DIFF
--- a/.github/workflows/fabric_gen.yml
+++ b/.github/workflows/fabric_gen.yml
@@ -27,7 +27,7 @@ jobs:
                   if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
                   if [ -f requirements.txt ]; then python3.9 -m pip install -r requirements.txt; fi
                   sudo apt update
-                  sudo apt install python-tk -y
+                  sudo apt install python3-tk -y
             - name: Lint with flake8
               run: |
                   # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
CI is currently broken:

![image](https://github.com/user-attachments/assets/f8e025b0-0d86-433c-aa3d-112eacc62335)

(from #344)

This should fix it - it's just an outdated package name.