### PR TITLE
fix:fabric_geometry: Non-deterministic geometry CSV generation

### DIFF
--- a/FABulous/geometry_generator/fabric_geometry.py
+++ b/FABulous/geometry_generator/fabric_geometry.py
@@ -251,7 +251,7 @@ class FabricGeometry:
                 )
             writer.writerows([[], []])
 
-            for tileName in self.tileNames:
+            for tileName in sorted(self.tileNames):
                 tileGeometry = self.tileGeomMap[tileName]
                 tileGeometry.saveToCSV(writer)
 


### PR DESCRIPTION
The geometry CSV output is based on a set.
The order of elements in Python set is non-deterministic.

This resulted in a different eFPGA_geometry.csv for every fabric run, even if nothing was changed in the fabric itself.