### PR TITLE
Add the desync frame during the bitstream generation

### DIFF
--- a/FABulous/fabric_cad/bit_gen.py
+++ b/FABulous/fabric_cad/bit_gen.py
@@ -170,6 +170,10 @@ def genBitstream(fasmFile: str, specFile: str, bitstreamFile: str):
             bitStr += bitstring_to_bytes(frame_select_temp)
             bitStr += bit_array[i][j]
 
+    # Add desync frame
+    # 20th bit is desync flag
+    bitStr += bytes.fromhex("00100000")
+
     # Note - format in output file is line by line:
     # Tile Loc, Tile Type, X, Y, bits...... \n
     # Each line is one tile


### PR DESCRIPTION
Since #311 might still take some time to be merged and the fix sometimes collides with updates from the dev branch when only done locally I want to propose we get this small but important fix into the dev branch. 

All credit is given to @mole99, I just extracted it from his PR.
@EverythingElseWasAlreadyTaken Let me know if this is the correct way to get some feature out of another PR or if there is something smarter (e.g. cherry picking?).