### PR TITLE
fix:fabric_gen Add parseBelFile import

### DIFF
--- a/FABulous/fabric_generator/fabric_gen.py
+++ b/FABulous/fabric_generator/fabric_gen.py
@@ -42,6 +42,7 @@ from FABulous.fabric_generator.code_generation_Verilog import VerilogWriter
 from FABulous.fabric_generator.code_generation_VHDL import VHDLWriter
 from FABulous.fabric_generator.code_generator import codeGenerator
 from FABulous.fabric_generator.file_parser import (
+    parseBelFile,
     parseConfigMem,
     parseList,
     parseMatrix,


### PR DESCRIPTION
parseBelFile import was missing after #364.

Testworkflow failed silently, but this should be fixed with #366.
