### PR TITLE
chore: update FABulous arg test and fix caching

### DIFF
--- a/.github/actions/prepare_FABulous_container/action.yaml
+++ b/.github/actions/prepare_FABulous_container/action.yaml
@@ -54,7 +54,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: |
-          /tmp/oss-cad-suite
+          ${{ runner.temp }}/oss-cad-suite
         key: oss-cad-suite-${{ runner.os }}-${{ steps.oss-cad-version.outputs.version }}
         restore-keys: |
           oss-cad-suite-${{ runner.os }}-${{ steps.oss-cad-version.outputs.version }}-

--- a/.github/actions/prepare_FABulous_container/action.yaml
+++ b/.github/actions/prepare_FABulous_container/action.yaml
@@ -35,8 +35,8 @@ runs:
       shell: bash
       run: |
         # Get the latest release info from YosysHQ/oss-cad-suite-build
-        if [ -n "${{ inputs.github_token }}" ]; then
-          VERSION=$(curl -s -H "Authorization: token ${{ inputs.github_token }}" \
+        if [ -n "${{ github.token }}" ]; then
+          VERSION=$(curl -s -H "Authorization: token ${{ github.token }}" \
             "https://api.github.com/repos/YosysHQ/oss-cad-suite-build/releases/latest" | \
             jq -r '.tag_name // "unknown"')
         else
@@ -59,7 +59,7 @@ runs:
       if: steps.cache-oss-cad.outputs.cache-hit != 'true'
       uses: YosysHQ/setup-oss-cad-suite@v3
       with:
-        github-token: ${{ inputs.github_token }}
+        github-token: ${{ github.token }}
     - name: Install GHDL mcode nightly
       # GHDL mcode is required to test our fabric.
       # The oss-cad-suite action installs GHDL, but with the LLVM backend, which is much slower for our simulation
@@ -95,4 +95,3 @@ runs:
       shell: bash
       run: |
         echo "/home/runner/work/FABulous/FABulous/install/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin:$PATH" >> "$GITHUB_PATH"
-

--- a/.github/actions/prepare_FABulous_container/action.yaml
+++ b/.github/actions/prepare_FABulous_container/action.yaml
@@ -63,7 +63,7 @@ runs:
       if: steps.cache-oss-cad.outputs.cache-hit == 'true'
       shell: bash
       run: |
-        "${{ runner.temp }}/oss-cad-suite/bin:$PATH" >> "$GITHUB_PATH"
+        echo "${{ runner.temp }}/oss-cad-suite/bin:$PATH" >> "$GITHUB_PATH"
     - name: Set up OSS CAD suite
       if: steps.cache-oss-cad.outputs.cache-hit != 'true'
       uses: YosysHQ/setup-oss-cad-suite@v3

--- a/.github/actions/prepare_FABulous_container/action.yaml
+++ b/.github/actions/prepare_FABulous_container/action.yaml
@@ -59,6 +59,11 @@ runs:
         restore-keys: |
           oss-cad-suite-${{ runner.os }}-${{ steps.oss-cad-version.outputs.version }}-
           oss-cad-suite-${{ runner.os }}-
+    - name: set up OSS CAD path
+      if: steps.cache-oss-cad.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        "${{ runner.temp }}/oss-cad-suite/bin:$PATH" >> "$GITHUB_PATH"
     - name: Set up OSS CAD suite
       if: steps.cache-oss-cad.outputs.cache-hit != 'true'
       uses: YosysHQ/setup-oss-cad-suite@v3

--- a/.github/actions/prepare_FABulous_container/action.yaml
+++ b/.github/actions/prepare_FABulous_container/action.yaml
@@ -14,10 +14,6 @@ inputs:
     description: "Additional python packages to install"
     required: false
     default: ""
-  github_token:
-    description: "GitHub token for API access"
-    required: false
-    default: ""
 
 runs:
   using: "composite"
@@ -35,22 +31,30 @@ runs:
       shell: bash
       run: |
         # Get the latest release info from YosysHQ/oss-cad-suite-build
+        # Use authenticated API call to avoid rate limits
         if [ -n "${{ github.token }}" ]; then
-          VERSION=$(curl -s -H "Authorization: token ${{ github.token }}" \
+          VERSION=$(curl -s -H "Authorization: Bearer ${{ github.token }}" \
             "https://api.github.com/repos/YosysHQ/oss-cad-suite-build/releases/latest" | \
             jq -r '.tag_name // "unknown"')
         else
           VERSION=$(curl -s "https://api.github.com/repos/YosysHQ/oss-cad-suite-build/releases/latest" | \
             jq -r '.tag_name // "unknown"')
         fi
+
+        # Fallback to a fixed version if API call fails
+        if [ "$VERSION" = "unknown" ] || [ "$VERSION" = "null" ] || [ -z "$VERSION" ]; then
+          echo "Warning: Failed to get OSS CAD Suite version from API, using fallback"
+          VERSION="2024-10-15"  # Use a recent stable version as fallback
+        fi
+
+        echo "Using OSS CAD Suite version: $VERSION"
         echo "version=$VERSION" >> $GITHUB_OUTPUT
     - name: Cache OSS CAD Suite
       id: cache-oss-cad
       uses: actions/cache@v4
       with:
         path: |
-          ~/.local/share/oss-cad-suite
-          ~/bin
+          /tmp/oss-cad-suite
         key: oss-cad-suite-${{ runner.os }}-${{ steps.oss-cad-version.outputs.version }}
         restore-keys: |
           oss-cad-suite-${{ runner.os }}-${{ steps.oss-cad-version.outputs.version }}-

--- a/.github/workflows/pytest_testing.yml
+++ b/.github/workflows/pytest_testing.yml
@@ -78,7 +78,6 @@ jobs:
       - uses: ./.github/actions/prepare_FABulous_container
         with:
           additional_system_packages: "iverilog"
-          github_token: ${{ secrets.GITHUB_TOKEN }}[]
 
       # When running pytest, we write the new test durations using options
       # `--store-durations --clean-durations`.

--- a/tests/CLI_test/conftest.py
+++ b/tests/CLI_test/conftest.py
@@ -51,9 +51,7 @@ def cli(tmp_path):
     os.environ["FAB_PROJ_DIR"] = str(projectDir)
     create_project(projectDir)
     setup_logger(0, False)
-    cli = FABulous_CLI(
-        writerType="verilog", projectDir=projectDir, enteringDir=tmp_path
-    )
+    cli = FABulous_CLI(writerType="verilog", projectDir=projectDir, enteringDir=tmp_path)
     cli.debug = True
     run_cmd(cli, "load_fabric")
     yield cli
@@ -68,6 +66,15 @@ def project(tmp_path):
     create_project(project_dir)
     yield project_dir
     os.environ.pop("FAB_PROJ_DIR", None)
+
+
+@pytest.fixture(autouse=True)
+def cleanup_logger():
+    """Ensure logger is properly cleaned up after each test to prevent
+    'logging to closed file' errors when tests exit quickly"""
+    yield
+    # Remove all logger handlers to prevent logging to closed files
+    logger.remove()
 
 
 @pytest.fixture


### PR DESCRIPTION
Update the argument test implementation to something that can be mocked, which prevents any downloading from happening in a test. 

Fix caching so we don't hit the API limit. 