### PR TITLE
Cherry pick: geometry_gen:fabric_geometry: Fix indexing error for smaller fabrics

### DIFF
--- a/FABulous/geometry_generator/fabric_geometry.py
+++ b/FABulous/geometry_generator/fabric_geometry.py
@@ -105,7 +105,7 @@ class FabricGeometry:
             maxWidth = 0
             maxSmRelX = 0
             maxSmWidth = 0
-            for i in range(self.fabric.numberOfColumns):
+            for i in range(self.fabric.numberOfRows):
                 maxWidth = max(maxWidth, tileGeometries[i][j].width)
                 maxSmRelX = max(maxSmRelX, tileGeometries[i][j].smGeometry.relX)
                 maxSmWidth = max(maxSmWidth, tileGeometries[i][j].smGeometry.width)


### PR DESCRIPTION
This is just a cherry pick of a fix that is already applied on the `master` branch (#208). Since I currently work with a fabric that has fewer tiles on the Y axis than on the X axis, this bug does often bite me. Let me know if I did this correctly or if this will somehow bite us once we merge `dev` into `master`. Below is the original description:

Fix an indexing error in geometry generation that caused FABulous to crash when the fabric had fewer tiles on the Y axis than on the X axis.