### PR TITLE
fix: requirements.txt format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   'fasm>=0.0.2',
   'requests>=2.0.0',
   'cmd2>=2',
-  'bitarray>=3.4.3',
+  'bitarray>=3.0.0',
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,9 @@ loguru>=0.7.0
 fasm>=0.0.2
 cmd2>=2,<3
 requests>=2.0.0
-pytest>=8.3.5
-pytest-mock
-bitarray
-pytest>=8.4.1,
-pytest-mock>=3.14.1,
-cocotb>=1.9.2
+bitarray>=3.4.3
+pytest>=8.4.0
+pytest-mock>=3.14.0
+cocotb>=1.9.0
 cocotb-test>=0.2.6
-pytest-split
+pytest-split>=0.10.0


### PR DESCRIPTION
Remove some trailing commas in requirements.txt, which could lead to errors in older pip versions and remove duplicate requirements.

Set lower base version of bitarray in pyproject.toml for better compatibility.