### PR TITLE
fix:fabric_gen: Bistream spec gen for non power of 2 MUX

### DIFF
--- a/FABulous/fabric_generator/fabric_gen.py
+++ b/FABulous/fabric_generator/fabric_gen.py
@@ -2605,7 +2605,7 @@ class FabricGenerator:
                 for source, sinkList in result.items():
                     controlWidth = 0
                     for i, sink in enumerate(reversed(sinkList)):
-                        controlWidth = len(sinkList).bit_length() - 1
+                        controlWidth = (len(sinkList) - 1).bit_length()
                         controlValue = f"{len(sinkList) - 1 - i:0{controlWidth}b}"
                         pip = f"{sink}.{source}"
                         if len(sinkList) < 2:


### PR DESCRIPTION
The bitstream spec generation was wrong for non power of 2 MUX. The number of bits to encode a MUX was calculated by (muxsize.bit_length() -1). As an example, this results 3 config bits for a MUX15 and 4 bits for a MUX17, which is not correct.

We changed this to (muxsize - 1).bit_length() for the MUX encoding calculation. This results in the right number of config bits: MUX15: 4 bits, MUX16: 4 bits MUX17: 5 bits...