### PR TITLE
chore(CI): Update checkout and repurpose makefile CI

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -10,7 +10,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/prepare_FABulous_container
         with:
           install_ghdl_mcode: "false"

--- a/.github/workflows/fabric_gen.yml
+++ b/.github/workflows/fabric_gen.yml
@@ -19,10 +19,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: github.base_ref
+      - uses: ./.github/actions/prepare_FABulous_container
+      - name: generate old project
+        run: |
+          FABulous -c demo
+      
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/prepare_FABulous_container
       - name: Run fabric generator flow and simulation with FABulous makefile
         run: |
-          FABulous -c demo
           cd demo/Test
           make FAB_sim
 
@@ -31,13 +38,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: github.base_ref
       - uses: ./.github/actions/prepare_FABulous_container
-        # with:
-          # install_GHDL_mcode: true
-          # GH composite workflwos do not support conditional steps yet. :(
-          # https://github.com/actions/runner/blob/main/docs/adrs/0549-composite-run-steps.md
-      - name: Run fabric generator flow and simulation with FABulous makefile
+      - name: generate old project
         run: |
           FABulous -c demo_vhdl -w vhdl
+
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/prepare_FABulous_container
+      - name: Run fabric generator flow and simulation with FABulous makefile
+        run: |
           cd demo_vhdl/Test
           make full_sim

--- a/.github/workflows/fabric_gen.yml
+++ b/.github/workflows/fabric_gen.yml
@@ -7,7 +7,7 @@ jobs:
     name: Run Verilog fabric generator flow and simulation with FABulous CLI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/prepare_FABulous_container
       - name: Run fabric generator flow and simulation with FABulous CLI
         run: |
@@ -18,7 +18,7 @@ jobs:
     name: Run Verilog fabric generator flow and simulation with FABulous makefile
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/prepare_FABulous_container
       - name: Run fabric generator flow and simulation with FABulous makefile
         run: |
@@ -30,7 +30,7 @@ jobs:
     name: Run VHDL fabric generator flow and simulation with FABulous makefile
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/prepare_FABulous_container
         # with:
           # install_GHDL_mcode: true

--- a/.github/workflows/pre-commit-hooks.yml
+++ b/.github/workflows/pre-commit-hooks.yml
@@ -6,6 +6,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v5
     - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pytest_testing.yml
+++ b/.github/workflows/pytest_testing.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       # These two steps will be executed only when there IS a cache hit (exact match or not). 
       # When a matrix job is retried, it will reuse the same artifact, to execute the exact same split.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Download test durations


### PR DESCRIPTION
Updated all action to using the lastest checkout action

Update the makefile CI for checking old project fabric, as now we can run regular check invoking from pytest. 