### PR TITLE
fix: Set bitarry min version to 3.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   'fasm>=0.0.2',
   'requests>=2.0.0',
   'cmd2>=2',
-  'bitarray>=3.0.0',
+  'bitarray>=3.3.0',
 ]
 
 [project.urls]


### PR DESCRIPTION
We accidentally set the min version of bitarry in the pyproject.toml to 3.0.0 but we need features from 3.3.0.