### PR TITLE
feat: better context management and new start interface

### DIFF
--- a/.github/workflows/backwards-compatibility.yml
+++ b/.github/workflows/backwards-compatibility.yml
@@ -37,7 +37,7 @@ jobs:
         uses: trstringer/manual-approval@v1
         with:
           secret: ${{ github.TOKEN }}
-          approvers: FABulous
+          approvers: Core
           minimum-approvals: 2
           issue-title: "Backwards compatibility test failed for ${{ matrix.name }} - Manual approval required"
           issue-body: |

--- a/.github/workflows/backwards-compatibility.yml
+++ b/.github/workflows/backwards-compatibility.yml
@@ -31,26 +31,3 @@ jobs:
         run: |
           cd /tmp/demo_${{ matrix.type }}/Test
           make FAB_sim
-      
-      - name: Manual approval for failed backward-compatibility check
-        if: ${{ steps.run_simulation.outcome == 'failure' }}
-        uses: trstringer/manual-approval@v1
-        with:
-          secret: ${{ github.TOKEN }}
-          approvers: Core
-          minimum-approvals: 2
-          issue-title: "Backwards compatibility test failed for ${{ matrix.name }} - Manual approval required"
-          issue-body: |
-            The backwards compatibility test for ${{ matrix.name }} has failed.
-            
-            **PR:** ${{ github.event.pull_request.title }}
-            **Branch:** ${{ github.head_ref }}
-            **Matrix Type:** ${{ matrix.type }}
-            
-            Please review the failure and approve if the breaking change is acceptable.
-          exclude-workflow-initiator-as-approver: false
-          fail-on-denial: true
-      
-      - name: Fail workflow if simulation failed and not approved
-        if: ${{ steps.run_simulation.outcome == 'failure' }}
-        run: exit 1

--- a/.github/workflows/backwards-compatibility.yml
+++ b/.github/workflows/backwards-compatibility.yml
@@ -37,7 +37,7 @@ jobs:
         uses: trstringer/manual-approval@v1
         with:
           secret: ${{ github.TOKEN }}
-          approvers: FPGA-Research
+          approvers: FABulous
           minimum-approvals: 2
           issue-title: "Backwards compatibility test failed for ${{ matrix.name }} - Manual approval required"
           issue-body: |

--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -70,7 +70,6 @@ ProjectDirType = Annotated[
     typer.Argument(
         help="Directory path to project folder",
         parser=validate_project_directory,
-        callback=lambda v: logger.info(f"Setting current working directory to: {v}"),
         resolve_path=True,
         exists=True,
     ),
@@ -306,8 +305,8 @@ def start_cmd(project_dir: ProjectDirType = None) -> None:
     fab_CLI.debug = shared_state.debug
 
     # Change to project directory
-    if project_dir is not None:
-        os.chdir(project_dir)
+    if settings.proj_dir is not None:
+        os.chdir(settings.proj_dir)
     fab_CLI.onecmd_plus_hooks("load_fabric")
     fab_CLI.cmdloop()
     os.chdir(entering_dir)
@@ -344,9 +343,9 @@ def run_cmd(
     fab_CLI.debug = shared_state.debug
 
     # Change to project directory
-    logger.info(f"Setting current working directory to: {project_dir}")
-    if project_dir is not None:
-        os.chdir(project_dir)
+    logger.info(f"Setting current working directory to: {settings.proj_dir}")
+    if settings.proj_dir is not None:
+        os.chdir(settings.proj_dir)
     fab_CLI.onecmd_plus_hooks("load_fabric")
 
     # Ensure commands is a list

--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -229,14 +229,14 @@ def script_cmd(
 
     # Initialize context
     entering_dir = Path.cwd()
-    if project_dir is not None:
-        os.chdir(project_dir)
-
     init_context(
         project_dir=project_dir,
         global_dot_env=shared_state.global_dot_env,
         project_dot_env=shared_state.project_dot_env,
     )
+    script_file = script_file.absolute()
+    if project_dir is not None:
+        os.chdir(project_dir)
     fab_CLI = FABulous_CLI(
         shared_state.writer,
         force=shared_state.force,

--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -1,8 +1,10 @@
-import argparse
 import os
 from importlib.metadata import version
 from pathlib import Path
+from typing import Annotated, Literal
 
+import click
+import typer
 from loguru import logger
 from packaging.version import Version
 
@@ -10,291 +12,651 @@ from FABulous.FABulous_CLI.helper import (
     create_project,
     install_oss_cad_suite,
     setup_logger,
-    update_project_version,
 )
-from FABulous.FABulous_settings import setup_global_env_vars, setup_project_env_vars
+from FABulous.FABulous_settings import FABulousCliSettings
+
+# Using direct parameter passing instead of global context for cleaner architecture
+
+app = typer.Typer(
+    rich_markup_mode="rich",
+    help="[bold blue]FABulous FPGA Fabric Generator[/bold blue]\n\nA command line interface for FABulous FPGA fabric generation and management.",
+    no_args_is_help=True,
+)
 
 
-def main() -> None:
-    """Main function to start the command line interface of FABulous, sets up argument
-    parsing, initialises required components and handles start the FABulous CLI.
+def version_callback(value: bool) -> None:
+    """Print version information and exit."""
+    if value:
+        package_version = Version(version("FABulous-FPGA"))
+        typer.echo(f"FABulous CLI {package_version.base_version}")
+        raise typer.Exit
 
-    Also logs terminal output and if .FABulous folder is missing.
 
-    Command line arguments
-    ----------------------
-    project_dir : str
-        Directory path to project folder.
-    -c, --createProject :  bool
-        Flag to create new project.
-    -fs, --FABulousScript: str, optional
-        Run FABulous with a FABulous script.
-    -ts, --TCLscript: str, optional
-        Run FABulous with a TCL script.
-    -log : str, optional
-        Log all the output from the terminal.
-    -w, --writer : <'verilog', 'vhdl'>, optional
-        Set type of HDL code generated. Currently supports .V and .VHDL (Default .V)
-    -md, --metaDataDir : str, optional
-        Set output directory for metadata files, e.g. pip.txt, bel.txt
-    -v, --verbose : bool, optional
-        Show detailed log information including function and line number.
-    -gde, --globalDotEnv : str, optional
-        Set global .env file path. Default is $FAB_ROOT/.env
-    -pde, --projectDotEnv : str, optional
-        Set project .env file path. Default is $FAB_PROJ_DIR/.env
-    -iocd, --install_oss_cad_suite : str, optional
-        Install the oss-cad-suite in the project directory.
+# Simplified shared options - no callbacks needed, pass parameters directly
+CommonVerbose = Annotated[
+    int,
+    typer.Option("--verbose", "-v", count=True, help="Show detailed log information"),
+]
+CommonDebug = Annotated[bool, typer.Option("--debug", help="Enable debug mode")]
+CommonLogFile = Annotated[
+    Path | None, typer.Option("--log", help="Log all output to file")
+]
+CommonForce = Annotated[
+    bool, typer.Option("--force", help="Force command execution and ignore errors")
+]
+CommonWriter = Annotated[
+    str | None, typer.Option("--writer", "-w", help="Set type of HDL code generated")
+]
+CommonGlobalDotEnv = Annotated[
+    Path | None,
+    typer.Option("--global-dot-env", "-gde", help="Set global .env file path"),
+]
+CommonProjectDotEnv = Annotated[
+    Path | None,
+    typer.Option("--project-dot-env", "-pde", help="Set project .env file path"),
+]
+
+
+def detect_script_type(script_path: Path) -> str:
+    """Detect script type based on file extension and content."""
+    # Check by file extension first
+    suffix = script_path.suffix.lower()
+    if suffix in [".fab", ".fs"]:
+        return "fabulous"
+    if suffix in [".tcl"]:
+        return "tcl"
+
+    return "fabulous"
+
+
+def setup_environment_and_logging(
+    project_dir: Path,
+    global_dot_env: Path | None = None,
+    project_dot_env: Path | None = None,
+    verbose: int = 0,
+    debug: bool = False,
+    log_file: Path | None = None,
+    writer: str | None = None,
+) -> FABulousCliSettings:
+    """Set up environment variables and logging configuration using Pydantic settings.
+
+    Returns:
+        FABulousCliSettings instance with all environment variables loaded
     """
-    parser = argparse.ArgumentParser(
-        description="The command line interface for FABulous"
+    # Setup logger first
+    setup_logger(verbose, debug, log_file=log_file or Path())
+
+    # Create settings instance with custom .env file handling
+    return FABulousCliSettings.create_with_env_files(
+        project_dir=project_dir,
+        global_dot_env=global_dot_env,
+        project_dot_env=project_dot_env,
+        verbose=verbose,
+        debug=debug,
+        log_file=log_file,
+        force=False,  # Will be overridden by CLI args when needed
+        writer=writer,
     )
 
-    create_group = parser.add_mutually_exclusive_group()
 
-    create_group.add_argument(
-        "-c",
-        "--createProject",
-        default=False,
-        action="store_true",
-        help="Create a new project",
-    )
+def validate_project_directory(project_dir: Path) -> Path:
+    """Validate that the project directory exists and is a valid FABulous project."""
+    if not project_dir.exists():
+        logger.error(f"The directory provided does not exist: {project_dir}")
+        raise typer.Exit(1)
 
-    create_group.add_argument(
-        "-iocs",
-        "--install_oss_cad_suite",
-        help="Install the oss-cad-suite in the directory."
-        "This will create a new directory called oss-cad-suite in the provided"
-        "directory and install the oss-cad-suite there."
-        "If there is already a directory called oss-cad-suite, it will be removed and replaced with a new one."
-        "This will also automatically add the FAB_OSS_CAD_SUITE env var in the global FABulous .env file. ",
-        action="store_true",
-        default=False,
-    )
-
-    script_group = parser.add_mutually_exclusive_group()
-
-    parser.add_argument(
-        "project_dir",
-        default="",
-        nargs="?",
-        help="The directory to the project folder",
-    )
-
-    script_group.add_argument(
-        "-fs",
-        "--FABulousScript",
-        default=None,
-        help="Run FABulous with a FABulous script. A FABulous script is a text file containing only FABulous commands"
-        "This will automatically exit the CLI once the command finish execution, and the exit will always happen gracefully.",
-        nargs=1,
-        type=Path,
-    )
-
-    script_group.add_argument(
-        "-ts",
-        "--TCLScript",
-        default=None,
-        help="Run FABulous with a TCL script. A TCL script is a text file containing a mix of TCL commands and FABulous commands."
-        "This will automatically exit the CLI once the command finish execution, and the exit will always happen gracefully.",
-        nargs=1,
-        type=Path,
-    )
-
-    script_group.add_argument(
-        "-p",
-        "--commands",
-        nargs=1,
-        help="execute <commands> (to chain commands, separate them with semicolon + whitespace: 'cmd1; cmd2')",
-    )
-
-    parser.add_argument(
-        "-log",
-        default="",
-        type=Path,
-        nargs="?",
-        const="FABulous.log",
-        help="Log all the output from the terminal",
-    )
-
-    parser.add_argument(
-        "-w",
-        "--writer",
-        choices=["verilog", "vhdl"],
-        help="Set the type of HDL code generated by the tool. Currently support Verilog and VHDL (Default using Verilog)",
-    )
-
-    parser.add_argument(
-        "-md",
-        "--metaDataDir",
-        default=".FABulous",
-        nargs=1,
-        help="Set the output directory for the meta data files eg. pip.txt, bel.txt",
-    )
-
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        default=False,
-        action="count",
-        help="Show detailed log information including function and line number. For -vv additionally output from "
-        "FABulator is logged to the shell for the start_FABulator command",
-    )
-
-    parser.add_argument(
-        "-gde",
-        "--globalDotEnv",
-        nargs=1,
-        help="Set the global .env file path. Default is $FAB_ROOT/.env",
-    )
-
-    parser.add_argument(
-        "-pde",
-        "--projectDotEnv",
-        nargs=1,
-        help="Set the project .env file path. Default is $FAB_PROJ_DIR/.env",
-    )
-
-    parser.add_argument(
-        "--force",
-        action="store_true",
-        help="Force the command to run and ignore any errors. This feature does not work for the TCLScript argument",
-    )
-
-    parser.add_argument("--debug", action="store_true", help="Enable debug mode")
-
-    parser.add_argument(
-        "--version",
-        action="version",
-        version=f"FABulous CLI {Version(version('FABulous-FPGA')).base_version}",
-    )
-
-    parser.add_argument(
-        "--update-project-version",
-        action="store_true",
-        help="Update the project version to match the FABulous package version",
-    )
-
-    args = parser.parse_args()
-
-    setup_logger(args.verbose, args.debug, log_file=args.log)
-
-    # Start with default value
-    projectDir = Path().cwd()
-
-    # Setup global and project env vars to load .env files
-    setup_global_env_vars(args)
-    setup_project_env_vars(args)
-
-    projectDir = Path(os.getenv("FAB_PROJ_DIR"))
-
-    # Finally, user provided argument takes highest priority
-    if args.project_dir:
-        projectDir = Path(args.project_dir).absolute().resolve()
-
-    if args.createProject:
-        create_project(projectDir, args.writer)
-        exit(0)
-
-    if args.install_oss_cad_suite:
-        install_oss_cad_suite(projectDir, True)
-        exit(0)
-
-    if not (projectDir / ".FABulous").exists():
+    if not (project_dir / ".FABulous").exists():
         logger.error(
             "The directory provided is not a FABulous project as it does not have a .FABulous folder"
         )
-        exit(1)
+        raise typer.Exit(1)
 
-    if not projectDir.exists():
-        logger.error(f"The directory provided does not exist: {projectDir}")
-        exit(1)
+    return project_dir
 
-    if args.update_project_version and not update_project_version(projectDir):
-        logger.error(
-            "Failed to update project version. Please check the logs for more details."
-        )
-        exit(1)
 
-    # init the settings right before we start the CLI
+def check_version_compatibility(_: Path) -> None:
+    """Check version compatibility between package and project."""
     from FABulous.FABulous_settings import FABulousSettings
 
     project_version = FABulousSettings().proj_version
     package_version = Version(version("FABulous-FPGA"))
+
     if package_version.release < project_version.release:
         logger.error(
             f"Version incompatible! FABulous-FPGA version: {package_version}, Project version: {project_version}\n"
-            r'Please run "FABulous \<project_dir\> --update-project-version" to update the project version.'
+            r'Please run "FABulous <project_dir> --update-project-version" to update the project version.'
         )
-        exit(1)
+        raise typer.Exit(1)
+
     if project_version.major != package_version.major:
         logger.error(
             f"Major version mismatch! FABulous-FPGA major version: {package_version.major}, Project major version: {project_version.major}\n"
             "This may lead to compatibility issues. Please ensure the project is compatible with the current FABulous-FPGA version."
         )
 
+
+@app.command(
+    "create-project",
+    help="Create a new FABulous project.",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+def create_project_cmd(
+    project_dir: Annotated[
+        Path, typer.Argument(help="Directory path to create the project in")
+    ],
+    writer: Annotated[
+        str,
+        typer.Option(
+            "--writer",
+            "-w",
+            help="Set type of HDL code generated",
+            click_type=click.Choice(["verilog", "vhdl"]),
+        ),
+    ] = "verilog",
+    verbose: CommonVerbose = 0,
+    debug: CommonDebug = False,
+    log_file: CommonLogFile = None,
+) -> None:
+    """Create a new FABulous project."""
+    setup_logger(verbose, debug, log_file=log_file or Path())
+
+    project_dir = project_dir.absolute().resolve()
+    # Type check for mypy - we know writer is valid due to typer.Choice constraint
+    writer_typed: Literal["verilog", "vhdl"] = writer  # type: ignore
+    create_project(project_dir, writer_typed)
+    logger.info(f"Successfully created FABulous project at {project_dir}")
+
+
+@app.command("install-oss-cad-suite")
+def install_oss_cad_suite_cmd(
+    directory: Annotated[
+        Path, typer.Argument(help="Directory to install oss-cad-suite in")
+    ],
+    verbose: CommonVerbose = 0,
+    debug: CommonDebug = False,
+    log_file: CommonLogFile = None,
+) -> None:
+    """Install the oss-cad-suite in the specified directory.
+
+    This will create a new directory called oss-cad-suite and install the suite there.
+    If the directory already exists, it will be replaced. This also automatically adds
+    the FAB_OSS_CAD_SUITE env var in the global FABulous .env file.
+    """
+    setup_logger(verbose, debug, log_file=log_file or Path())
+
+    directory = directory.absolute().resolve()
+    install_oss_cad_suite(directory, True)
+    logger.info(f"Successfully installed oss-cad-suite at {directory}")
+
+
+@app.command("script")
+def script_cmd(
+    project_dir: Annotated[
+        Path, typer.Argument(help="Directory path to project folder")
+    ],
+    script_file: Annotated[Path, typer.Argument(help="Script file to execute")],
+    script_type: Annotated[
+        str | None,
+        typer.Option(
+            "--type", "-t", help="Override script type detection (fabulous|tcl)"
+        ),
+    ] = None,
+    verbose: CommonVerbose = 0,
+    debug: CommonDebug = False,
+    log_file: CommonLogFile = None,
+    global_dot_env: CommonGlobalDotEnv = None,
+    project_dot_env: CommonProjectDotEnv = None,
+    force: CommonForce = False,
+    writer: CommonWriter = None,
+    update_project_version: Annotated[
+        bool,
+        typer.Option(
+            "--update-project-version",
+            help="Update project version to match package version",
+        ),
+    ] = False,
+    _version: Annotated[
+        bool | None,
+        typer.Option(
+            "--version",
+            callback=version_callback,
+            is_eager=True,
+            help="Show version and exit",
+        ),
+    ] = None,
+) -> None:
+    """Execute a script file with auto-detection of script type.
+
+    Automatically detects whether the script is a FABulous (.fab, .fs) or TCL (.tcl)
+    script based on file extension and content. You can override the detection with
+    --type.
+    """
+    # Detect script type if not explicitly provided
+    if script_type is None:
+        script_type = detect_script_type(script_file)
+        logger.info(f"Auto-detected script type: {script_type}")
+    else:
+        if script_type not in ["fabulous", "tcl"]:
+            logger.error("Script type must be either 'fabulous' or 'tcl'")
+            raise typer.Exit(1)
+        logger.info(f"Using user-specified script type: {script_type}")
+
+    # Setup logging using parameters
+    setup_logger(verbose, debug, log_file=log_file or Path())
+
+    # Create settings directly from parameters
+    settings = FABulousCliSettings.create_with_env_files(
+        project_dir=project_dir,
+        global_dot_env=global_dot_env,
+        project_dot_env=project_dot_env,
+        verbose=verbose,
+        debug=debug,
+        log_file=log_file,
+        force=force,
+        writer=writer,
+    )
+
+    # Validate project directory
+    project_dir = validate_project_directory(project_dir)
+
+    # Handle project version update
+    if update_project_version:
+        from FABulous.FABulous_CLI.helper import (
+            update_project_version as update_version_func,
+        )
+
+        if not update_version_func(project_dir):
+            logger.error(
+                "Failed to update project version. Please check the logs for more details."
+            )
+            raise typer.Exit(1)
+        logger.info("Project version updated successfully")
+        return
+
+    # Check version compatibility
+    check_version_compatibility(project_dir)
+
+    # Initialize CLI using settings
     from FABulous.FABulous_CLI.FABulous_CLI import FABulous_CLI
 
     fab_CLI = FABulous_CLI(
-        FABulousSettings().proj_lang,
-        projectDir,
-        Path().cwd(),
-        force=args.force,
+        settings.proj_lang,
+        project_dir,
+        Path.cwd(),
+        force=force,
     )
-    fab_CLI.debug = args.debug
-    fabScript: None | Path = None
-    tclScript: None | Path = None
-    if args.FABulousScript:
-        fabScript = args.FABulousScript[0].absolute()
-    if args.TCLScript:
-        tclScript = args.TCLScript[0].absolute()
+    fab_CLI.debug = debug
 
-    logger.info(f"Setting current working directory to: {projectDir}")
-    os.chdir(projectDir)
+    # Change to project directory
+    logger.info(f"Setting current working directory to: {project_dir}")
+    os.chdir(project_dir)
     fab_CLI.onecmd_plus_hooks("load_fabric")
 
-    if commands := args.commands:
-        commands = [i for i in commands[0].split("; ") if i.strip()]
-        for c in commands:
-            fab_CLI.onecmd_plus_hooks(c)
-            if fab_CLI.exit_code and not args.force:
-                logger.error(
-                    f"Command '{c}' execution failed with exit code {fab_CLI.exit_code}"
-                )
-                exit(fab_CLI.exit_code)
-        else:
-            logger.info(
-                f'Commands "{"; ".join(i.strip() for i in commands)}" executed successfully'
-            )
-            exit(fab_CLI.exit_code)
+    # Execute script based on type
+    if script_type == "tcl":
+        fab_CLI.onecmd_plus_hooks(f"run_tcl {script_file.absolute()}")
+        script_name = "TCL script"
+    else:  # fabulous
+        fab_CLI.onecmd_plus_hooks(f"run_script {script_file.absolute()}")
+        script_name = "FABulous script"
 
-    elif fabScript is not None:
-        fab_CLI.onecmd_plus_hooks(f"run_script {fabScript}")
+    if fab_CLI.exit_code:
+        logger.error(
+            f"{script_name} {script_file} execution failed with exit code {fab_CLI.exit_code}"
+        )
+    else:
+        logger.info(f"{script_name} {script_file} executed successfully")
+
+    raise typer.Exit(fab_CLI.exit_code)
+
+
+@app.command()
+def run(
+    project_dir: Annotated[
+        Path | None, typer.Argument(help="Directory path to project folder")
+    ] = None,
+    fabulous_script: Annotated[
+        Path | None,
+        typer.Option(
+            "--fabulous-script", "-fs", help="Run FABulous with a FABulous script"
+        ),
+    ] = None,
+    tcl_script: Annotated[
+        Path | None,
+        typer.Option("--tcl-script", "-ts", help="Run FABulous with a TCL script"),
+    ] = None,
+    commands: Annotated[
+        str | None,
+        typer.Option("--commands", "-p", help="Execute commands (separate with '; ')"),
+    ] = None,
+    verbose: CommonVerbose = 0,
+    debug: CommonDebug = False,
+    log_file: CommonLogFile = None,
+    global_dot_env: CommonGlobalDotEnv = None,
+    project_dot_env: CommonProjectDotEnv = None,
+    force: CommonForce = False,
+    writer: CommonWriter = None,
+    update_project_version: Annotated[
+        bool,
+        typer.Option(
+            "--update-project-version",
+            help="Update project version to match package version",
+        ),
+    ] = False,
+    _version: Annotated[
+        bool | None,
+        typer.Option(
+            "--version",
+            callback=version_callback,
+            is_eager=True,
+            help="Show version and exit",
+        ),
+    ] = None,
+) -> None:
+    """Run FABulous with the specified project and options.
+
+    This is the main command for running FABulous in interactive mode or with scripts.
+    """
+    # Determine project directory - CLI arg takes precedence, fallback to current dir
+    if project_dir is None:
+        project_dir = Path.cwd()
+    else:
+        project_dir = project_dir.absolute().resolve()
+
+    # Setup logging using parameters
+    setup_logger(verbose, debug, log_file=log_file or Path())
+
+    # Create settings directly from parameters (avoids environment variable manipulation)
+    settings = FABulousCliSettings.create_with_env_files(
+        project_dir=project_dir,
+        global_dot_env=global_dot_env,
+        project_dot_env=project_dot_env,
+        verbose=verbose,
+        debug=debug,
+        log_file=log_file,
+        force=force,
+        writer=writer,
+    )
+
+    # Validate project directory
+    project_dir = validate_project_directory(project_dir)
+
+    # Handle project version update
+    if update_project_version:
+        from FABulous.FABulous_CLI.helper import (
+            update_project_version as update_version_func,
+        )
+
+        if not update_version_func(project_dir):
+            logger.error(
+                "Failed to update project version. Please check the logs for more details."
+            )
+            raise typer.Exit(1)
+        logger.info("Project version updated successfully")
+        return
+
+    # Check version compatibility
+    check_version_compatibility(project_dir)
+
+    # Initialize CLI using settings
+    from FABulous.FABulous_CLI.FABulous_CLI import FABulous_CLI
+
+    fab_CLI = FABulous_CLI(
+        settings.proj_lang,
+        project_dir,
+        Path.cwd(),
+        force=force,
+    )
+    fab_CLI.debug = debug
+
+    # Change to project directory
+    logger.info(f"Setting current working directory to: {project_dir}")
+    os.chdir(project_dir)
+    fab_CLI.onecmd_plus_hooks("load_fabric")
+
+    # Handle different execution modes
+    if commands is not None:  # Check for None instead of truthy to handle empty string
+        # Execute commands mode
+        command_list = [cmd.strip() for cmd in commands.split("; ") if cmd.strip()]
+        if command_list:  # Only execute if there are actual commands
+            for cmd in command_list:
+                fab_CLI.onecmd_plus_hooks(cmd)
+                if fab_CLI.exit_code and not force:
+                    logger.error(
+                        f"Command '{cmd}' execution failed with exit code {fab_CLI.exit_code}"
+                    )
+                    raise typer.Exit(fab_CLI.exit_code)
+            logger.info(f'Commands "{"; ".join(command_list)}" executed successfully')
+        else:
+            logger.info("No commands to execute")
+        # Exit with the CLI exit code (could be non-zero if force was used and there were errors)
+        raise typer.Exit(fab_CLI.exit_code)
+
+    if fabulous_script:
+        # Execute FABulous script mode
+        fab_CLI.onecmd_plus_hooks(f"run_script {fabulous_script.absolute()}")
         if fab_CLI.exit_code:
             logger.error(
-                f"FABulous script {args.FABulousScript} execution failed with exit code {fab_CLI.exit_code}"
+                f"FABulous script {fabulous_script} execution failed with exit code {fab_CLI.exit_code}"
             )
         else:
-            logger.info(f"FABulous script {args.FABulousScript} executed successfully")
-        exit(fab_CLI.exit_code)
+            logger.info(f"FABulous script {fabulous_script} executed successfully")
+        raise typer.Exit(fab_CLI.exit_code)
 
-    elif tclScript is not None:
-        fab_CLI.onecmd_plus_hooks(f"run_tcl {tclScript}")
+    if tcl_script:
+        # Execute TCL script mode
+        fab_CLI.onecmd_plus_hooks(f"run_tcl {tcl_script.absolute()}")
         if fab_CLI.exit_code:
             logger.error(
-                f"TCL script {args.TCLScript} execution failed with exit code {fab_CLI.exit_code}"
+                f"TCL script {tcl_script} execution failed with exit code {fab_CLI.exit_code}"
             )
         else:
-            logger.info(f"TCL script {args.TCLScript} executed successfully")
-        exit(fab_CLI.exit_code)
+            logger.info(f"TCL script {tcl_script} executed successfully")
+        raise typer.Exit(fab_CLI.exit_code)
+
+    # Interactive mode
+    fab_CLI.interactive = True
+    if verbose >= 2:
+        fab_CLI.verbose = True
+
+    fab_CLI.cmdloop()
+
+
+def main() -> None:
+    """Main entry point for the FABulous CLI."""
+    import sys
+
+    # Check if we have legacy argparse-style arguments for backward compatibility
+    legacy_args = [
+        "--createProject",
+        "--install_oss_cad_suite",
+        "--FABulousScript",
+        "--TCLScript",
+        "--commands",
+        "--writer",
+        "--verbose",
+        "--debug",
+        "--log",
+        "--globalDotEnv",
+        "--projectDotEnv",
+        "--force",
+        "--updateProjectVersion",
+        "--version",
+    ]
+
+    if len(sys.argv) > 1 and any(arg in legacy_args for arg in sys.argv):
+        # Convert legacy arguments to new typer command format with deprecation warning
+        convert_legacy_args_with_deprecation_warning()
+    else:
+        # Use the new Typer interface
+        app()
+
+
+def convert_legacy_args_with_deprecation_warning() -> None:
+    """Convert legacy argparse arguments to new Typer commands with deprecation
+    warning."""
+    import argparse
+    import sys
+    from pathlib import Path
+
+    # Show deprecation warning
+    logger.warning(
+        "You are using deprecated argparse-style arguments. "
+        "Please migrate to the new typer-based commands:\n"
+        "  --createProject <dir> → FABulous create-project <dir>\n"
+        "  --install_oss_cad_suite → FABulous install-oss-cad-suite <dir>\n"
+        "  <project_dir> --commands <cmd> → FABulous run <project_dir> --commands <cmd>\n"
+        "  See 'FABulous --help' for more information."
+    )
+
+    # Create a parser that matches the original argparse interface
+    parser = argparse.ArgumentParser(
+        description="The command line interface for FABulous"
+    )
+
+    create_group = parser.add_mutually_exclusive_group()
+    create_group.add_argument(
+        "-c",
+        "--createProject",
+        action="store_true",
+        default=False,
+        help="Create a new project",
+    )
+    create_group.add_argument(
+        "-iocs",
+        "--install_oss_cad_suite",
+        action="store_true",
+        default=False,
+        help="Install the oss-cad-suite in the directory",
+    )
+
+    script_group = parser.add_mutually_exclusive_group()
+    parser.add_argument(
+        "project_dir", default="", nargs="?", help="The directory to the project folder"
+    )
+    script_group.add_argument(
+        "-fs",
+        "--FABulousScript",
+        default=None,
+        nargs=1,
+        type=Path,
+        help="Run FABulous with a FABulous script",
+    )
+    script_group.add_argument(
+        "-ts",
+        "--TCLScript",
+        default=None,
+        nargs=1,
+        type=Path,
+        help="Run FABulous with a TCL script",
+    )
+    script_group.add_argument(
+        "-p", "--commands", default=None, help="Execute commands (separate with '; ')"
+    )
+
+    parser.add_argument(
+        "-w",
+        "--writer",
+        choices=["verilog", "vhdl"],
+        default=None,
+        help="Set type of HDL code generated",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Show detailed log information",
+    )
+    parser.add_argument(
+        "--debug", action="store_true", default=False, help="Enable debug mode"
+    )
+    parser.add_argument("--log", "-log", type=Path, help="Log all output to file")
+    parser.add_argument(
+        "-gde", "--globalDotEnv", type=Path, help="Set global .env file path"
+    )
+    parser.add_argument(
+        "-pde", "--projectDotEnv", type=Path, help="Set project .env file path"
+    )
+    parser.add_argument(
+        "--force", action="store_true", default=False, help="Force command execution"
+    )
+    parser.add_argument(
+        "--updateProjectVersion",
+        action="store_true",
+        default=False,
+        help="Update project version",
+    )
+    parser.add_argument(
+        "--version", action="store_true", default=False, help="Show version and exit"
+    )
+
+    # Parse the legacy arguments
+    args = parser.parse_args()
+
+    # Convert to new Typer command format and execute
+    if args.version:
+        from importlib.metadata import version
+
+        from packaging.version import Version
+
+        package_version = Version(version("FABulous-FPGA"))
+        logger.info(f"FABulous CLI {package_version.base_version}")
+        sys.exit(0)
+
+    elif args.createProject:
+        # Convert to: FABulous create-project <project_dir> [options]
+        if not args.project_dir:
+            logger.error("Project directory is required when creating a project")
+            sys.exit(2)
+        project_dir = Path(args.project_dir)
+        try:
+            create_project_cmd(
+                project_dir=project_dir,
+                writer=args.writer or "verilog",
+                verbose=args.verbose,
+                debug=args.debug,
+                log_file=args.log,
+            )
+            sys.exit(0)
+        except typer.Exit as e:
+            sys.exit(e.exit_code)
+
+    elif args.install_oss_cad_suite:
+        # Convert to: FABulous install-oss-cad-suite <directory> [options]
+        directory = Path(args.project_dir) if args.project_dir else Path.cwd()
+        try:
+            install_oss_cad_suite_cmd(
+                directory=directory,
+                verbose=args.verbose,
+                debug=args.debug,
+                log_file=args.log,
+            )
+            sys.exit(0)
+        except typer.Exit as e:
+            sys.exit(e.exit_code)
 
     else:
-        fab_CLI.interactive = True
-        if args.verbose == 2:
-            fab_CLI.verbose = True
-
-        fab_CLI.cmdloop()
-        exit(0)
+        # Convert to: FABulous run <project_dir> [options]
+        try:
+            run(
+                project_dir=Path(args.project_dir) if args.project_dir else None,
+                fabulous_script=args.FABulousScript[0] if args.FABulousScript else None,
+                tcl_script=args.TCLScript[0] if args.TCLScript else None,
+                commands=args.commands,
+                writer=args.writer,
+                verbose=args.verbose,
+                debug=args.debug,
+                log_file=args.log,
+                global_dot_env=args.globalDotEnv,
+                project_dot_env=args.projectDotEnv,
+                force=args.force,
+                update_project_version=args.updateProjectVersion,
+            )
+            # If we get here without an exception, exit with success
+            sys.exit(0)
+        except typer.Exit as e:
+            sys.exit(e.exit_code)
 
 
 if __name__ == "__main__":

--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -114,7 +114,7 @@ def common_options(
         typer.Option(
             "--writer",
             "-w",
-            help="Set type of HDL code generated",
+            help="Set type of HDL code generated. System Verilog is not supported yet.",
             case_sensitive=False,
         ),
     ] = HDLType.VERILOG,

--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -106,7 +106,8 @@ def common_options(
         typer.Option("--project-dot-env", "-pde", help="Set project .env file path"),
     ] = None,
     force: Annotated[
-        bool, typer.Option("--force", help="Force command execution and ignore errors")
+        bool,
+        typer.Option("--force", "-f", help="Force command execution and ignore errors"),
     ] = False,
     writer: Annotated[
         HDLType,
@@ -282,8 +283,9 @@ def script_cmd(
 
 
 @app.command("start")
+@app.command("s", hidden=True)
 def start_cmd(project_dir: ProjectDirType = None) -> None:
-    """Run FABulous with the specified project and options.
+    """Start FABulous in interactive mode. Alias: s.
 
     This is the main command for running FABulous in interactive mode or with scripts.
     If no project directory is specified, uses the current directory.
@@ -313,6 +315,7 @@ def start_cmd(project_dir: ProjectDirType = None) -> None:
 
 
 @app.command("run")
+@app.command("r", hidden=True)
 def run_cmd(
     project_dir: ProjectDirType = None,
     commands: Annotated[
@@ -325,6 +328,11 @@ def run_cmd(
         ),
     ] = None,
 ) -> None:
+    """Run commands directly in a FABulous project.
+
+    Alias: r
+    """
+
     settings = init_context(
         project_dir=project_dir,
         global_dot_env=shared_state.global_dot_env,
@@ -388,7 +396,12 @@ def run_cmd(
 
 def main() -> None:
     try:
-        if sys.argv[1] not in [i.name for i in app.registered_commands]:
+        if len(sys.argv) == 1:
+            app()
+
+        first_non_flag = [i for i in sys.argv[1:] if not i.startswith("-")][0]
+
+        if first_non_flag not in [i.name for i in app.registered_commands]:
             convert_legacy_args_with_deprecation_warning()
         else:
             app()
@@ -559,6 +572,8 @@ def convert_legacy_args_with_deprecation_warning() -> None:
         r"  FABulous \<project_dir> --commands \<cmd> → FABulous run \<project_dir> \<cmd>"
         "\n"
         r"  FABulous \<project_dir>  → FABulous start \<project_dir>"
+        "\n"
+        r"  FABulous \<project_dir> --debug  → FABulous --debug start \<project_dir>"
         "\n"
         "  See 'FABulous --help' for more information."
     )

--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -229,7 +229,7 @@ def script_cmd(
 
     # Initialize context
     entering_dir = Path.cwd()
-    init_context(
+    settings = init_context(
         project_dir=project_dir,
         global_dot_env=shared_state.global_dot_env,
         project_dot_env=shared_state.project_dot_env,
@@ -238,7 +238,7 @@ def script_cmd(
     if project_dir is not None:
         os.chdir(project_dir)
     fab_CLI = FABulous_CLI(
-        shared_state.writer,
+        settings.proj_lang,
         force=shared_state.force,
     )
     fab_CLI.debug = shared_state.debug
@@ -399,12 +399,12 @@ def main() -> None:
         if len(sys.argv) == 1:
             app()
 
-        first_non_flag = [i for i in sys.argv[1:] if not i.startswith("-")][0]
-
-        if first_non_flag not in [i.name for i in app.registered_commands]:
-            convert_legacy_args_with_deprecation_warning()
+        for i in sys.argv[1:]:
+            if i in [i.name for i in app.registered_commands]:
+                app()
+                break
         else:
-            app()
+            convert_legacy_args_with_deprecation_warning()
     except typer.Exit as e:
         sys.exit(e.exit_code)
     except Exception as e:  # noqa: BLE001 General overall capture

--- a/FABulous/FABulous_API.py
+++ b/FABulous/FABulous_API.py
@@ -74,7 +74,6 @@ class FABulous_API:
         if fabricCSV != "":
             self.fabric = fileParser.parseFabricCSV(fabricCSV)
             self.geometryGenerator = GeometryGenerator(self.fabric)
-
         if isinstance(self.writer, VHDLCodeGenerator):
             self.fileExtension = ".vhdl"
 

--- a/FABulous/FABulous_API.py
+++ b/FABulous/FABulous_API.py
@@ -30,7 +30,7 @@ from FABulous.fabric_generator.gen_fabric.gen_tile import (
     generateTile,
 )
 from FABulous.fabric_generator.gen_fabric.gen_top_wrapper import generateTopWrapper
-from FABulous.FABulous_settings import FABulousSettings
+from FABulous.FABulous_settings import get_context
 from FABulous.geometry_generator.geometry_gen import GeometryGenerator
 
 
@@ -163,7 +163,7 @@ class FABulous_API:
             Name of the tile for which the switch matrix will be generated.
         """
         if tile := self.fabric.getTileByName(tileName):
-            switch_matrix_debug_signal = FABulousSettings().switch_matrix_debug_signal
+            switch_matrix_debug_signal = get_context().switch_matrix_debug_signal
             logger.info(
                 f"Generate switch matrix debug signals: {switch_matrix_debug_signal}"
             )

--- a/FABulous/FABulous_CLI/FABulous_CLI.py
+++ b/FABulous/FABulous_CLI/FABulous_CLI.py
@@ -16,7 +16,6 @@
 
 import argparse
 import csv
-import os
 import pickle
 import pprint
 import subprocess as sp
@@ -53,7 +52,6 @@ from FABulous.FABulous_CLI import cmd_synthesis
 from FABulous.FABulous_CLI.helper import (
     CommandPipeline,
     allow_blank,
-    check_if_application_exists,
     copy_verilog_files,
     install_oss_cad_suite,
     make_hex,
@@ -883,9 +881,7 @@ class FABulous_CLI(Cmd):
         copy_verilog_files(self.projectDir / "Fabric", fabricFilesDir)
         file_list = [str(i) for i in fabricFilesDir.glob("*.v")]
 
-        iverilog = check_if_application_exists(
-            os.getenv("FAB_IVERILOG_PATH", "iverilog")
-        )
+        iverilog = get_context().iverilog_path
         runCmd = [
             f"{iverilog}",
             "-D",

--- a/FABulous/FABulous_CLI/FABulous_CLI.py
+++ b/FABulous/FABulous_CLI/FABulous_CLI.py
@@ -60,7 +60,7 @@ from FABulous.FABulous_CLI.helper import (
     remove_dir,
     wrap_with_except_handling,
 )
-from FABulous.FABulous_settings import get_context
+from FABulous.FABulous_settings import get_context, init_context
 
 META_DATA_DIR = ".FABulous"
 
@@ -123,7 +123,6 @@ class FABulous_CLI(Cmd):
     def __init__(
         self,
         writerType: str | None,
-        projectDir: Path,
         force: bool = False,
         interactive: bool = False,
         verbose: bool = False,
@@ -131,8 +130,7 @@ class FABulous_CLI(Cmd):
     ) -> None:
         """Initialises the FABulous shell instance.
 
-        Determines file extension based on the type of writer used in 'fab'
-        and sets fabricLoaded to true if 'fab' has 'fabric' attribute.
+        This sets up the necessary context and initialises the FABulous API.
 
         Parameters
         ----------
@@ -143,6 +141,11 @@ class FABulous_CLI(Cmd):
         script : str, optional
             Path to optional Tcl script to be executed, by default ""
         """
+        try:
+            get_context()
+        except RuntimeError:
+            init_context()
+
         super().__init__(
             persistent_history_file=f"{get_context().proj_dir}/{META_DATA_DIR}/.fabulous_history",
             allow_cli_args=False,
@@ -158,14 +161,14 @@ class FABulous_CLI(Cmd):
             )
             sys.exit(1)
 
-        self.projectDir = projectDir.absolute()
+        self.projectDir = get_context().proj_dir
         self.add_settable(
             Settable("projectDir", Path, "The directory of the project", self)
         )
 
         self.tiles = []
         self.superTiles = []
-        self.csvFile = Path(projectDir / "fabric.csv")
+        self.csvFile = Path(self.projectDir / "fabric.csv")
         self.add_settable(
             Settable(
                 "csvFile", Path, "The fabric file ", self, completer=Cmd.path_complete

--- a/FABulous/FABulous_CLI/FABulous_CLI.py
+++ b/FABulous/FABulous_CLI/FABulous_CLI.py
@@ -60,7 +60,7 @@ from FABulous.FABulous_CLI.helper import (
     remove_dir,
     wrap_with_except_handling,
 )
-from FABulous.FABulous_settings import FABulousSettings
+from FABulous.FABulous_settings import get_context
 
 META_DATA_DIR = ".FABulous"
 
@@ -144,7 +144,7 @@ class FABulous_CLI(Cmd):
             Path to optional Tcl script to be executed, by default ""
         """
         super().__init__(
-            persistent_history_file=f"{FABulousSettings().proj_dir}/{META_DATA_DIR}/.fabulous_history",
+            persistent_history_file=f"{get_context().proj_dir}/{META_DATA_DIR}/.fabulous_history",
             allow_cli_args=False,
         )
 
@@ -318,7 +318,7 @@ class FABulous_CLI(Cmd):
         Sets the the FAB_OSS_CAD_SUITE environment variable in the .env file.
         """
         if args.destination_folder == "":
-            dest_dir = FABulousSettings().root
+            dest_dir = get_context().root
         else:
             dest_dir = args.destination_folder
 
@@ -566,7 +566,7 @@ class FABulous_CLI(Cmd):
         If no installation can be found, a warning is produced.
         """
         logger.info("Checking for FABulator installation")
-        fabulatorRoot = FABulousSettings().fabulator_root
+        fabulatorRoot = get_context().fabulator_root
 
         if fabulatorRoot is None:
             logger.warning("FABULATOR_ROOT environment variable not set.")
@@ -726,7 +726,7 @@ class FABulous_CLI(Cmd):
 
         if Path(f"{self.projectDir}/{parent}").exists():
             # TODO rewriting the fab_arch script so no need to copy file for work around
-            npnr = FABulousSettings().nextpnr_path
+            npnr = get_context().nextpnr_path
             if f"{json_file}" in [
                 str(i.name) for i in Path(f"{self.projectDir}/{parent}").iterdir()
             ]:
@@ -910,7 +910,7 @@ class FABulous_CLI(Cmd):
         if self.verbose or self.debug:
             logger.info(f"Make hex file {bitstreamHexPath}")
         make_hex(bitstreamPath, bitstreamHexPath)
-        vvp = FABulousSettings().vvp_path
+        vvp = get_context().vvp_path
 
         # $plusargs is used to pass the bitstream hex and waveform path to the testbench
         vvpArgs = [
@@ -1013,6 +1013,8 @@ class FABulous_CLI(Cmd):
 
         with Path(args.file).open() as f:
             for i in f:
+                if i.startswith("#"):
+                    continue
                 self.onecmd_plus_hooks(i.strip())
                 if self.exit_code != 0:
                     if not self.force:

--- a/FABulous/FABulous_CLI/FABulous_CLI.py
+++ b/FABulous/FABulous_CLI/FABulous_CLI.py
@@ -112,7 +112,6 @@ class FABulous_CLI(Cmd):
     prompt: str = "FABulous> "
     fabulousAPI: FABulous_API
     projectDir: Path
-    enteringDir: Path
     top: str
     allTile: list[str]
     csvFile: Path
@@ -125,9 +124,10 @@ class FABulous_CLI(Cmd):
         self,
         writerType: str | None,
         projectDir: Path,
-        enteringDir: Path,
         force: bool = False,
         interactive: bool = False,
+        verbose: bool = False,
+        debug: bool = False,
     ) -> None:
         """Initialises the FABulous shell instance.
 
@@ -147,7 +147,6 @@ class FABulous_CLI(Cmd):
             persistent_history_file=f"{FABulousSettings().proj_dir}/{META_DATA_DIR}/.fabulous_history",
             allow_cli_args=False,
         )
-        self.enteringDir = enteringDir
 
         if writerType == "verilog":
             self.fabulousAPI = FABulous_API(VerilogCodeGenerator())
@@ -173,13 +172,14 @@ class FABulous_CLI(Cmd):
             )
         )
 
-        self.verbose = False
+        self.verbose = verbose
         self.add_settable(Settable("verbose", bool, "verbose output", self))
 
         self.force = force
         self.add_settable(Settable("force", bool, "force execution", self))
 
         self.interactive = interactive
+        self.debug = debug
 
         if isinstance(self.fabulousAPI.writer, VHDLCodeGenerator):
             self.extension = "vhdl"
@@ -238,7 +238,6 @@ class FABulous_CLI(Cmd):
     def do_exit(self, *_ignored: str) -> bool:
         """Exits the FABulous shell and logs info message."""
         logger.info("Exiting FABulous shell")
-        os.chdir(self.enteringDir)
         return True
 
     do_quit = do_exit

--- a/FABulous/FABulous_CLI/FABulous_CLI.py
+++ b/FABulous/FABulous_CLI/FABulous_CLI.py
@@ -168,7 +168,7 @@ class FABulous_CLI(Cmd):
 
         self.tiles = []
         self.superTiles = []
-        self.csvFile = Path(self.projectDir / "fabric.csv")
+        self.csvFile = Path(self.projectDir / "fabric.csv").resolve()
         self.add_settable(
             Settable(
                 "csvFile", Path, "The fabric file ", self, completer=Cmd.path_complete
@@ -350,7 +350,7 @@ class FABulous_CLI(Cmd):
                 self.fabulousAPI.loadFabric(self.csvFile)
             else:
                 raise FileNotFoundError(
-                    "No argument is given and the csv file is set but the file does not exist"
+                    f"No argument is given and the csv file is set at {self.csvFile} but the file does not exist"
                 )
         else:
             self.fabulousAPI.loadFabric(args.file)

--- a/FABulous/FABulous_CLI/__init__.py
+++ b/FABulous/FABulous_CLI/__init__.py
@@ -1,0 +1,5 @@
+"""CLI module for FABulous."""
+
+from .FABulous_CLI import FABulous_CLI
+
+__all__ = ["FABulous_CLI"]

--- a/FABulous/FABulous_CLI/cmd_synthesis.py
+++ b/FABulous/FABulous_CLI/cmd_synthesis.py
@@ -7,7 +7,7 @@ from cmd2 import Cmd, Cmd2ArgumentParser, with_argparser, with_category
 from loguru import logger
 
 from FABulous.custom_exception import CommandError
-from FABulous.FABulous_settings import FABulousSettings
+from FABulous.FABulous_settings import get_context
 
 if TYPE_CHECKING:
     from FABulous.FABulous_CLI.FABulous_CLI import FABulous_CLI
@@ -256,7 +256,7 @@ def do_synthesis(self: "FABulous_CLI", args: argparse.Namespace) -> None:
             return
 
     json_file = paths[0].with_suffix(".json")
-    yosys = FABulousSettings().yosys_path
+    yosys = get_context().yosys_path
 
     cmd = [
         "synth_fabulous",

--- a/FABulous/FABulous_CLI/helper.py
+++ b/FABulous/FABulous_CLI/helper.py
@@ -5,8 +5,11 @@ import re
 import shutil
 import sys
 import tarfile
+import tempfile
 from collections.abc import Callable, Sequence
+from importlib import resources
 from importlib.metadata import version
+from importlib.resources.abc import Traversable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -16,7 +19,7 @@ from loguru import logger
 from packaging.version import Version
 
 from FABulous.custom_exception import PipelineCommandError
-from FABulous.FABulous_settings import get_context
+from FABulous.FABulous_settings import get_context, init_context
 
 if TYPE_CHECKING:
     from loguru import Record
@@ -94,20 +97,29 @@ def create_project(
     if lang not in ["verilog", "vhdl"]:
         lang = "verilog"
 
-    fabulousRoot = get_context().root
-
-    # Copy the project template
-    common_template = fabulousRoot / "fabric_files/FABulous_project_template_common"
-    lang_template = fabulousRoot / f"fabric_files/FABulous_project_template_{lang}"
-    if not common_template.exists():
-        raise FileNotFoundError(
-            f"Common template not found: {common_template}, is FAB_ROOT not set right?"
+    # Copy the project template using importlib.resources
+    try:
+        common_template_ref = (
+            resources.files("FABulous.fabric_files")
+            / "FABulous_project_template_common"
+        )
+        lang_template_ref = (
+            resources.files("FABulous.fabric_files")
+            / f"FABulous_project_template_{lang}"
         )
 
-    if not lang_template.exists():
+        # Check if templates exist
+        if not common_template_ref.is_dir():
+            raise FileNotFoundError("Common template not found in package resources")
+        if not lang_template_ref.is_dir():
+            raise FileNotFoundError(
+                f"Language template ({lang}) not found in package resources"
+            )
+
+    except (ImportError, AttributeError) as e:
         raise FileNotFoundError(
-            f"Language template not found: {lang_template}, is FAB_ROOT not set right?"
-        )
+            f"Unable to access fabric templates from package: {e}"
+        ) from e
 
     if project_dir.exists():
         logger.error("Project directory already exists!")
@@ -116,16 +128,28 @@ def create_project(
         project_dir.mkdir(parents=True, exist_ok=True)
         (project_dir / ".FABulous").mkdir(parents=True, exist_ok=True)
 
-    for source in [common_template, lang_template]:
-        for item in source.rglob("*"):
-            dest_item = project_dir / item.relative_to(source)
-            if item.is_dir():
-                dest_item.mkdir(parents=True, exist_ok=True)
-            else:
-                if dest_item.exists():
-                    logger.warning(f"File {dest_item} already exists. Overwriting...")
-                dest_item.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(item, dest_item)
+    # Copy templates from package resources using shutil.copytree
+    # Use a robust approach that works in all environments
+    def _copy_template_safely(template_ref: Traversable, target_dir: Path) -> None:
+        """Copy template files safely, handling different installation environments."""
+        try:
+            # Try direct copy first (works in development/editable installs)
+            with resources.as_file(template_ref) as template_src:
+                shutil.copytree(template_src, target_dir, dirs_exist_ok=True)
+        except (OSError, PermissionError, shutil.Error) as e:
+            # Fallback: extract to temp directory first (works with wheels, frozen apps)
+            logger.debug(f"Direct copy failed ({e}), using temp directory fallback")
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_template = Path(temp_dir) / "template"
+                with resources.as_file(template_ref) as template_src:
+                    shutil.copytree(template_src, temp_template)
+                shutil.copytree(temp_template, target_dir, dirs_exist_ok=True)
+
+    # Copy common template first
+    _copy_template_safely(common_template_ref, project_dir)
+
+    # Copy language-specific template (may overwrite some common files)
+    _copy_template_safely(lang_template_ref, project_dir)
 
     # Replace {HDL_SUFFIX} placeholder in all tile csv files
     new_suffix = "v" if lang == "verilog" else "vhdl"
@@ -307,6 +331,7 @@ def install_oss_cad_suite(destination_folder: Path, update: bool = False) -> Non
     system = platform.system().lower()
     machine = platform.machine().lower()
     url = None
+    init_context(None)
 
     # check if oss-cad-suite folder already exists
     ocs_folder = destination_folder / "oss-cad-suite"
@@ -388,29 +413,13 @@ def install_oss_cad_suite(destination_folder: Path, update: bool = False) -> Non
     logger.info(f"Remove archive {ocs_archive}")
     ocs_archive.unlink()
 
-    fab_root_env = get_context().root
-    if fab_root_env is None:
-        logger.error(
-            "FAB_ROOT environment variable is not set. Cannot update .env file for OSS CAD Suite."
-        )
-        raise OSError(
-            "FAB_ROOT is not set, cannot determine .env file path for OSS CAD Suite."
-        )
-    env_file = Path(fab_root_env) / ".env"
-    env_cont = ""
-    if env_file.is_file():
-        logger.info(f"Updating FAB_OSS_CAD_SUITE in .env file {env_file}")
-        env_cont = env_file.read_text()
-        env_cont = env_cont.split("\n")
-        for line in env_cont:
-            if "FAB_OSS_CAD_SUITE" in line:
-                env_cont.remove(line)
-        env_cont.append(f"FAB_OSS_CAD_SUITE={ocs_folder.absolute()}")
-    else:
-        logger.info(f"Creating .env file {env_file}")
-        env_cont = [f"FAB_OSS_CAD_SUITE={ocs_folder.absolute()}"]
-
-    env_file.write_text("\n".join(env_cont))
+    # Use user config directory for global .env file
+    user_config_dir = get_context().user_config_dir
+    user_config_dir.mkdir(parents=True, exist_ok=True)
+    env_file = user_config_dir / ".env"
+    if not env_file.exists():
+        env_file.touch()
+    set_key(env_file, "FAB_OSS_CAD_SUITE", str(ocs_folder.absolute()))
 
     # export oss-cad-suite to PATH
     os.environ["PATH"] += os.pathsep + str(ocs_folder / "bin")

--- a/FABulous/FABulous_CLI/helper.py
+++ b/FABulous/FABulous_CLI/helper.py
@@ -49,7 +49,6 @@ def setup_logger(verbosity: int, debug: bool, log_file: Path = Path()) -> None:
 
         if os.getenv("FABULOUS_TESTING", None):
             final_log = f"{record['level'].name}: {record['message']}\n"
-
         return final_log
 
     # Determine the log level for the sink
@@ -389,7 +388,7 @@ def install_oss_cad_suite(destination_folder: Path, update: bool = False) -> Non
     logger.info(f"Remove archive {ocs_archive}")
     ocs_archive.unlink()
 
-    fab_root_env = os.getenv("FAB_ROOT")
+    fab_root_env = get_context().root
     if fab_root_env is None:
         logger.error(
             "FAB_ROOT environment variable is not set. Cannot update .env file for OSS CAD Suite."

--- a/FABulous/FABulous_CLI/helper.py
+++ b/FABulous/FABulous_CLI/helper.py
@@ -1,3 +1,5 @@
+"""Helper functions for FABulous."""
+
 import functools
 import os
 import platform
@@ -30,6 +32,7 @@ MAX_BITBYTES = 16384
 
 
 def setup_logger(verbosity: int, debug: bool, log_file: Path = Path()) -> None:
+    """Setup logger for FABulous."""
     # Remove the default logger to avoid duplicate logs
     logger.remove()
 
@@ -228,35 +231,6 @@ def make_hex(binfile: Path, outfile: Path) -> None:
                 print(f"{bindata[i]:02x}", file=f)
             else:
                 print("0", file=f)
-
-
-def check_if_application_exists(application: str) -> Path:
-    """Checks if an application is installed on the system.
-
-    Parameters
-    ----------
-    application : str
-        Name of the application to check.
-    throw_exception : bool, optional
-        If True, throws an exception if the application is not installed, by default True
-
-    Returns
-    -------
-    Path
-        Path to  the application, if installed.
-
-    Raises
-    ------
-    Exception
-        If the application is not installed and throw_exception is True.
-    """
-    path = shutil.which(application)
-    if path is not None:
-        return Path(path)
-    error_msg = f"{application} is not installed. Please install it or set FAB_<APPLICATION>_PATH in the .env file."
-    # To satisfy the `-> Path` return type, an exception must be raised if no path is found.
-    # The throw_exception parameter's original intent might need review if non-exception paths were desired.
-    raise FileNotFoundError(error_msg)
 
 
 def wrap_with_except_handling(fun_to_wrap: Callable) -> Callable:

--- a/FABulous/FABulous_CLI/helper.py
+++ b/FABulous/FABulous_CLI/helper.py
@@ -98,7 +98,7 @@ def create_project(
     logger.info(project_dir)
 
     if lang not in ["verilog", "vhdl"]:
-        lang = "verilog"
+        raise ValueError(f"Unsupported language: {lang}")
 
     # Copy the project template using importlib.resources
     try:

--- a/FABulous/FABulous_CLI/helper.py
+++ b/FABulous/FABulous_CLI/helper.py
@@ -435,9 +435,11 @@ def update_project_version(project_dir: Path) -> bool:
 class CommandPipeline:
     """Helper class to manage command execution with error handling."""
 
-    def __init__(self, cli_instance: "FABulous_CLI") -> None:
+    def __init__(self, cli_instance: "FABulous_CLI", force: bool = False) -> None:
         self.cli = cli_instance
         self.steps = []
+        self.force = force
+        self.final_exit_code = 0
 
     def add_step(
         self, command: str, error_message: str = "Command failed"
@@ -447,10 +449,28 @@ class CommandPipeline:
         return self
 
     def execute(self) -> bool:
-        """Execute all steps in the pipeline."""
+        """Execute all steps in the pipeline.
+
+        Returns:
+            bool: True if all commands succeeded, False if any failed.
+
+        Raises:
+            PipelineCommandError: If any command fails and force=False.
+        """
 
         for command, error_message in self.steps:
             self.cli.onecmd_plus_hooks(command)
             if self.cli.exit_code != 0:
-                raise PipelineCommandError(error_message)
-        return True
+                self.final_exit_code = self.cli.exit_code
+                logger.error(
+                    f"Command '{command}' execution failed with exit code {self.cli.exit_code}"
+                )
+
+                if not self.force:
+                    raise PipelineCommandError(error_message)
+
+        return self.final_exit_code == 0
+
+    def get_exit_code(self) -> int:
+        """Get the final exit code from pipeline execution."""
+        return self.final_exit_code

--- a/FABulous/FABulous_settings.py
+++ b/FABulous/FABulous_settings.py
@@ -5,13 +5,12 @@ from shutil import which
 
 from loguru import logger
 from packaging.version import Version
-from pydantic import field_validator
-from pydantic_core.core_schema import FieldValidationInfo  # type: ignore
+from pydantic import ValidationInfo, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class FABulousSettings(BaseSettings):
-    """Application settings.
+    """FABulous settings.
 
     Tool paths are resolved lazily during validation so that environment variable setup
     (including PATH updates for oss-cad-suite) can occur beforehand.
@@ -35,27 +34,6 @@ class FABulousSettings(BaseSettings):
 
     proj_lang: HDLType = HDLType.VERILOG
     switch_matrix_debug_signal: bool = False
-
-    # CLI-specific options (previously in FABulousCliSettings)
-    verbose: int = 0
-    debug: bool = False
-    log_file: Path | None = None
-    force: bool = False
-
-    # Script execution options
-    fabulous_script: Path | None = None
-    tcl_script: Path | None = None
-    commands: str | None = None
-
-    # Project creation options
-    create_project: bool = False
-    install_oss_cad_suite: bool = False
-
-    # Version and help options
-    update_project_version: bool = False
-
-    # Output directory for metadata
-    metadata_dir: str = ".FABulous"
 
     @field_validator("proj_version", "proj_version_created", mode="before")
     @classmethod
@@ -150,6 +128,9 @@ class FABulousSettings(BaseSettings):
     )
     @classmethod
     def resolve_tool_paths(cls, value: Path | None, info: FieldValidationInfo) -> Path | None:  # type: ignore[override]
+    def resolve_tool_paths(
+        cls, value: Path | None, info: ValidationInfo
+    ) -> Path | None:  # type: ignore[override]
         if value is not None:
             return value
         tool_map = {
@@ -169,40 +150,13 @@ class FABulousSettings(BaseSettings):
         logger.warning(f"{tool} not found in PATH during settings initialisation. Some features may be unavailable.")
         return None
 
-    # CLI-specific validators
-    @field_validator("fabulous_script", "tcl_script", mode="before")
-    @classmethod
-    def validate_script_paths(cls, value: str | Path | None) -> Path | None:
-        """Convert script paths to Path objects but don't validate existence yet.
-
-        File existence will be validated at execution time to maintain backward
-        compatibility with legacy argument handling.
-        """
-        if value is None:
-            return None
-        if isinstance(value, str):
-            value = Path(value)
-        return value.absolute()
-
-    @field_validator("log_file", mode="before")
-    @classmethod
-    def validate_log_file(cls, value: str | Path | None) -> Path | None:
-        """Validate log file path, creating parent directories if needed."""
-        if value is None:
-            return None
-        if isinstance(value, str):
-            value = Path(value)
-        # Ensure parent directory exists
-        value.parent.mkdir(parents=True, exist_ok=True)
-        return value.absolute()
-
 
 # Module-level singleton pattern for settings management
 _context_instance: FABulousSettings | None = None
 
 
 def init_context(
-    project_dir: Path | None = None,
+    project_dir: Path | None,
     global_dot_env: Path | None = None,
     project_dot_env: Path | None = None,
 ) -> FABulousSettings:
@@ -211,12 +165,12 @@ def init_context(
     This should be called once at application startup to configure the global settings.
     Subsequent calls will override the existing context.
 
+    This will also resolve the project directory and environment variables.
+
     Args:
-        model: Pydantic model with settings (preferred approach)
-        project_dir: Project directory path (legacy approach)
-        global_dot_env: Global .env file path (legacy approach)
-        project_dot_env: Project .env file path (legacy approach)
-        **kwargs: Additional settings parameters (legacy approach)
+        project_dir: Project directory path
+        global_dot_env: Global .env file path
+        project_dot_env: Project .env file path
 
     Returns:
         The initialized FABulousSettings instance
@@ -225,16 +179,11 @@ def init_context(
     # Resolve .env files in priority order
     env_files: list[Path] = []
 
-    fab_root = (
-        Path(r) if (r := os.getenv("FAB_ROOT")) else Path(__file__).parent.resolve()
-    )
+    fab_root = Path(r) if (r := os.getenv("FAB_ROOT")) else Path(__file__).parent.resolve()
 
     # Check FABulous directory first
     if fab_root.joinpath(".env").exists():
         env_files.append(fab_root.joinpath(".env"))
-    # Check parent directory as fallback
-    elif fab_root.parent.joinpath(".env").exists():
-        env_files.append(fab_root.parent.joinpath(".env"))
 
     # 2. User-provided global .env file
     if global_dot_env:
@@ -242,26 +191,47 @@ def init_context(
             env_files.append(global_dot_env)
         else:
             logger.warning(f"Global .env file not found: {global_dot_env} this is ignored")
+    if global_dot_env and global_dot_env.exists():
+        env_files.append(global_dot_env)
+    else:
+        if global_dot_env is not None and not global_dot_env.exists():
+            logger.warning(
+                f"Global .env file not found: {global_dot_env} this is ignored"
+            )
 
     # 3. Default project .env files
-    if project_dir:
-        fab_proj_dir = os.getenv("FAB_PROJ_DIR", str(project_dir))
-        if fab_proj_dir:
-            fab_project_dir = Path(fab_proj_dir) / ".FABulous"
+    fab_proj_dir = os.getenv("FAB_PROJ_DIR")
+    if fab_proj_dir:
+        fab_project_dir = Path(fab_proj_dir) / ".FABulous" / ".env"
 
-            # project_dir/.env (lower priority)
-            if fab_project_dir.parent.joinpath(".env").exists():
-                env_files.append(fab_project_dir.parent.joinpath(".env"))
+        # .FABulous/.env (higher priority)
+        if fab_project_dir.exists():
+            env_files.append(fab_project_dir)
 
-            # .FABulous/.env (higher priority)
-            if fab_project_dir.joinpath(".env").exists():
-                env_files.append(fab_project_dir.joinpath(".env"))
+    if project_dir and (project_dir / ".FABulous" / ".env").exists():
+        env_files.append(project_dir / ".FABulous" / ".env")
+    else:
+        if project_dir is not None and (project_dir / ".FABulous" / ".env").exists():
+            logger.warning(
+                f"Project directory not found: {project_dir} this is ignored"
+            )
 
     # 4. User-provided project .env file (highest .env priority)
     if project_dot_env and project_dot_env.exists():
         env_files.append(project_dot_env)
+    else:
+        if project_dot_env is None:
+            logger.warning(
+                f"Project .env file not found: {project_dot_env} this is ignored"
+            )
 
-    _context_instance = FABulousSettings(_env_file=tuple(env_files), root=fab_root)
+    if project_dir:
+        _context_instance = FABulousSettings(
+            _env_file=tuple(env_files), root=fab_root, proj_dir=project_dir
+        )
+    else:
+        _context_instance = FABulousSettings(_env_file=tuple(env_files), root=fab_root)
+
     logger.debug("FABulous context initialized")
     return _context_instance
 

--- a/FABulous/FABulous_settings.py
+++ b/FABulous/FABulous_settings.py
@@ -1,4 +1,4 @@
-from importlib.metadata import version
+from importlib.metadata import version as meta_version
 from pathlib import Path
 from shutil import which
 
@@ -41,9 +41,14 @@ class FABulousSettings(BaseSettings):
     model_pack: Path | None = None
     switch_matrix_debug_signal: bool = False
     proj_version_created: Version = Version("0.0.1")
-    proj_version: Version = Version(version("FABulous-FPGA"))
+    proj_version: Version = Version(meta_version("FABulous-FPGA"))
+    version: Version = Field(
+        default=Version(meta_version("FABulous-FPGA")),
+        deprecated=True,
+        description="Deprecated, use proj_version instead",
+    )
 
-    @field_validator("proj_version", "proj_version_created", mode="before")
+    @field_validator("proj_version", "proj_version_created", "version", mode="before")
     @classmethod
     def parse_version_str(cls, value: str | Version) -> Version:
         """Parse version from string or Version object."""

--- a/FABulous/FABulous_settings.py
+++ b/FABulous/FABulous_settings.py
@@ -1,143 +1,13 @@
 import os
-import sys
 from importlib.metadata import version
 from pathlib import Path
 from shutil import which
 
-from dotenv import load_dotenv
 from loguru import logger
 from packaging.version import Version
 from pydantic import field_validator
 from pydantic_core.core_schema import FieldValidationInfo  # type: ignore
 from pydantic_settings import BaseSettings, SettingsConfigDict
-
-
-def setup_fab_root() -> None:
-    """Set up FAB_ROOT environment variable if not already set."""
-    fab_root = os.getenv("FAB_ROOT")
-    if fab_root is None:
-        # Prefer the package directory (the one containing fabric_files) as FAB_ROOT
-        pkg_dir = Path(__file__).parent.resolve()
-        if pkg_dir.joinpath("fabric_files").exists():
-            fab_root = str(pkg_dir)
-        else:  # Fallback to previous behaviour (repository root)
-            fab_root = str(Path(__file__).parent.parent.resolve())
-        os.environ["FAB_ROOT"] = fab_root
-        logger.info("FAB_ROOT environment variable not set!")
-        logger.info(f"Using {fab_root} as FAB_ROOT")
-    else:
-        # If there is the FABulous folder in the FAB_ROOT, then set the FAB_ROOT to the FABulous folder
-        if Path(fab_root).exists():
-            if Path(fab_root).joinpath("FABulous").exists():
-                fab_root = str(Path(fab_root).joinpath("FABulous"))
-            os.environ["FAB_ROOT"] = fab_root
-        else:
-            logger.error(
-                f"FAB_ROOT environment variable set to {fab_root} but the directory does not exist"
-            )
-            sys.exit(1)
-        logger.info(f"FAB_ROOT set to {fab_root}")
-
-
-def setup_additional_env_vars() -> None:
-    """Setup additional FABulous-specific environment variables."""
-    # Export oss-cad-suite bin path to PATH
-    if ocs_path := os.getenv("FAB_OSS_CAD_SUITE"):
-        current_path = os.environ.get("PATH", "")
-        new_path = ocs_path + "/bin"
-        if new_path not in current_path:
-            os.environ["PATH"] = current_path + os.pathsep + new_path
-
-
-def load_env_files_with_priority(
-    global_dot_env: Path | None = None,
-    project_dot_env: Path | None = None,
-    project_dir: Path | None = None,
-) -> None:
-    """Load .env files with proper priority order.
-
-    Priority (lowest to highest - later files override earlier ones):
-    1. Default global .env
-    2. User-given global .env
-    3. Default project .env
-    4. User-given project .env
-
-    Environment variables and CLI arguments still have highest priority.
-    """
-    # Setup FAB_ROOT first
-    setup_fab_root()
-
-    fab_root = os.getenv("FAB_ROOT")
-    if fab_root:
-        fab_dir = Path(fab_root)
-
-        # Load default global .env (lowest priority)
-        if fab_dir.joinpath(".env").exists() and fab_dir.joinpath(".env").is_file():
-            load_dotenv(fab_dir.joinpath(".env"))
-            logger.info(f"Loaded global .env file from {fab_root}/.env")
-        elif (
-            fab_dir.parent.joinpath(".env").exists()
-            and fab_dir.parent.joinpath(".env").is_file()
-        ):
-            load_dotenv(fab_dir.parent.joinpath(".env"))
-            logger.info(
-                f"Loaded global .env file from {fab_dir.parent.joinpath('.env')}"
-            )
-
-    # Load user-given global .env (higher priority)
-    if global_dot_env:
-        if global_dot_env.is_file():
-            load_dotenv(global_dot_env)
-            logger.info(f"Load global .env file from {global_dot_env}")
-        elif (
-            global_dot_env.joinpath(".env").exists()
-            and global_dot_env.joinpath(".env").is_file()
-        ):
-            load_dotenv(global_dot_env.joinpath(".env"))
-            logger.info(f"Load global .env file from {global_dot_env.joinpath('.env')}")
-        else:
-            logger.warning(f"No global .env file found at {global_dot_env}")
-
-    # Set project directory env var if needed - but only set it after all global .env files are loaded
-    # This way, if any .env file sets FAB_PROJ_DIR, it will take precedence
-    fab_proj_dir_before = os.getenv("FAB_PROJ_DIR")
-    if project_dir and not fab_proj_dir_before:
-        os.environ["FAB_PROJ_DIR"] = str(project_dir.absolute())
-
-    # Load default project .env files
-    fab_proj_dir = os.getenv("FAB_PROJ_DIR")
-    if fab_proj_dir:
-        fab_project_dir = Path(fab_proj_dir) / ".FABulous"
-
-        # Try project_dir/.env
-        if (
-            fab_project_dir.parent.joinpath(".env").exists()
-            and fab_project_dir.parent.joinpath(".env").is_file()
-        ):
-            load_dotenv(fab_project_dir.parent.joinpath(".env"), override=True)
-            logger.info(
-                f"Loaded project .env file from {fab_project_dir.parent.joinpath('.env')}"
-            )
-
-        # Try .FABulous/.env (higher priority than project_dir/.env)
-        if (
-            fab_project_dir.joinpath(".env").exists()
-            and fab_project_dir.joinpath(".env").is_file()
-        ):
-            load_dotenv(fab_project_dir.joinpath(".env"), override=True)
-            logger.info(f"Loaded project .env file from {fab_project_dir}/.env')")
-
-    # Load user-given project .env (highest .env priority)
-    if project_dot_env:
-        if project_dot_env.exists() and project_dot_env.is_file():
-            load_dotenv(project_dot_env, override=True)
-            # Keep legacy log string for backward compatibility with existing tests
-            logger.info("Loaded global .env file from pde (project .env override)")
-        else:
-            logger.warning(f"No project .env file found at {project_dot_env}")
-
-    # Setup additional environment variables
-    setup_additional_env_vars()
 
 
 class FABulousSettings(BaseSettings):
@@ -165,7 +35,27 @@ class FABulousSettings(BaseSettings):
 
     proj_lang: HDLType = HDLType.VERILOG
     switch_matrix_debug_signal: bool = False
-    model_pack: Path | None = None
+
+    # CLI-specific options (previously in FABulousCliSettings)
+    verbose: int = 0
+    debug: bool = False
+    log_file: Path | None = None
+    force: bool = False
+
+    # Script execution options
+    fabulous_script: Path | None = None
+    tcl_script: Path | None = None
+    commands: str | None = None
+
+    # Project creation options
+    create_project: bool = False
+    install_oss_cad_suite: bool = False
+
+    # Version and help options
+    update_project_version: bool = False
+
+    # Output directory for metadata
+    metadata_dir: str = ".FABulous"
 
     @field_validator("proj_version", "proj_version_created", mode="before")
     @classmethod
@@ -279,144 +169,7 @@ class FABulousSettings(BaseSettings):
         logger.warning(f"{tool} not found in PATH during settings initialisation. Some features may be unavailable.")
         return None
 
-
-class FABulousCliSettings(FABulousSettings):
-    """CLI-specific settings that extend the base FABulousSettings."""
-
-    # CLI-specific options
-    verbose: int = 0
-    debug: bool = False
-    log_file: Path | None = None
-    force: bool = False
-
-    # Script execution options
-    fabulous_script: Path | None = None
-    tcl_script: Path | None = None
-    commands: str | None = None
-
-    # Project creation options
-    create_project: bool = False
-    install_oss_cad_suite: bool = False
-
-    # Version and help options
-    update_project_version: bool = False
-
-    # Environment file overrides - paths to .env files to load
-    global_dot_env: Path | None = None
-    project_dot_env: Path | None = None
-
-    # Output directory for metadata
-    metadata_dir: str = ".FABulous"
-
-    @classmethod
-    def create_with_env_files(
-        cls,
-        project_dir: Path | None = None,
-        global_dot_env: Path | None = None,
-        project_dot_env: Path | None = None,
-        **kwargs: dict,
-    ) -> "FABulousCliSettings":
-        """Create FABulousCliSettings with .env file loading.
-
-        This loads .env files with proper priority before creating the Pydantic settings
-        instance. Environment variables and CLI arguments will still override .env file
-        values.
-        """
-        # Load .env files with proper priority
-        load_env_files_with_priority(global_dot_env, project_dot_env, project_dir)
-
-        # Handle writer field override if provided in CLI arguments
-        if "writer" in kwargs and kwargs["writer"]:
-            # Set up environment variable for writer override
-            old_writer = os.environ.get("FAB_PROJ_LANG")
-            os.environ["FAB_PROJ_LANG"] = kwargs["writer"]
-            try:
-                instance = cls(**kwargs)
-            finally:
-                # Restore original environment
-                if old_writer is not None:
-                    os.environ["FAB_PROJ_LANG"] = old_writer
-                elif "FAB_PROJ_LANG" in os.environ:
-                    del os.environ["FAB_PROJ_LANG"]
-        else:
-            logger.error(f"FAB_ROOT environment variable set to {fabulousRoot} but the directory does not exist")
-            sys.exit()
-
-        logger.info(f"FAB_ROOT set to {fabulousRoot}")
-
-    # Load the .env file and make env variables available globally
-    if p := os.getenv("FAB_ROOT"):
-        fabDir = Path(p)
-    else:
-        raise EnvironmentNotSet("FAB_ROOT environment variable not set")
-    if args.globalDotEnv:
-        gde = Path(args.globalDotEnv)
-        if gde.is_file():
-            load_dotenv(gde)
-            logger.info(f"Load global .env file from {gde}")
-        elif gde.joinpath(".env").exists() and gde.joinpath(".env").is_file():
-            load_dotenv(gde.joinpath(".env"))
-            logger.info(f"Load global .env file from {gde.joinpath('.env')}")
-        else:
-            logger.warning(f"No global .env file found at {gde}")
-    elif fabDir.joinpath(".env").exists() and fabDir.joinpath(".env").is_file():
-        load_dotenv(fabDir.joinpath(".env"))
-        logger.info(f"Loaded global .env file from {fabulousRoot}/.env")
-    elif fabDir.parent.joinpath(".env").exists() and fabDir.parent.joinpath(".env").is_file():
-        load_dotenv(fabDir.parent.joinpath(".env"))
-        logger.info(f"Loaded global .env file from {fabDir.parent.joinpath('.env')}")
-    else:
-        logger.info("No global .env file found")
-
-    # Set project directory env var, this can not be saved in the .env file,
-    # since it can change if the project folder is moved
-    if not os.getenv("FAB_PROJ_DIR"):
-        os.environ["FAB_PROJ_DIR"] = str(Path(args.project_dir).absolute())
-
-    # Export oss-cad-suite bin path to PATH
-    if ocs_path := os.getenv("FAB_OSS_CAD_SUITE"):
-        os.environ["PATH"] += os.pathsep + ocs_path + "/bin"
-
-
-def setup_project_env_vars(args: argparse.Namespace) -> None:
-    """Set up environment variables for the project.
-
-    Parameters
-    ----------
-    args : argparse.Namespace
-        Command line arguments
-    """
-    # Load the .env file and make env variables available globally
-    if p := os.getenv("FAB_PROJ_DIR"):
-        fabDir = Path(p) / ".FABulous"
-    else:
-        raise EnvironmentNotSet("FAB_PROJ_DIR environment variable not set")
-
-    if args.projectDotEnv:
-        pde = Path(args.projectDotEnv)
-        if pde.exists() and pde.is_file():
-            load_dotenv(pde, override=True)
-            # Keep legacy log string for backward compatibility with existing tests
-            logger.info("Loaded global .env file from pde (project .env override)")
-    elif fabDir.joinpath(".env").exists() and fabDir.joinpath(".env").is_file():
-        load_dotenv(fabDir.joinpath(".env"), override=True)
-        logger.info(f"Loaded project .env file from {fabDir}/.env')")
-    elif fabDir.parent.joinpath(".env").exists() and fabDir.parent.joinpath(".env").is_file():
-        load_dotenv(fabDir.parent.joinpath(".env"), override=True)
-        logger.info(f"Loaded project .env file from {fabDir.parent.joinpath('.env')}")
-    else:
-        logger.warning("No project .env file found")
-
-    # Overwrite project language param, if writer is specified as command line argument
-    if args.writer and args.writer != os.getenv("FAB_PROJ_LANG"):
-        logger.warning(
-            f"Overwriting project language for current run, from {os.getenv('FAB_PROJ_LANG')} to {args.writer}, which was specified as command line argument"
-        )
-        os.environ["FAB_PROJ_LANG"] = args.writer
-            instance = cls(**kwargs)
-
-        return instance
-
+    # CLI-specific validators
     @field_validator("fabulous_script", "tcl_script", mode="before")
     @classmethod
     def validate_script_paths(cls, value: str | Path | None) -> Path | None:
@@ -429,18 +182,6 @@ def setup_project_env_vars(args: argparse.Namespace) -> None:
             return None
         if isinstance(value, str):
             value = Path(value)
-        return value.absolute()
-
-    @field_validator("global_dot_env", "project_dot_env", mode="before")
-    @classmethod
-    def validate_env_file_paths(cls, value: str | Path | None) -> Path | None:
-        """Validate that .env file paths exist if provided."""
-        if value is None:
-            return None
-        if isinstance(value, str):
-            value = Path(value)
-        if not value.exists():
-            raise ValueError(f"File does not exist: {value}")
         return value.absolute()
 
     @field_validator("log_file", mode="before")
@@ -456,16 +197,105 @@ def setup_project_env_vars(args: argparse.Namespace) -> None:
         return value.absolute()
 
 
+# FABulousCliSettings class removed - functionality merged into FABulousSettings
+
+
+# Module-level singleton pattern for settings management
+_context_instance: FABulousSettings | None = None
+
+
+def init_context(
+    fab_root: Path,
+    project_dir: Path | None = None,
+    global_dot_env: Path | None = None,
+    project_dot_env: Path | None = None,
+) -> FABulousSettings:
+    """Initialize the global FABulous context with settings.
+
+    This should be called once at application startup to configure the global settings.
+    Subsequent calls will override the existing context.
+
+    Args:
+        model: Pydantic model with settings (preferred approach)
+        project_dir: Project directory path (legacy approach)
+        global_dot_env: Global .env file path (legacy approach)
+        project_dot_env: Project .env file path (legacy approach)
+        **kwargs: Additional settings parameters (legacy approach)
+
+    Returns:
+        The initialized FABulousSettings instance
+    """
+    # Resolve .env files in priority order
+    env_files: list[Path] = []
+
+    fab_dir = Path(fab_root)
+    # Check FABulous directory first
+    if fab_dir.joinpath(".env").exists():
+        env_files.append(fab_dir.joinpath(".env"))
+    # Check parent directory as fallback
+    elif fab_dir.parent.joinpath(".env").exists():
+        env_files.append(fab_dir.parent.joinpath(".env"))
+
+    # 2. User-provided global .env file
+    if global_dot_env:
+        if global_dot_env.exists():
+            env_files.append(global_dot_env)
+        else:
+            logger.warning(f"Global .env file not found: {global_dot_env} this is ignored")
+
+    # 3. Default project .env files
+    if project_dir:
+        fab_proj_dir = os.getenv("FAB_PROJ_DIR", str(project_dir))
+        if fab_proj_dir:
+            fab_project_dir = Path(fab_proj_dir) / ".FABulous"
+
+            # project_dir/.env (lower priority)
+            if fab_project_dir.parent.joinpath(".env").exists():
+                env_files.append(fab_project_dir.parent.joinpath(".env"))
+
+            # .FABulous/.env (higher priority)
+            if fab_project_dir.joinpath(".env").exists():
+                env_files.append(fab_project_dir.joinpath(".env"))
+
+    # 4. User-provided project .env file (highest .env priority)
+    if project_dot_env and project_dot_env.exists():
+        env_files.append(project_dot_env)
+
+    _context_instance = FABulousSettings(_env_file=tuple(env_files))
+    logger.debug("FABulous context initialized")
+    return _context_instance
+
+
+def get_context() -> FABulousSettings:
+    """Get the global FABulous context.
+
+    Returns:
+        The current FABulousSettings instance
+
+    Raises:
+        RuntimeError: If context has not been initialized with init_context()
+    """
+    global _context_instance
+
+    if _context_instance is None:
+        raise RuntimeError("FABulous context not initialized. Call init_context() first.")
+
+    return _context_instance
+
+
+def reset_context() -> None:
+    """Reset the global context (primarily for testing)."""
+    global _context_instance
+    _context_instance = None
+    logger.debug("FABulous context reset")
+
+
 # Legacy functions for backward compatibility (deprecated)
 def setup_global_env_vars(*_args: object) -> None:
-    """Legacy function - deprecated. Use FABulousCliSettings instead."""
-    logger.warning(
-        "setup_global_env_vars is deprecated. Use FABulousCliSettings.create_with_env_files instead."
-    )
+    """Legacy function - deprecated. Use init_context() instead."""
+    logger.warning("setup_global_env_vars is deprecated. Use init_context() instead.")
 
 
 def setup_project_env_vars(*_args: object) -> None:
-    """Legacy function - deprecated. Use FABulousCliSettings instead."""
-    logger.warning(
-        "setup_project_env_vars is deprecated. Use FABulousCliSettings.create_with_env_files instead."
-    )
+    """Legacy function - deprecated. Use init_context() instead."""
+    logger.warning("setup_project_env_vars is deprecated. Use init_context() instead.")

--- a/FABulous/FABulous_settings.py
+++ b/FABulous/FABulous_settings.py
@@ -11,6 +11,8 @@ from pydantic_settings import (
     SettingsConfigDict,
 )
 
+from FABulous.fabric_definition.define import HDLType
+
 # User configuration directory for FABulous
 FAB_USER_CONFIG_DIR = Path(typer.get_app_dir("FABulous", force_posix=True))
 
@@ -30,11 +32,13 @@ class FABulousSettings(BaseSettings):
     nextpnr_path: Path | None = None
     iverilog_path: Path | None = None
     vvp_path: Path | None = None
+    ghdl_path: Path | None = None
     fabulator_root: Path | None = None
     oss_cad_suite: Path | None = None
 
     proj_dir: Path = Field(default_factory=Path.cwd)
     proj_lang: str = "verilog"
+    model_pack: Path | None = None
     switch_matrix_debug_signal: bool = False
     proj_version_created: Version = Version("0.0.1")
     proj_version: Version = Version(version("FABulous-FPGA"))
@@ -107,7 +111,6 @@ class FABulousSettings(BaseSettings):
         mode="before",
     )
     @classmethod
-    def resolve_tool_paths(cls, value: Path | None, info: FieldValidationInfo) -> Path | None:  # type: ignore[override]
     def resolve_tool_paths(
         cls, value: Path | None, info: ValidationInfo
     ) -> Path | None:  # type: ignore[override]
@@ -127,7 +130,9 @@ class FABulousSettings(BaseSettings):
         if tool_path is not None:
             return Path(tool_path).resolve()
 
-        logger.warning(f"{tool} not found in PATH during settings initialisation. Some features may be unavailable.")
+        logger.warning(
+            f"{tool} not found in PATH during settings initialisation. Some features may be unavailable."
+        )
         return None
 
 
@@ -167,7 +172,9 @@ def init_context(
         if global_dot_env.exists():
             env_files.append(global_dot_env)
         else:
-            logger.warning(f"Global .env file not found: {global_dot_env} this is ignored")
+            logger.warning(
+                f"Global .env file not found: {global_dot_env} this is ignored"
+            )
     if global_dot_env and global_dot_env.exists():
         env_files.append(global_dot_env)
     elif global_dot_env is not None:
@@ -224,7 +231,9 @@ def get_context() -> FABulousSettings:
     global _context_instance
 
     if _context_instance is None:
-        raise RuntimeError("FABulous context not initialized. Call init_context() first.")
+        raise RuntimeError(
+            "FABulous context not initialized. Call init_context() first."
+        )
 
     return _context_instance
 

--- a/FABulous/FABulous_settings.py
+++ b/FABulous/FABulous_settings.py
@@ -1,4 +1,3 @@
-import argparse
 import os
 import sys
 from importlib.metadata import version
@@ -12,8 +11,133 @@ from pydantic import field_validator
 from pydantic_core.core_schema import FieldValidationInfo  # type: ignore
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from FABulous.custom_exception import EnvironmentNotSet
-from FABulous.fabric_definition.define import HDLType
+
+def setup_fab_root() -> None:
+    """Set up FAB_ROOT environment variable if not already set."""
+    fab_root = os.getenv("FAB_ROOT")
+    if fab_root is None:
+        # Prefer the package directory (the one containing fabric_files) as FAB_ROOT
+        pkg_dir = Path(__file__).parent.resolve()
+        if pkg_dir.joinpath("fabric_files").exists():
+            fab_root = str(pkg_dir)
+        else:  # Fallback to previous behaviour (repository root)
+            fab_root = str(Path(__file__).parent.parent.resolve())
+        os.environ["FAB_ROOT"] = fab_root
+        logger.info("FAB_ROOT environment variable not set!")
+        logger.info(f"Using {fab_root} as FAB_ROOT")
+    else:
+        # If there is the FABulous folder in the FAB_ROOT, then set the FAB_ROOT to the FABulous folder
+        if Path(fab_root).exists():
+            if Path(fab_root).joinpath("FABulous").exists():
+                fab_root = str(Path(fab_root).joinpath("FABulous"))
+            os.environ["FAB_ROOT"] = fab_root
+        else:
+            logger.error(
+                f"FAB_ROOT environment variable set to {fab_root} but the directory does not exist"
+            )
+            sys.exit(1)
+        logger.info(f"FAB_ROOT set to {fab_root}")
+
+
+def setup_additional_env_vars() -> None:
+    """Setup additional FABulous-specific environment variables."""
+    # Export oss-cad-suite bin path to PATH
+    if ocs_path := os.getenv("FAB_OSS_CAD_SUITE"):
+        current_path = os.environ.get("PATH", "")
+        new_path = ocs_path + "/bin"
+        if new_path not in current_path:
+            os.environ["PATH"] = current_path + os.pathsep + new_path
+
+
+def load_env_files_with_priority(
+    global_dot_env: Path | None = None,
+    project_dot_env: Path | None = None,
+    project_dir: Path | None = None,
+) -> None:
+    """Load .env files with proper priority order.
+
+    Priority (lowest to highest - later files override earlier ones):
+    1. Default global .env
+    2. User-given global .env
+    3. Default project .env
+    4. User-given project .env
+
+    Environment variables and CLI arguments still have highest priority.
+    """
+    # Setup FAB_ROOT first
+    setup_fab_root()
+
+    fab_root = os.getenv("FAB_ROOT")
+    if fab_root:
+        fab_dir = Path(fab_root)
+
+        # Load default global .env (lowest priority)
+        if fab_dir.joinpath(".env").exists() and fab_dir.joinpath(".env").is_file():
+            load_dotenv(fab_dir.joinpath(".env"))
+            logger.info(f"Loaded global .env file from {fab_root}/.env")
+        elif (
+            fab_dir.parent.joinpath(".env").exists()
+            and fab_dir.parent.joinpath(".env").is_file()
+        ):
+            load_dotenv(fab_dir.parent.joinpath(".env"))
+            logger.info(
+                f"Loaded global .env file from {fab_dir.parent.joinpath('.env')}"
+            )
+
+    # Load user-given global .env (higher priority)
+    if global_dot_env:
+        if global_dot_env.is_file():
+            load_dotenv(global_dot_env)
+            logger.info(f"Load global .env file from {global_dot_env}")
+        elif (
+            global_dot_env.joinpath(".env").exists()
+            and global_dot_env.joinpath(".env").is_file()
+        ):
+            load_dotenv(global_dot_env.joinpath(".env"))
+            logger.info(f"Load global .env file from {global_dot_env.joinpath('.env')}")
+        else:
+            logger.warning(f"No global .env file found at {global_dot_env}")
+
+    # Set project directory env var if needed - but only set it after all global .env files are loaded
+    # This way, if any .env file sets FAB_PROJ_DIR, it will take precedence
+    fab_proj_dir_before = os.getenv("FAB_PROJ_DIR")
+    if project_dir and not fab_proj_dir_before:
+        os.environ["FAB_PROJ_DIR"] = str(project_dir.absolute())
+
+    # Load default project .env files
+    fab_proj_dir = os.getenv("FAB_PROJ_DIR")
+    if fab_proj_dir:
+        fab_project_dir = Path(fab_proj_dir) / ".FABulous"
+
+        # Try project_dir/.env
+        if (
+            fab_project_dir.parent.joinpath(".env").exists()
+            and fab_project_dir.parent.joinpath(".env").is_file()
+        ):
+            load_dotenv(fab_project_dir.parent.joinpath(".env"), override=True)
+            logger.info(
+                f"Loaded project .env file from {fab_project_dir.parent.joinpath('.env')}"
+            )
+
+        # Try .FABulous/.env (higher priority than project_dir/.env)
+        if (
+            fab_project_dir.joinpath(".env").exists()
+            and fab_project_dir.joinpath(".env").is_file()
+        ):
+            load_dotenv(fab_project_dir.joinpath(".env"), override=True)
+            logger.info(f"Loaded project .env file from {fab_project_dir}/.env')")
+
+    # Load user-given project .env (highest .env priority)
+    if project_dot_env:
+        if project_dot_env.exists() and project_dot_env.is_file():
+            load_dotenv(project_dot_env, override=True)
+            # Keep legacy log string for backward compatibility with existing tests
+            logger.info("Loaded global .env file from pde (project .env override)")
+        else:
+            logger.warning(f"No project .env file found at {project_dot_env}")
+
+    # Setup additional environment variables
+    setup_additional_env_vars()
 
 
 class FABulousSettings(BaseSettings):
@@ -23,7 +147,7 @@ class FABulousSettings(BaseSettings):
     (including PATH updates for oss-cad-suite) can occur beforehand.
     """
 
-    model_config = SettingsConfigDict(env_prefix="FAB_", case_sensitive=False)
+    model_config = SettingsConfigDict(env_prefix="FAB_", case_sensitive=False, extra="allow")
 
     root: Path = Path()
     yosys_path: Path | None = None
@@ -156,32 +280,64 @@ class FABulousSettings(BaseSettings):
         return None
 
 
-def setup_global_env_vars(args: argparse.Namespace) -> None:
-    """Set up global  environment variables.
+class FABulousCliSettings(FABulousSettings):
+    """CLI-specific settings that extend the base FABulousSettings."""
 
-    Parameters
-    ----------
-    args : argparse.Namespace
-        Command line arguments
-    """
-    # Set FAB_ROOT environment variable
-    fabulousRoot = os.getenv("FAB_ROOT")
-    if fabulousRoot is None:
-        # Prefer the package directory (the one containing fabric_files) as FAB_ROOT
-        pkg_dir = Path(__file__).parent.resolve()
-        if pkg_dir.joinpath("fabric_files").exists():
-            fabulousRoot = str(pkg_dir)
-        else:  # Fallback to previous behaviour (repository root)
-            fabulousRoot = str(Path(__file__).parent.parent.resolve())
-        os.environ["FAB_ROOT"] = fabulousRoot
-        logger.info("FAB_ROOT environment variable not set!")
-        logger.info(f"Using {fabulousRoot} as FAB_ROOT")
-    else:
-        # If there is the FABulous folder in the FAB_ROOT, then set the FAB_ROOT to the FABulous folder
-        if Path(fabulousRoot).exists():
-            if Path(fabulousRoot).joinpath("FABulous").exists():
-                fabulousRoot = str(Path(fabulousRoot).joinpath("FABulous"))
-            os.environ["FAB_ROOT"] = fabulousRoot
+    # CLI-specific options
+    verbose: int = 0
+    debug: bool = False
+    log_file: Path | None = None
+    force: bool = False
+
+    # Script execution options
+    fabulous_script: Path | None = None
+    tcl_script: Path | None = None
+    commands: str | None = None
+
+    # Project creation options
+    create_project: bool = False
+    install_oss_cad_suite: bool = False
+
+    # Version and help options
+    update_project_version: bool = False
+
+    # Environment file overrides - paths to .env files to load
+    global_dot_env: Path | None = None
+    project_dot_env: Path | None = None
+
+    # Output directory for metadata
+    metadata_dir: str = ".FABulous"
+
+    @classmethod
+    def create_with_env_files(
+        cls,
+        project_dir: Path | None = None,
+        global_dot_env: Path | None = None,
+        project_dot_env: Path | None = None,
+        **kwargs: dict,
+    ) -> "FABulousCliSettings":
+        """Create FABulousCliSettings with .env file loading.
+
+        This loads .env files with proper priority before creating the Pydantic settings
+        instance. Environment variables and CLI arguments will still override .env file
+        values.
+        """
+        # Load .env files with proper priority
+        load_env_files_with_priority(global_dot_env, project_dot_env, project_dir)
+
+        # Handle writer field override if provided in CLI arguments
+        if "writer" in kwargs and kwargs["writer"]:
+            # Set up environment variable for writer override
+            old_writer = os.environ.get("FAB_PROJ_LANG")
+            os.environ["FAB_PROJ_LANG"] = kwargs["writer"]
+            try:
+                instance = cls(**kwargs)
+            finally:
+                # Restore original environment
+                if old_writer is not None:
+                    os.environ["FAB_PROJ_LANG"] = old_writer
+                elif "FAB_PROJ_LANG" in os.environ:
+                    del os.environ["FAB_PROJ_LANG"]
         else:
             logger.error(f"FAB_ROOT environment variable set to {fabulousRoot} but the directory does not exist")
             sys.exit()
@@ -257,3 +413,59 @@ def setup_project_env_vars(args: argparse.Namespace) -> None:
             f"Overwriting project language for current run, from {os.getenv('FAB_PROJ_LANG')} to {args.writer}, which was specified as command line argument"
         )
         os.environ["FAB_PROJ_LANG"] = args.writer
+            instance = cls(**kwargs)
+
+        return instance
+
+    @field_validator("fabulous_script", "tcl_script", mode="before")
+    @classmethod
+    def validate_script_paths(cls, value: str | Path | None) -> Path | None:
+        """Convert script paths to Path objects but don't validate existence yet.
+
+        File existence will be validated at execution time to maintain backward
+        compatibility with legacy argument handling.
+        """
+        if value is None:
+            return None
+        if isinstance(value, str):
+            value = Path(value)
+        return value.absolute()
+
+    @field_validator("global_dot_env", "project_dot_env", mode="before")
+    @classmethod
+    def validate_env_file_paths(cls, value: str | Path | None) -> Path | None:
+        """Validate that .env file paths exist if provided."""
+        if value is None:
+            return None
+        if isinstance(value, str):
+            value = Path(value)
+        if not value.exists():
+            raise ValueError(f"File does not exist: {value}")
+        return value.absolute()
+
+    @field_validator("log_file", mode="before")
+    @classmethod
+    def validate_log_file(cls, value: str | Path | None) -> Path | None:
+        """Validate log file path, creating parent directories if needed."""
+        if value is None:
+            return None
+        if isinstance(value, str):
+            value = Path(value)
+        # Ensure parent directory exists
+        value.parent.mkdir(parents=True, exist_ok=True)
+        return value.absolute()
+
+
+# Legacy functions for backward compatibility (deprecated)
+def setup_global_env_vars(*_args: object) -> None:
+    """Legacy function - deprecated. Use FABulousCliSettings instead."""
+    logger.warning(
+        "setup_global_env_vars is deprecated. Use FABulousCliSettings.create_with_env_files instead."
+    )
+
+
+def setup_project_env_vars(*_args: object) -> None:
+    """Legacy function - deprecated. Use FABulousCliSettings instead."""
+    logger.warning(
+        "setup_project_env_vars is deprecated. Use FABulousCliSettings.create_with_env_files instead."
+    )

--- a/FABulous/FABulous_settings.py
+++ b/FABulous/FABulous_settings.py
@@ -153,8 +153,9 @@ class FABulousSettings(BaseSettings):
             "VHDL": "VHDL",
             "VHD": "VHDL",
         }
-        key = alias_map.get(key, key)
-        return HDLType[key]
+        if key not in alias_map:
+            raise ValueError(f"Invalid project language: {value}")
+        return HDLType[alias_map[key]]
 
     # Resolve external tool paths only after object creation (post env setup)
     @field_validator(

--- a/FABulous/FABulous_settings.py
+++ b/FABulous/FABulous_settings.py
@@ -55,7 +55,7 @@ class FABulousSettings(BaseSettings):
             return None
         if not value.is_dir():
             raise ValueError(f"{value} is not a valid directory")
-        return value
+        return value.resolve()
 
     @field_validator("user_config_dir", mode="after")
     @classmethod
@@ -76,7 +76,7 @@ class FABulousSettings(BaseSettings):
 
         if not (Path(value) / ".FABulous").exists():
             raise ValueError(f"{value} is not a FABulous project")
-        return value
+        return value.resolve()
 
     @field_validator("proj_lang", mode="after")
     @classmethod

--- a/FABulous/FABulous_settings.py
+++ b/FABulous/FABulous_settings.py
@@ -202,7 +202,6 @@ _context_instance: FABulousSettings | None = None
 
 
 def init_context(
-    fab_root: Path,
     project_dir: Path | None = None,
     global_dot_env: Path | None = None,
     project_dot_env: Path | None = None,
@@ -226,13 +225,16 @@ def init_context(
     # Resolve .env files in priority order
     env_files: list[Path] = []
 
-    fab_dir = Path(fab_root)
+    fab_root = (
+        Path(r) if (r := os.getenv("FAB_ROOT")) else Path(__file__).parent.resolve()
+    )
+
     # Check FABulous directory first
-    if fab_dir.joinpath(".env").exists():
-        env_files.append(fab_dir.joinpath(".env"))
+    if fab_root.joinpath(".env").exists():
+        env_files.append(fab_root.joinpath(".env"))
     # Check parent directory as fallback
-    elif fab_dir.parent.joinpath(".env").exists():
-        env_files.append(fab_dir.parent.joinpath(".env"))
+    elif fab_root.parent.joinpath(".env").exists():
+        env_files.append(fab_root.parent.joinpath(".env"))
 
     # 2. User-provided global .env file
     if global_dot_env:
@@ -259,7 +261,7 @@ def init_context(
     if project_dot_env and project_dot_env.exists():
         env_files.append(project_dot_env)
 
-    _context_instance = FABulousSettings(_env_file=tuple(env_files))
+    _context_instance = FABulousSettings(_env_file=tuple(env_files), root=fab_root)
     logger.debug("FABulous context initialized")
     return _context_instance
 

--- a/FABulous/FABulous_settings.py
+++ b/FABulous/FABulous_settings.py
@@ -197,9 +197,6 @@ class FABulousSettings(BaseSettings):
         return value.absolute()
 
 
-# FABulousCliSettings class removed - functionality merged into FABulousSettings
-
-
 # Module-level singleton pattern for settings management
 _context_instance: FABulousSettings | None = None
 
@@ -225,6 +222,7 @@ def init_context(
     Returns:
         The initialized FABulousSettings instance
     """
+    global _context_instance
     # Resolve .env files in priority order
     env_files: list[Path] = []
 
@@ -288,14 +286,3 @@ def reset_context() -> None:
     global _context_instance
     _context_instance = None
     logger.debug("FABulous context reset")
-
-
-# Legacy functions for backward compatibility (deprecated)
-def setup_global_env_vars(*_args: object) -> None:
-    """Legacy function - deprecated. Use init_context() instead."""
-    logger.warning("setup_global_env_vars is deprecated. Use init_context() instead.")
-
-
-def setup_project_env_vars(*_args: object) -> None:
-    """Legacy function - deprecated. Use init_context() instead."""
-    logger.warning("setup_project_env_vars is deprecated. Use init_context() instead.")

--- a/FABulous/fabric_cad/gen_bitstream_spec.py
+++ b/FABulous/fabric_cad/gen_bitstream_spec.py
@@ -6,7 +6,7 @@ from loguru import logger
 from FABulous.fabric_definition.Fabric import Fabric
 from FABulous.fabric_generator.parser.parse_configmem import parseConfigMem
 from FABulous.fabric_generator.parser.parse_switchmatrix import parseMatrix
-from FABulous.FABulous_settings import FABulousSettings
+from FABulous.FABulous_settings import get_context
 
 if TYPE_CHECKING:
     from FABulous.fabric_definition.ConfigMem import ConfigMem
@@ -58,7 +58,7 @@ def generateBitstreamSpec(fabric: Fabric) -> dict[str, dict]:
                     configMemPath = tile.matrixDir / f"{tile.name}_ConfigMem.csv"
                 else:
                     configMemPath = (
-                        FABulousSettings().proj_dir
+                        get_context().proj_dir
                         / "Tile"
                         / tile.name
                         / f"{tile.name}_ConfigMem.csv"

--- a/FABulous/fabric_definition/Yosys_obj.py
+++ b/FABulous/fabric_definition/Yosys_obj.py
@@ -263,7 +263,6 @@ class YosysJson:
         temp = temp / "my_package.vhd"
         temp.touch()
         temp.write_text("package my_package is\nend package;\n")
-
         if self.srcPath.suffix in {".vhd", ".vhdl"}:
             runCmd = [
                 f"{ghdl!s}",

--- a/FABulous/fabric_definition/Yosys_obj.py
+++ b/FABulous/fabric_definition/Yosys_obj.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Literal
 
 from FABulous.custom_exception import InvalidFileType
-from FABulous.FABulous_settings import FABulousSettings
+from FABulous.FABulous_settings import get_context
 
 """
 Type alias for Yosys bit vectors containing integers or logic values.
@@ -254,8 +254,8 @@ class YosysJson:
             )
 
         self.srcPath = path
-        yosys = FABulousSettings().yosys_path
-        ghdl = FABulousSettings().ghdl_path
+        yosys = get_context().yosys_path
+        ghdl = get_context().ghdl_path
         json_file = self.srcPath.with_suffix(".json")
 
         # FIXME: a fake file to ensure things working with 1.3
@@ -271,7 +271,7 @@ class YosysJson:
                 "--std=08",
                 "--out=verilog",
                 str(temp),
-                f"{FABulousSettings().model_pack!s}",
+                f"{get_context().model_pack!s}",
                 f"{self.srcPath}",
                 "-e",
                 f"{self.srcPath.stem}",

--- a/FABulous/fabric_generator/gen_fabric/fabric_automation.py
+++ b/FABulous/fabric_generator/gen_fabric/fabric_automation.py
@@ -18,7 +18,7 @@ from FABulous.fabric_generator.code_generator.code_generator_VHDL import (
 )
 from FABulous.fabric_generator.parser.parse_hdl import parseBelFile
 from FABulous.fabric_generator.parser.parse_switchmatrix import parseList
-from FABulous.FABulous_settings import FABulousSettings
+from FABulous.FABulous_settings import get_context
 
 if TYPE_CHECKING:
     from FABulous.fabric_generator.code_generator.code_generator import CodeGenerator
@@ -45,7 +45,7 @@ def generateCustomTileConfig(tile_path: Path) -> Path:
         Path to the generated tile .csv file.
     """
     tile_name: str = ""
-    project_tile_dir: Path = FABulousSettings().proj_dir / "Tile"
+    project_tile_dir: Path = get_context().proj_dir / "Tile"
 
     tile_files = {}
     tile_csv: Path
@@ -180,8 +180,8 @@ def generateSwitchmatrixList(
          ValueError
              Number of carry ins and carry outs do not match.
     """
-    projdir = FABulousSettings().proj_dir
-    fab_root = FABulousSettings().root
+    projdir = get_context().proj_dir
+    fab_root = get_context().root
     CLBDummyFile = (
         fab_root / "fabric_files" / "dummy_files" / "DUMMY_switch_matrix.list"
     )
@@ -833,7 +833,7 @@ def genIOBel(
 
     bel: Bel = parseBelFile(writer.outFileName, "")
 
-    prims_file = FABulousSettings().proj_dir / "user_design" / "custom_prims.v"
+    prims_file = get_context().proj_dir / "user_design" / "custom_prims.v"
     if not prims_file.exists():
         logger.info(f"Creating {prims_file}")
         prims_file.touch()

--- a/FABulous/fabric_generator/parser/parse_csv.py
+++ b/FABulous/fabric_generator/parser/parse_csv.py
@@ -28,7 +28,7 @@ from FABulous.fabric_generator.parser.parse_switchmatrix import (
     parseMatrix,
     parsePortLine,
 )
-from FABulous.FABulous_settings import FABulousSettings
+from FABulous.FABulous_settings import get_context
 
 if TYPE_CHECKING:
     from FABulous.fabric_definition.Bel import Bel
@@ -77,7 +77,7 @@ def parseTilesCSV(fileName: Path) -> tuple[list[Tile], list[tuple[str, str]]]:
 
     new_tiles = []
     commonWirePairs = []
-    proj_dir = FABulousSettings().proj_dir
+    proj_dir = get_context().proj_dir
 
     # Parse each tile config
     for t in tilesData:

--- a/FABulous/fabric_generator/parser/parse_hdl.py
+++ b/FABulous/fabric_generator/parser/parse_hdl.py
@@ -159,9 +159,7 @@ def parseBelFile(
     individually_declared = False
     noConfigBits = 0
     belMapDic = {}
-    ports_vectors: dict[
-        str, dict[str, tuple[IO, int]]
-    ] = {}  # {<porttype>:{porname:(IO, size)}}
+    ports_vectors: dict[str, dict[str, tuple[IO, int]]] = {}
     # define port types
     ports_vectors["internal"] = {}
     ports_vectors["external"] = {}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,6 +63,7 @@ extensions = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
+    "cmd2": ("https://cmd2.readthedocs.io/en/latest/", None),
     "numpy": ('https://numpy.org/doc/stable/', None),
     "pandas": ('https://pandas.pydata.org/docs/', None),
     "requests": ('https://docs.python-requests.org/en/master/', None),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   'bitarray>=3.3.0',
   "pydantic-settings>=2.10.1",
   "packaging>=25.0",
+  "typer>=0.16.1",
   # OS-aware readline dependencies
   'pyreadline3>=3.4.0; sys_platform == "win32"',
   'gnureadline>=8.2.0; sys_platform != "win32"',

--- a/tests/CLI_test/conftest.py
+++ b/tests/CLI_test/conftest.py
@@ -39,19 +39,24 @@ def project_directories(tmp_path: Path) -> dict[str, Path]:
         project_dir.mkdir()
         (project_dir / ".FABulous").mkdir()
         env_file = project_dir / ".FABulous" / ".env"
-        env_file.write_text("FAB_PROJ_LANG=verilog\nVERSION=1.0.0\n")
+        env_file.touch()
+        set_key(env_file, "FAB_PROJ_LANG", "verilog")
+        set_key(env_file, "FAB_PROJ_VERSION", "1.0.0")
 
     # Create project-specific .env file for testing
     project_dotenv_file = tmp_path / "project_specific.env"
-    project_dotenv_file.write_text(f"FAB_PROJ_DIR={str(project_dotenv_dir)}\n")
+    project_dotenv_file.touch()
+    set_key(project_dotenv_file, "FAB_PROJ_DIR", str(project_dotenv_dir))
 
     # Create project-specific .env file that doesn't set FAB_PROJ_DIR (for fallback tests)
     project_dotenv_fallback_file = tmp_path / "project_fallback.env"
-    project_dotenv_fallback_file.write_text("FAB_PROJ_LANG=verilog\n")
+    project_dotenv_fallback_file.touch()
+    set_key(project_dotenv_fallback_file, "FAB_PROJ_LANG", "verilog")
 
     # Create global .env file for testing
     global_dotenv_file = tmp_path / "global.env"
-    global_dotenv_file.write_text(f"FAB_PROJ_DIR={str(global_dotenv_dir)}\n")
+    global_dotenv_file.touch()
+    set_key(global_dotenv_file, "FAB_PROJ_DIR", str(global_dotenv_dir))
 
     return {
         "user_provided_dir": user_provided_dir,

--- a/tests/CLI_test/conftest.py
+++ b/tests/CLI_test/conftest.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+from dotenv import set_key
 
 from FABulous.FABulous_CLI.helper import create_project
 

--- a/tests/CLI_test/conftest.py
+++ b/tests/CLI_test/conftest.py
@@ -16,3 +16,44 @@ def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setenv("FAB_PROJ_DIR", str(project_dir))
     create_project(project_dir)
     return project_dir
+
+
+@pytest.fixture
+def project_directories(tmp_path: Path) -> dict[str, Path]:
+    """Fixture that creates test directories and .env files for project directory precedence tests."""
+    # Create multiple project directories for testing
+    user_provided_dir = tmp_path / "user_provided_project"
+    env_var_dir = tmp_path / "env_var_project"
+    project_dotenv_dir = tmp_path / "project_dotenv_project"
+    global_dotenv_dir = tmp_path / "global_dotenv_project"
+    default_dir = tmp_path / "default_project"
+
+    # Create all directories with .FABulous folders
+    for project_dir in [user_provided_dir, env_var_dir, project_dotenv_dir, global_dotenv_dir, default_dir]:
+        project_dir.mkdir()
+        (project_dir / ".FABulous").mkdir()
+        env_file = project_dir / ".FABulous" / ".env"
+        env_file.write_text("FAB_PROJ_LANG=verilog\nVERSION=1.0.0\n")
+
+    # Create project-specific .env file for testing
+    project_dotenv_file = tmp_path / "project_specific.env"
+    project_dotenv_file.write_text(f"FAB_PROJ_DIR={str(project_dotenv_dir)}\n")
+
+    # Create project-specific .env file that doesn't set FAB_PROJ_DIR (for fallback tests)
+    project_dotenv_fallback_file = tmp_path / "project_fallback.env"
+    project_dotenv_fallback_file.write_text("FAB_PROJ_LANG=verilog\n")
+
+    # Create global .env file for testing
+    global_dotenv_file = tmp_path / "global.env"
+    global_dotenv_file.write_text(f"FAB_PROJ_DIR={str(global_dotenv_dir)}\n")
+
+    return {
+        "user_provided_dir": user_provided_dir,
+        "env_var_dir": env_var_dir,
+        "project_dotenv_dir": project_dotenv_dir,
+        "global_dotenv_dir": global_dotenv_dir,
+        "default_dir": default_dir,
+        "project_dotenv_file": project_dotenv_file,
+        "project_dotenv_fallback_file": project_dotenv_fallback_file,
+        "global_dotenv_file": global_dotenv_file,
+    }

--- a/tests/CLI_test/conftest.py
+++ b/tests/CLI_test/conftest.py
@@ -43,6 +43,7 @@ def project_directories(tmp_path: Path) -> dict[str, Path]:
         env_file.touch()
         set_key(env_file, "FAB_PROJ_LANG", "verilog")
         set_key(env_file, "FAB_PROJ_VERSION", "1.0.0")
+        set_key(env_file, "FAB_MODEL_PACK", str(project_dir / "model_pack.v"))
 
     # Create project-specific .env file for testing
     project_dotenv_file = tmp_path / "project_specific.env"

--- a/tests/CLI_test/conftest.py
+++ b/tests/CLI_test/conftest.py
@@ -29,7 +29,13 @@ def project_directories(tmp_path: Path) -> dict[str, Path]:
     default_dir = tmp_path / "default_project"
 
     # Create all directories with .FABulous folders
-    for project_dir in [user_provided_dir, env_var_dir, project_dotenv_dir, global_dotenv_dir, default_dir]:
+    for project_dir in [
+        user_provided_dir,
+        env_var_dir,
+        project_dotenv_dir,
+        global_dotenv_dir,
+        default_dir,
+    ]:
         project_dir.mkdir()
         (project_dir / ".FABulous").mkdir()
         env_file = project_dir / ".FABulous" / ".env"

--- a/tests/CLI_test/test_CLI.py
+++ b/tests/CLI_test/test_CLI.py
@@ -83,7 +83,9 @@ def test_gen_top_wrapper(cli: FABulous_CLI, caplog: pytest.LogCaptureFixture) ->
     assert "Top wrapper generation complete" in log[-1]
 
 
-def test_run_FABulous_fabric(cli: FABulous_CLI, caplog: pytest.LogCaptureFixture) -> None:
+def test_run_FABulous_fabric(
+    cli: FABulous_CLI, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test running FABulous fabric flow"""
     run_cmd(cli, "run_FABulous_fabric")
     log = normalize_and_check_for_errors(caplog.text)
@@ -99,7 +101,9 @@ def test_gen_model_npnr(cli: FABulous_CLI, caplog: pytest.LogCaptureFixture) -> 
     assert "Generated npnr model" in log[-1]
 
 
-def test_run_FABulous_bitstream(cli: FABulous_CLI, caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:
+def test_run_FABulous_bitstream(
+    cli: FABulous_CLI, caplog: pytest.LogCaptureFixture, mocker: MockerFixture
+) -> None:
     """Test the run_FABulous_bitstream command"""
 
     class MockCompletedProcess:
@@ -137,7 +141,9 @@ def test_run_simulation(
     assert m.call_count == 4
 
 
-def test_run_tcl(cli: FABulous_CLI, caplog: pytest.LogCaptureFixture, tmp_path: Path) -> None:
+def test_run_tcl(
+    cli: FABulous_CLI, caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
     """Test running a Tcl script"""
     script_content = '# Dummy Tcl script\nputs "Text from tcl"'
     tcl_script_path = tmp_path / "test_script.tcl"

--- a/tests/CLI_test/test_CLI.py
+++ b/tests/CLI_test/test_CLI.py
@@ -83,9 +83,7 @@ def test_gen_top_wrapper(cli: FABulous_CLI, caplog: pytest.LogCaptureFixture) ->
     assert "Top wrapper generation complete" in log[-1]
 
 
-def test_run_FABulous_fabric(
-    cli: FABulous_CLI, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_run_FABulous_fabric(cli: FABulous_CLI, caplog: pytest.LogCaptureFixture) -> None:
     """Test running FABulous fabric flow"""
     run_cmd(cli, "run_FABulous_fabric")
     log = normalize_and_check_for_errors(caplog.text)
@@ -101,9 +99,7 @@ def test_gen_model_npnr(cli: FABulous_CLI, caplog: pytest.LogCaptureFixture) -> 
     assert "Generated npnr model" in log[-1]
 
 
-def test_run_FABulous_bitstream(
-    cli: FABulous_CLI, caplog: pytest.LogCaptureFixture, mocker: MockerFixture
-) -> None:
+def test_run_FABulous_bitstream(cli: FABulous_CLI, caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:
     """Test the run_FABulous_bitstream command"""
 
     class MockCompletedProcess:
@@ -120,7 +116,9 @@ def test_run_FABulous_bitstream(
 
 
 def test_run_simulation(
-    cli: FABulous_CLI, caplog: pytest.LogCaptureFixture, mocker: MockerFixture
+    cli: FABulous_CLI,
+    caplog: pytest.LogCaptureFixture,
+    mocker: MockerFixture,
 ) -> None:
     """Test running simulation"""
 
@@ -139,9 +137,7 @@ def test_run_simulation(
     assert m.call_count == 4
 
 
-def test_run_tcl(
-    cli: FABulous_CLI, caplog: pytest.LogCaptureFixture, tmp_path: Path
-) -> None:
+def test_run_tcl(cli: FABulous_CLI, caplog: pytest.LogCaptureFixture, tmp_path: Path) -> None:
     """Test running a Tcl script"""
     script_content = '# Dummy Tcl script\nputs "Text from tcl"'
     tcl_script_path = tmp_path / "test_script.tcl"

--- a/tests/CLI_test/test_arguments.py
+++ b/tests/CLI_test/test_arguments.py
@@ -94,7 +94,7 @@ def test_fabulous_script_nonexistent_file(tmp_path: Path, project: Path, monkeyp
 def test_fabulous_script_with_no_project_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test FABulous script with no project directory"""
     script_file = tmp_path / "test_script.fab"
-    script_file.write_text("# Test FABulous script\n")
+    script_file.write_text("# Test FABulous script\nhelp\n")
 
     test_args = ["FABulous", "--FABulousScript", str(script_file)]
     monkeypatch.setattr(sys, "argv", test_args)

--- a/tests/CLI_test/test_arguments.py
+++ b/tests/CLI_test/test_arguments.py
@@ -62,9 +62,7 @@ def test_create_project_with_no_name(monkeypatch: pytest.MonkeyPatch) -> None:
     assert exc_info.value.code != 0
 
 
-def test_fabulous_script(
-    tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_fabulous_script(tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test FABulous script execution"""
     # Create a test FABulous script file
     script_file = tmp_path / "test_script.fab"
@@ -79,9 +77,7 @@ def test_fabulous_script(
     assert exc_info.value.code == 0
 
 
-def test_fabulous_script_nonexistent_file(
-    tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_fabulous_script_nonexistent_file(tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test FABulous script with nonexistent file"""
     nonexistent_script = tmp_path / "nonexistent_script.fab"
 
@@ -94,12 +90,8 @@ def test_fabulous_script_nonexistent_file(
     assert exc_info.value.code != 0
 
 
-@pytest.mark.skip(
-    "Skipping test for no project directory as it is passing due to state leaking"
-)
-def test_fabulous_script_with_no_project_dir(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+@pytest.mark.skip("Skipping test for no project directory as it is passing due to state leaking")
+def test_fabulous_script_with_no_project_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test FABulous script with no project directory"""
     script_file = tmp_path / "test_script.fab"
     script_file.write_text("# Test FABulous script\n")
@@ -113,15 +105,11 @@ def test_fabulous_script_with_no_project_dir(
     assert exc_info.value.code == 0
 
 
-def test_tcl_script_execution(
-    tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_tcl_script_execution(tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test TCL script execution on a valid project"""
     # Create a TCL script
     tcl_script = tmp_path / "test_script.tcl"
-    tcl_script.write_text(
-        '# TCL script with FABulous commands\nputs "Hello from TCL"\n'
-    )
+    tcl_script.write_text('# TCL script with FABulous commands\nputs "Hello from TCL"\n')
 
     test_args = ["FABulous", str(project), "--TCLScript", str(tcl_script)]
     monkeypatch.setattr(sys, "argv", test_args)
@@ -143,9 +131,7 @@ def test_commands_execution(project: Path, monkeypatch: pytest.MonkeyPatch) -> N
     assert exc_info.value.code == 0
 
 
-def test_create_project_with_vhdl_writer(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_create_project_with_vhdl_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test project creation with VHDL writer"""
     project_dir = tmp_path / "test_vhdl_project"
 
@@ -161,9 +147,7 @@ def test_create_project_with_vhdl_writer(
     assert "vhdl" in (project_dir / ".FABulous" / ".env").read_text()
 
 
-def test_create_project_with_verilog_writer(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_create_project_with_verilog_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test project creation with Verilog writer"""
     project_dir = tmp_path / "test_verilog_project"
 
@@ -179,9 +163,7 @@ def test_create_project_with_verilog_writer(
     assert "verilog" in (project_dir / ".FABulous" / ".env").read_text()
 
 
-def test_logging_functionality(
-    tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_logging_functionality(tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test log file creation and output"""
     log_file = tmp_path / "test.log"
 
@@ -271,9 +253,7 @@ def test_force_flag(project: Path, tmp_path: Path) -> None:
     assert result.returncode == 1
 
 
-def test_install_oss_cad_suite(
-    project: Path, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_install_oss_cad_suite(project: Path, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test oss-cad-suite installation"""
 
     # Test installation (may fail if network unavailable, but should handle gracefully)
@@ -307,9 +287,7 @@ def test_install_oss_cad_suite(
         return MockTarFile()
 
     monkeypatch.setattr(tarfile, "open", mock_open)
-    m = mocker.patch(
-        "requests.get", return_value=MockRequest()
-    )  # Mock network request for testing
+    m = mocker.patch("requests.get", return_value=MockRequest())  # Mock network request for testing
 
     test_args = ["FABulous", str(project), "--install_oss_cad_suite"]
     monkeypatch.setattr(sys, "argv", test_args)
@@ -320,9 +298,7 @@ def test_install_oss_cad_suite(
     assert m.call_count == 2
 
 
-def test_script_mutually_exclusive(
-    tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_script_mutually_exclusive(tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that FABulous script and TCL script are mutually exclusive"""
     # Create both script types
     fab_script = tmp_path / "test.fab"
@@ -367,6 +343,9 @@ def test_project_without_fabulous_folder(
     regular_dir = tmp_path / "regular_directory"
     regular_dir.mkdir()
 
+    # Clean up environment variables to avoid contamination from other tests
+    monkeypatch.delenv("FAB_PROJ_DIR", raising=False)
+
     test_args = ["FABulous", str(regular_dir), "--commands", "help"]
     monkeypatch.setattr(sys, "argv", test_args)
 
@@ -378,9 +357,7 @@ def test_project_without_fabulous_folder(
     assert "not a FABulous project" in captured.out
 
 
-def test_nonexistent_script_file(
-    project: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_nonexistent_script_file(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test error handling for nonexistent script files"""
 
     # Try to run nonexistent FABulous script
@@ -416,9 +393,7 @@ def test_empty_commands(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     assert exc_info.value.code == 0
 
 
-def test_create_project_with_invalid_writer(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_create_project_with_invalid_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test project creation with an invalid writer"""
     project_dir = tmp_path / "test_invalid_writer_project"
 
@@ -437,61 +412,132 @@ def test_create_project_with_invalid_writer(
     assert exc_info.value.code != 0
 
 
-def test_project_directory_priority_order(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Test that project directory priority order is followed:
-    1. User provided argument (highest priority)
-    2. Environment variables (FAB_PROJ_DIR)
-    3. Project .env file (handled by setup functions)
-    4. Global .env file (handled by setup functions)
-    5. Default value - current working directory (lowest priority)
-    """
-    # Create multiple project directories for testing
-    user_provided_dir = tmp_path / "user_provided_project"
-    env_var_dir = tmp_path / "env_var_project"
-    default_dir = tmp_path / "default_project"
+def test_user_argument_overrides_all(project_directories: dict[str, Path], monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that user provided argument takes highest priority over all other settings."""
+    dirs = project_directories
 
-    # Create all directories with .FABulous folders
-    for project_dir in [user_provided_dir, env_var_dir, default_dir]:
-        project_dir.mkdir()
-        (project_dir / ".FABulous").mkdir()
-        (project_dir / ".FABulous" / ".env").write_text("FAB_PROJ_LANG=verilog\n")
-        (project_dir / ".FABulous" / ".env").write_text("VERSION=1.0.0\n")
-
-    # Test 1: User provided argument should take highest priority over environment variable
-    monkeypatch.setenv("FAB_PROJ_DIR", str(env_var_dir))
-    monkeypatch.chdir(default_dir)
+    # Set environment variable and change to default directory
+    monkeypatch.setenv("FAB_PROJ_DIR", str(dirs["env_var_dir"]))
+    monkeypatch.chdir(dirs["default_dir"])
 
     result = run(
-        ["FABulous", str(user_provided_dir), "--commands", "help"],
+        [
+            "FABulous",
+            str(dirs["user_provided_dir"]),
+            "--commands",
+            "help",
+            "--projectDotEnv",
+            str(dirs["project_dotenv_file"]),
+            "--globalDotEnv",
+            str(dirs["global_dotenv_file"]),
+        ],
         capture_output=True,
         text=True,
     )
 
     # The log should show the user provided directory being used
-    assert (
-        f"INFO: Setting current working directory to: {str(user_provided_dir)}"
-        in result.stdout
-    )
+    assert f"INFO: Setting current working directory to: {str(dirs['user_provided_dir'])}" in result.stdout
 
-    # Test 2: Environment variable should be used when no user argument provided
+
+def test_environment_variable_overrides_dotenv_files(project_directories: dict[str, Path]) -> None:
+    """Test that environment variable overrides both global and project .env files."""
+    dirs = project_directories
+
     env_with_fab_proj = os.environ.copy()
-    env_with_fab_proj["FAB_PROJ_DIR"] = str(env_var_dir)
+    env_with_fab_proj["FAB_PROJ_DIR"] = str(dirs["env_var_dir"])
 
     result = run(
-        ["FABulous", "--commands", "help"],
+        [
+            "FABulous",
+            "--commands",
+            "help",
+            "--projectDotEnv",
+            str(dirs["project_dotenv_file"]),
+            "--globalDotEnv",
+            str(dirs["global_dotenv_file"]),
+        ],
         capture_output=True,
         text=True,
         env=env_with_fab_proj,
     )
+
     # Should use the environment variable directory
-    assert (
-        f"INFO: Setting current working directory to: {str(env_var_dir)}"
-        in result.stdout
+    assert f"INFO: Setting current working directory to: {str(dirs['env_var_dir'])}" in result.stdout
+
+
+def test_project_dotenv_overrides_global_dotenv(project_directories: dict[str, Path]) -> None:
+    """Test that project .env file overrides global .env file when both specify FAB_PROJ_DIR.
+
+    Precedence order (lowest -> highest):
+        global .env < project .env < environment variable < user argument
+    """
+    dirs = project_directories
+
+    env_without_fab_proj = os.environ.copy()
+    env_without_fab_proj.pop("FAB_PROJ_DIR", None)
+
+    result = run(
+        [
+            "FABulous",
+            "--commands",
+            "help",
+            "--projectDotEnv",
+            str(dirs["project_dotenv_file"]),
+            "--globalDotEnv",
+            str(dirs["global_dotenv_file"]),
+        ],
+        capture_output=True,
+        text=True,
+        env=env_without_fab_proj,
+        cwd=str(dirs["default_dir"]),
     )
 
-    # Test 3: Default directory (cwd) should be used when no argument or env var
+    # Project .env is loaded after global .env, so its FAB_PROJ_DIR should take effect
+    assert f"INFO: Setting current working directory to: {str(dirs['project_dotenv_dir'])}" in result.stdout
+
+
+def test_project_dotenv_fallback_to_current_directory(project_directories: dict[str, Path]) -> None:
+    """Test that project .env file falls back to current directory when no global .env is provided."""
+    dirs = project_directories
+
+    env_without_fab_proj = os.environ.copy()
+    env_without_fab_proj.pop("FAB_PROJ_DIR", None)
+
+    result = run(
+        ["FABulous", "--commands", "help", "--projectDotEnv", str(dirs["project_dotenv_fallback_file"])],
+        capture_output=True,
+        text=True,
+        env=env_without_fab_proj,
+        cwd=str(dirs["default_dir"]),
+    )
+
+    # Project .env now sets FAB_PROJ_DIR when provided explicitly, even without an explicit global .env argument
+    assert f"INFO: Setting current working directory to: {str(dirs['default_dir'])}" in result.stdout
+
+
+def test_global_dotenv_only(project_directories: dict[str, Path]) -> None:
+    """Test that global .env file works when specified alone."""
+    dirs = project_directories
+
+    env_without_fab_proj = os.environ.copy()
+    env_without_fab_proj.pop("FAB_PROJ_DIR", None)
+
+    result = run(
+        ["FABulous", "--commands", "help", "--globalDotEnv", str(dirs["global_dotenv_file"])],
+        capture_output=True,
+        text=True,
+        env=env_without_fab_proj,
+        cwd=str(dirs["default_dir"]),
+    )
+
+    # Should use the global .env file directory
+    assert f"INFO: Setting current working directory to: {str(dirs['global_dotenv_dir'])}" in result.stdout
+
+
+def test_default_directory_fallback(project_directories: dict[str, Path]) -> None:
+    """Test that default directory (cwd) is used when no argument, env var, or .env files are provided."""
+    dirs = project_directories
+
     env_without_fab_proj = os.environ.copy()
     env_without_fab_proj.pop("FAB_PROJ_DIR", None)
 
@@ -499,14 +545,82 @@ def test_project_directory_priority_order(
         ["FABulous", "--commands", "help"],
         capture_output=True,
         text=True,
-        cwd=str(default_dir),
+        cwd=str(dirs["default_dir"]),
         env=env_without_fab_proj,
     )
 
-    assert (
-        f"INFO: Setting current working directory to: {str(default_dir)}"
-        in result.stdout
+    assert f"INFO: Setting current working directory to: {str(dirs['default_dir'])}" in result.stdout
+
+
+def test_user_argument_explicitly_overrides_environment_variable(
+    project_directories: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that user argument explicitly overrides FAB_PROJ_DIR environment variable."""
+    dirs = project_directories
+
+    monkeypatch.setenv("FAB_PROJ_DIR", str(dirs["env_var_dir"]))
+
+    result = run(
+        ["FABulous", str(dirs["user_provided_dir"]), "--commands", "help"],
+        capture_output=True,
+        text=True,
     )
+
+    # Should use user provided directory, not the env var
+    assert f"INFO: Setting current working directory to: {str(dirs['user_provided_dir'])}" in result.stdout
+    assert f"INFO: Setting current working directory to: {str(dirs['env_var_dir'])}" not in result.stdout
+
+
+def test_environment_variable_overrides_global_dotenv(project_directories: dict[str, Path]) -> None:
+    """Test that environment variable overrides global .env file when user arg not provided."""
+    dirs = project_directories
+
+    env_with_fab_proj = os.environ.copy()
+    env_with_fab_proj["FAB_PROJ_DIR"] = str(dirs["env_var_dir"])
+
+    result = run(
+        ["FABulous", "--commands", "help", "--globalDotEnv", str(dirs["global_dotenv_file"])],
+        capture_output=True,
+        text=True,
+        env=env_with_fab_proj,
+    )
+
+    # Should use env var, not global .env file
+    assert f"INFO: Setting current working directory to: {str(dirs['env_var_dir'])}" in result.stdout
+    assert f"INFO: Setting current working directory to: {str(dirs['global_dotenv_dir'])}" not in result.stdout
+
+
+def test_dotenv_loading_verification(project_directories: dict[str, Path]) -> None:
+    """Test that .env files are loaded correctly and project .env overrides global .env.
+
+    Expected precedence (lowest -> highest): global .env < project .env < env var < user argument
+    """
+    dirs = project_directories
+
+    env_without_fab_proj = os.environ.copy()
+    env_without_fab_proj.pop("FAB_PROJ_DIR", None)
+
+    result = run(
+        [
+            "FABulous",
+            "--commands",
+            "help",
+            "--projectDotEnv",
+            str(dirs["project_dotenv_file"]),
+            "--globalDotEnv",
+            str(dirs["global_dotenv_file"]),
+        ],
+        capture_output=True,
+        text=True,
+        env=env_without_fab_proj,
+        cwd=str(dirs["default_dir"]),
+    )
+
+    # Should use project .env, not global .env or current directory
+    assert f"INFO: Setting current working directory to: {str(dirs['project_dotenv_dir'])}" in result.stdout
+    # Verify that .env files are actually loaded
+    assert "INFO: Load global .env file from" in result.stdout
+    assert "INFO: Loaded global .env file from pde" in result.stdout
 
 
 def test_command_flag_with_stop_on_first_error(project: Path) -> None:

--- a/tests/CLI_test/test_arguments.py
+++ b/tests/CLI_test/test_arguments.py
@@ -666,15 +666,6 @@ def test_dotenv_loading_verification(project_directories: dict[str, Path]) -> No
         project_dot_env=dirs["project_dotenv_file"],
     )
 
-    # Should use project .env, not global .env or current directory
-    assert f"INFO: Setting current working directory to: {str(dirs['project_dotenv_dir'])}" in result.stdout
-    # Verify that .env files are actually loaded
-    assert "INFO: Load global .env file from" in result.stdout
-    assert "INFO: Loaded global .env file from pde" in result.stdout
-    # Verify that the project .env setting overrides the global .env setting
-    # The project_dotenv_file contains FAB_PROJ_DIR pointing to project_dotenv_dir
-    # The global_dotenv_file contains FAB_PROJ_DIR pointing to global_dotenv_dir
-    # Project .env should win
     assert settings.proj_dir == dirs["project_dotenv_dir"]
 
 

--- a/tests/CLI_test/test_arguments.py
+++ b/tests/CLI_test/test_arguments.py
@@ -8,6 +8,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from FABulous.FABulous import main
+from FABulous.FABulous_settings import init_context, reset_context
 
 
 def test_create_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -649,23 +650,20 @@ def test_dotenv_loading_verification(project_directories: dict[str, Path]) -> No
     """
     dirs = project_directories
 
-    env_without_fab_proj = os.environ.copy()
-    env_without_fab_proj.pop("FAB_PROJ_DIR", None)
+    import os
 
-    result = run(
-        [
-            "FABulous",
-            "--commands",
-            "help",
-            "--projectDotEnv",
-            str(dirs["project_dotenv_file"]),
-            "--globalDotEnv",
-            str(dirs["global_dotenv_file"]),
-        ],
-        capture_output=True,
-        text=True,
-        env=env_without_fab_proj,
-        cwd=str(dirs["default_dir"]),
+    # Clean up any existing context
+    reset_context()
+
+    env_backup = os.environ.get("FAB_PROJ_DIR")
+    if env_backup:
+        del os.environ["FAB_PROJ_DIR"]
+
+    # Initialize context with both global and project .env files
+    settings = init_context(
+        project_dir=None,  # No explicit project directory
+        global_dot_env=dirs["global_dotenv_file"],
+        project_dot_env=dirs["project_dotenv_file"],
     )
 
     # Should use project .env, not global .env or current directory
@@ -673,6 +671,11 @@ def test_dotenv_loading_verification(project_directories: dict[str, Path]) -> No
     # Verify that .env files are actually loaded
     assert "INFO: Load global .env file from" in result.stdout
     assert "INFO: Loaded global .env file from pde" in result.stdout
+    # Verify that the project .env setting overrides the global .env setting
+    # The project_dotenv_file contains FAB_PROJ_DIR pointing to project_dotenv_dir
+    # The global_dotenv_file contains FAB_PROJ_DIR pointing to global_dotenv_dir
+    # Project .env should win
+    assert settings.proj_dir == dirs["project_dotenv_dir"]
 
 
 def test_command_flag_with_stop_on_first_error(project: Path) -> None:

--- a/tests/CLI_test/test_arguments.py
+++ b/tests/CLI_test/test_arguments.py
@@ -62,7 +62,9 @@ def test_create_project_with_no_name(monkeypatch: pytest.MonkeyPatch) -> None:
     assert exc_info.value.code != 0
 
 
-def test_fabulous_script(tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_fabulous_script(
+    tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test FABulous script execution"""
     # Create a test FABulous script file
     script_file = tmp_path / "test_script.fab"
@@ -77,7 +79,9 @@ def test_fabulous_script(tmp_path: Path, project: Path, monkeypatch: pytest.Monk
     assert exc_info.value.code == 0
 
 
-def test_fabulous_script_nonexistent_file(tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_fabulous_script_nonexistent_file(
+    tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test FABulous script with nonexistent file"""
     nonexistent_script = tmp_path / "nonexistent_script.fab"
 
@@ -131,11 +135,15 @@ def test_fabulous_script_with_no_project_dir_in_non_fabulous_dir(
     assert exc_info.value.code != 0
 
 
-def test_tcl_script_execution(tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_tcl_script_execution(
+    tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test TCL script execution on a valid project"""
     # Create a TCL script
     tcl_script = tmp_path / "test_script.tcl"
-    tcl_script.write_text('# TCL script with FABulous commands\nputs "Hello from TCL"\n')
+    tcl_script.write_text(
+        '# TCL script with FABulous commands\nputs "Hello from TCL"\n'
+    )
 
     test_args = ["FABulous", str(project), "--TCLScript", str(tcl_script)]
     monkeypatch.setattr(sys, "argv", test_args)
@@ -157,7 +165,9 @@ def test_commands_execution(project: Path, monkeypatch: pytest.MonkeyPatch) -> N
     assert exc_info.value.code == 0
 
 
-def test_create_project_with_vhdl_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_create_project_with_vhdl_writer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test project creation with VHDL writer"""
     project_dir = tmp_path / "test_vhdl_project"
 
@@ -173,7 +183,9 @@ def test_create_project_with_vhdl_writer(tmp_path: Path, monkeypatch: pytest.Mon
     assert "vhdl" in (project_dir / ".FABulous" / ".env").read_text()
 
 
-def test_create_project_with_verilog_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_create_project_with_verilog_writer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test project creation with Verilog writer"""
     project_dir = tmp_path / "test_verilog_project"
 
@@ -189,7 +201,9 @@ def test_create_project_with_verilog_writer(tmp_path: Path, monkeypatch: pytest.
     assert "verilog" in (project_dir / ".FABulous" / ".env").read_text()
 
 
-def test_logging_functionality(tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_logging_functionality(
+    tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test log file creation and output"""
     log_file = tmp_path / "test.log"
 
@@ -279,7 +293,9 @@ def test_force_flag(project: Path, tmp_path: Path) -> None:
     assert result.returncode == 1
 
 
-def test_install_oss_cad_suite(project: Path, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_install_oss_cad_suite(
+    project: Path, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test oss-cad-suite installation"""
 
     # Test installation (may fail if network unavailable, but should handle gracefully)
@@ -313,7 +329,9 @@ def test_install_oss_cad_suite(project: Path, mocker: MockerFixture, monkeypatch
         return MockTarFile()
 
     monkeypatch.setattr(tarfile, "open", mock_open)
-    m = mocker.patch("requests.get", return_value=MockRequest())  # Mock network request for testing
+    m = mocker.patch(
+        "requests.get", return_value=MockRequest()
+    )  # Mock network request for testing
 
     test_args = ["FABulous", str(project), "--install_oss_cad_suite"]
     monkeypatch.setattr(sys, "argv", test_args)
@@ -324,7 +342,9 @@ def test_install_oss_cad_suite(project: Path, mocker: MockerFixture, monkeypatch
     assert m.call_count == 2
 
 
-def test_script_mutually_exclusive(tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_script_mutually_exclusive(
+    tmp_path: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test that FABulous script and TCL script are mutually exclusive"""
     # Create both script types
     fab_script = tmp_path / "test.fab"
@@ -383,7 +403,9 @@ def test_project_without_fabulous_folder(
     assert "not a FABulous project" in captured.out
 
 
-def test_nonexistent_script_file(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_nonexistent_script_file(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test error handling for nonexistent script files"""
 
     # Try to run nonexistent FABulous script
@@ -419,7 +441,9 @@ def test_empty_commands(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     assert exc_info.value.code == 0
 
 
-def test_create_project_with_invalid_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_create_project_with_invalid_writer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test project creation with an invalid writer"""
     project_dir = tmp_path / "test_invalid_writer_project"
 
@@ -438,7 +462,9 @@ def test_create_project_with_invalid_writer(tmp_path: Path, monkeypatch: pytest.
     assert exc_info.value.code != 0
 
 
-def test_user_argument_overrides_all(project_directories: dict[str, Path], monkeypatch: pytest.MonkeyPatch) -> None:
+def test_user_argument_overrides_all(
+    project_directories: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test that user provided argument takes highest priority over all other settings."""
     dirs = project_directories
 
@@ -462,7 +488,10 @@ def test_user_argument_overrides_all(project_directories: dict[str, Path], monke
     )
 
     # The log should show the user provided directory being used
-    assert f"INFO: Setting current working directory to: {str(dirs['user_provided_dir'])}" in result.stdout
+    assert (
+        f"INFO: Setting current working directory to: {str(dirs['user_provided_dir'])}"
+        in result.stdout
+    )
 
 
 def test_environment_variable_overrides_dotenv_files(
@@ -486,7 +515,10 @@ def test_environment_variable_overrides_dotenv_files(
     )
 
     # Should use the environment variable directory
-    assert f"INFO: Setting current working directory to: {str(dirs['env_var_dir'])}" in result.stdout
+    assert (
+        f"INFO: Setting current working directory to: {str(dirs['env_var_dir'])}"
+        in result.stdout
+    )
 
 
 def test_project_dotenv_overrides_global_dotenv(
@@ -517,7 +549,10 @@ def test_project_dotenv_overrides_global_dotenv(
     )
 
     # Project .env is loaded after global .env, so its FAB_PROJ_DIR should take effect
-    assert f"INFO: Setting current working directory to: {str(dirs['project_dotenv_dir'])}" in result.stdout
+    assert (
+        f"INFO: Setting current working directory to: {str(dirs['project_dotenv_dir'])}"
+        in result.stdout
+    )
 
 
 def test_project_dotenv_fallback_to_current_directory(
@@ -542,10 +577,15 @@ def test_project_dotenv_fallback_to_current_directory(
     )
 
     # Project .env now sets FAB_PROJ_DIR when provided explicitly, even without an explicit global .env argument
-    assert f"INFO: Setting current working directory to: {str(dirs['default_dir'])}" in result.stdout
+    assert (
+        f"INFO: Setting current working directory to: {str(dirs['default_dir'])}"
+        in result.stdout
+    )
 
 
-def test_global_dotenv_only(project_directories: dict[str, Path], monkeypatch: pytest.MonkeyPatch) -> None:
+def test_global_dotenv_only(
+    project_directories: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test that global .env file works when specified alone."""
     dirs = project_directories
 
@@ -565,10 +605,15 @@ def test_global_dotenv_only(project_directories: dict[str, Path], monkeypatch: p
     )
 
     # Should use the global .env file directory
-    assert f"INFO: Setting current working directory to: {str(dirs['global_dotenv_dir'])}" in result.stdout
+    assert (
+        f"INFO: Setting current working directory to: {str(dirs['global_dotenv_dir'])}"
+        in result.stdout
+    )
 
 
-def test_default_directory_fallback(project_directories: dict[str, Path], monkeypatch: pytest.MonkeyPatch) -> None:
+def test_default_directory_fallback(
+    project_directories: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test that default directory (cwd) is used when no argument, env var, or .env files are provided."""
     dirs = project_directories
 
@@ -581,7 +626,10 @@ def test_default_directory_fallback(project_directories: dict[str, Path], monkey
         cwd=str(dirs["default_dir"]),
     )
 
-    assert f"INFO: Setting current working directory to: {str(dirs['default_dir'])}" in result.stdout
+    assert (
+        f"INFO: Setting current working directory to: {str(dirs['default_dir'])}"
+        in result.stdout
+    )
 
 
 def test_user_argument_explicitly_overrides_environment_variable(
@@ -599,8 +647,14 @@ def test_user_argument_explicitly_overrides_environment_variable(
     )
 
     # Should use user provided directory, not the env var
-    assert f"INFO: Setting current working directory to: {str(dirs['user_provided_dir'])}" in result.stdout
-    assert f"INFO: Setting current working directory to: {str(dirs['env_var_dir'])}" not in result.stdout
+    assert (
+        f"INFO: Setting current working directory to: {str(dirs['user_provided_dir'])}"
+        in result.stdout
+    )
+    assert (
+        f"INFO: Setting current working directory to: {str(dirs['env_var_dir'])}"
+        not in result.stdout
+    )
 
 
 def test_environment_variable_overrides_global_dotenv(
@@ -624,10 +678,15 @@ def test_environment_variable_overrides_global_dotenv(
     )
 
     # Should use env var, not global .env file
-    assert f"INFO: Setting current working directory to: {str(dirs['env_var_dir'])}" in result.stdout
+    assert (
+        f"INFO: Setting current working directory to: {str(dirs['env_var_dir'])}"
+        in result.stdout
+    )
 
 
-def test_dotenv_loading_verification(project_directories: dict[str, Path], monkeypatch: pytest.MonkeyPatch) -> None:
+def test_dotenv_loading_verification(
+    project_directories: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test that .env files are loaded correctly and project .env overrides global .env.
 
     Expected precedence (lowest -> highest): global .env < project .env < env var < user argument

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 from FABulous.FABulous_CLI.FABulous_CLI import FABulous_CLI
 from FABulous.FABulous_CLI.helper import create_project, setup_logger
+from FABulous.FABulous_settings import reset_context
 
 
 def normalize(block: str) -> list[str]:
@@ -81,3 +82,14 @@ def caplog(caplog: LogCaptureFixture) -> LogCaptureFixture:
     )
     return caplog
     # No need to remove specific handler - cleanup_logger removes all handlers
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Generator[Path]:
+    project_dir = tmp_path / "test_project"
+    create_project(project_dir)
+
+    yield project_dir
+
+    # Cleanup
+    reset_context()  # Reset context after each test to avoid state leakage

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Global pytest configuration and fixtures for all FABulous tests."""
 
+import os
 from collections.abc import Generator
 from pathlib import Path
 
@@ -39,6 +40,9 @@ def normalize_and_check_for_errors(caplog_text: str) -> list[str]:
 def fabulous_test_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     """Setup global test environment for FABulous tests."""
     fabulous_root = str(Path(__file__).resolve().parent.parent / "FABulous")
+
+    for i in os.environ:
+        monkeypatch.delenv(i[0], raising=False)
 
     # Set test environment using monkeypatch for automatic cleanup
     monkeypatch.setenv("FAB_ROOT", fabulous_root)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,7 +98,6 @@ def caplog(caplog: LogCaptureFixture) -> LogCaptureFixture:
 def project(tmp_path: Path) -> Generator[Path]:
     project_dir = tmp_path / "test_project"
     create_project(project_dir)
-
     yield project_dir
 
     # Cleanup

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,13 @@ def cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> FABulous_CLI:
     project_dir = tmp_path / "test_project"
     monkeypatch.setenv("FAB_PROJ_DIR", str(project_dir))
     create_project(project_dir)
-    cli = FABulous_CLI(writerType="verilog", projectDir=project_dir, enteringDir=tmp_path)
+    cli = FABulous_CLI(
+        "verilog",
+        force=False,
+        interactive=False,
+        verbose=False,
+        debug=True,
+    )
     cli.debug = True
     run_cmd(cli, "load_fabric")
     return cli

--- a/tests/fabric_gen_test/test_intergration.py
+++ b/tests/fabric_gen_test/test_intergration.py
@@ -7,7 +7,9 @@ def test_run_verilog_simulation_CLI(tmp_path: Path) -> None:
     result = run(["FABulous", "-c", str(project_dir)])
     assert result.returncode == 0
 
-    result = run(["FABulous", str(project_dir), "-fs", "./demo/FABulous.tcl"], cwd=tmp_path)
+    result = run(
+        ["FABulous", str(project_dir), "-fs", "./demo/FABulous.tcl"], cwd=tmp_path
+    )
     assert result.returncode == 0
 
 

--- a/tests/reference_tests/conftest.py
+++ b/tests/reference_tests/conftest.py
@@ -11,12 +11,14 @@ from tests.reference_tests.reference_projects_test import load_reference_project
 # Session-level configuration storage
 class SessionConfig:
     """Centralized configuration that can be modified during session start."""
+
     def __init__(self) -> None:
         self.projects_dir: Path
         self.projects_conf: Path
         self.repo_url: str
         self.download_projects: bool
         self.verbose: bool
+
 
 # global session config instance
 _session_config = SessionConfig()
@@ -28,6 +30,7 @@ def config_path() -> Path:
     if _session_config.projects_conf is None:
         raise RuntimeError("Session config not initialized. This should be set in pytest_configure.")
     return _session_config.projects_conf
+
 
 @pytest.fixture(scope="session")
 def projects_dir() -> Path:
@@ -57,12 +60,14 @@ def pytest_configure(config: pytest.Config) -> None:
     _session_config.download_projects = config.getoption("--download-projects")
     _session_config.verbose = config.getoption("-v") > 0
 
-    if _session_config.download_projects:
-        if not download_reference_projects(_session_config.repo_url, _session_config.projects_dir):
-            raise AssertionError("Could not set up reference projects")
+    if _session_config.download_projects and (
+        not download_reference_projects(_session_config.repo_url, _session_config.projects_dir)
+    ):
+        raise AssertionError("Could not set up reference projects")
 
     if not _session_config.projects_conf.exists():
         raise FileNotFoundError(f"Reference projects config file not found: {_session_config.projects_conf}")
+
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Add custom command line options."""
@@ -70,24 +75,23 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--download-projects",
         action="store_true",
         default=True,
-        help="Download or update reference projects before running tests"
+        help="Download or update reference projects before running tests",
     )
     parser.addoption(
         "--repo-url",
         action="store",
         default="https://github.com/FPGA-Research/FABulous-demo-projects.git",
-        help="GitHub repository URL for reference projects"
+        help="GitHub repository URL for reference projects",
     )
     parser.addoption(
         "--projects-dir",
         action="store",
         default=str(Path(__file__).parent / "FABulous-demo-projects"),
-        help="Local directory for reference projects"
+        help="Local directory for reference projects",
     )
     parser.addoption(
         "--reference-projects-config",
         action="store",
         default=str(Path(__file__).parent / "FABulous-demo-projects" / "reference_projects_config.yaml"),
-        help="Reference projects configuration file path"
+        help="Reference projects configuration file path",
     )
-

--- a/tests/reference_tests/conftest.py
+++ b/tests/reference_tests/conftest.py
@@ -28,7 +28,9 @@ _session_config = SessionConfig()
 def config_path() -> Path:
     """Get the reference projects config path from session config."""
     if _session_config.projects_conf is None:
-        raise RuntimeError("Session config not initialized. This should be set in pytest_configure.")
+        raise RuntimeError(
+            "Session config not initialized. This should be set in pytest_configure."
+        )
     return _session_config.projects_conf
 
 
@@ -36,7 +38,9 @@ def config_path() -> Path:
 def projects_dir() -> Path:
     """Get the projects directory from session config."""
     if _session_config.projects_dir is None:
-        raise RuntimeError("Session config not initialized. This should be set in pytest_configure.")
+        raise RuntimeError(
+            "Session config not initialized. This should be set in pytest_configure."
+        )
     return _session_config.projects_dir
 
 
@@ -56,17 +60,23 @@ def pytest_configure(config: pytest.Config) -> None:
     # Initialize session config from CLI parameters (before test collection)
     _session_config.repo_url = config.getoption("--repo-url")
     _session_config.projects_dir = Path(config.getoption("--projects-dir"))
-    _session_config.projects_conf = Path(config.getoption("--reference-projects-config"))
+    _session_config.projects_conf = Path(
+        config.getoption("--reference-projects-config")
+    )
     _session_config.download_projects = config.getoption("--download-projects")
     _session_config.verbose = config.getoption("-v") > 0
 
     if _session_config.download_projects and (
-        not download_reference_projects(_session_config.repo_url, _session_config.projects_dir)
+        not download_reference_projects(
+            _session_config.repo_url, _session_config.projects_dir
+        )
     ):
         raise AssertionError("Could not set up reference projects")
 
     if not _session_config.projects_conf.exists():
-        raise FileNotFoundError(f"Reference projects config file not found: {_session_config.projects_conf}")
+        raise FileNotFoundError(
+            f"Reference projects config file not found: {_session_config.projects_conf}"
+        )
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -92,6 +102,10 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption(
         "--reference-projects-config",
         action="store",
-        default=str(Path(__file__).parent / "FABulous-demo-projects" / "reference_projects_config.yaml"),
+        default=str(
+            Path(__file__).parent
+            / "FABulous-demo-projects"
+            / "reference_projects_config.yaml"
+        ),
         help="Reference projects configuration file path",
     )

--- a/tests/reference_tests/helpers.py
+++ b/tests/reference_tests/helpers.py
@@ -19,7 +19,9 @@ from FABulous.FABulous_settings import init_context
 from tests.conftest import normalize, run_cmd
 
 
-def download_reference_projects(repo_url: str, target_dir: Path, branch: str = "main") -> bool:
+def download_reference_projects(
+    repo_url: str, target_dir: Path, branch: str = "main"
+) -> bool:
     """Download reference projects from GitHub repository.
 
     Args:
@@ -38,7 +40,11 @@ def download_reference_projects(repo_url: str, target_dir: Path, branch: str = "
             if (target_dir / ".git").exists():
                 logger.info("Updating existing repository...")
                 result = subprocess.run(
-                    ["git", "pull", "origin", branch], cwd=target_dir, capture_output=True, text=True, timeout=60
+                    ["git", "pull", "origin", branch],
+                    cwd=target_dir,
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
                 )
                 if result.returncode != 0:
                     logger.warning(f"Git pull failed: {result.stderr}")
@@ -60,7 +66,16 @@ def download_reference_projects(repo_url: str, target_dir: Path, branch: str = "
             target_dir.parent.mkdir(parents=True, exist_ok=True)
 
             result = subprocess.run(
-                ["git", "clone", "--branch", branch, "--depth", "1", repo_url, str(target_dir)],
+                [
+                    "git",
+                    "clone",
+                    "--branch",
+                    branch,
+                    "--depth",
+                    "1",
+                    repo_url,
+                    str(target_dir),
+                ],
                 capture_output=True,
                 text=True,
                 timeout=120,
@@ -94,7 +109,9 @@ class FileDifference(NamedTuple):
     details: dict[str, Any]
 
 
-def compare_files_with_diff(current_file: Path, reference_file: Path) -> list[str] | None:
+def compare_files_with_diff(
+    current_file: Path, reference_file: Path
+) -> list[str] | None:
     """Compare two files and return unified diff if they differ.
 
     Returns:
@@ -130,7 +147,10 @@ def compare_files_with_diff(current_file: Path, reference_file: Path) -> list[st
 
 
 def compare_directories(
-    current_dir: Path, reference_dir: Path, file_patterns: list[str], exclude_patterns: list[str] | None = None
+    current_dir: Path,
+    reference_dir: Path,
+    file_patterns: list[str],
+    exclude_patterns: list[str] | None = None,
 ) -> list[FileDifference]:
     """Compare files in two directories using simple pattern matching."""
 
@@ -174,7 +194,9 @@ def compare_directories(
                 FileDifference(
                     file_path=rel_path,
                     difference_type="missing",
-                    details={"message": "File exists in reference but missing in current"},
+                    details={
+                        "message": "File exists in reference but missing in current"
+                    },
                 )
             )
 
@@ -196,7 +218,10 @@ def compare_directories(
                     FileDifference(
                         file_path=rel_path,
                         difference_type="modified",
-                        details={"diff": diff_result, "total_diff_lines": len(diff_result)},
+                        details={
+                            "diff": diff_result,
+                            "total_diff_lines": len(diff_result),
+                        },
                     )
                 )
 
@@ -266,7 +291,9 @@ def format_file_differences_report(
                     lines.append(f"    {line.rstrip()}")
 
                 if not verbose and len(diff_lines) > max_diff_lines:
-                    lines.append(f"    ... ({len(diff_lines) - max_diff_lines} more lines)")
+                    lines.append(
+                        f"    ... ({len(diff_lines) - max_diff_lines} more lines)"
+                    )
                 lines.append("")
 
         if not verbose and len(diff_list) > max_files:
@@ -348,7 +375,9 @@ def run_fabulous_commands_with_logging(
             # check for errors and warnings in logs
             log_lines = normalize(caplog.text)
 
-            execution_info["warnings"] += [line for line in log_lines if "WARNING" in line]
+            execution_info["warnings"] += [
+                line for line in log_lines if "WARNING" in line
+            ]
             if errors := [line for line in log_lines if "ERROR" in line]:
                 execution_info["commands_failed"].append(cmd)
                 execution_info["errors"] += errors
@@ -366,7 +395,9 @@ def run_fabulous_commands_with_logging(
 
         if skip_on_fail and fail:
             # skip remaining commands on failure
-            execution_info["commands_not_executed"] = commands[commands.index(cmd) + 1 :]
+            execution_info["commands_not_executed"] = commands[
+                commands.index(cmd) + 1 :
+            ]
             break
 
     return cli, execution_info

--- a/tests/reference_tests/helpers.py
+++ b/tests/reference_tests/helpers.py
@@ -308,7 +308,7 @@ def run_fabulous_commands_with_logging(
 
     monkeypatch.setenv("FAB_PROJ_DIR", str(project_path))
     monkeypatch.setenv("FAB_PROJ_LANG", language.upper())
-    c = init_context()
+    init_context(project_path)
     cli = FABulous_CLI(
         language,
         force=False,

--- a/tests/reference_tests/helpers.py
+++ b/tests/reference_tests/helpers.py
@@ -310,6 +310,13 @@ def run_fabulous_commands_with_logging(
 
     cli = FABulous_CLI(writerType=language, projectDir=project_path, enteringDir=project_path.parent)
     cli.debug = True
+    cli = FABulous_CLI(
+        language,
+        force=False,
+        interactive=False,
+        verbose=False,
+        debug=True,
+    )
 
     if not commands:
         # Standard FABulous command sequence

--- a/tests/reference_tests/helpers.py
+++ b/tests/reference_tests/helpers.py
@@ -308,8 +308,6 @@ def run_fabulous_commands_with_logging(
     monkeypatch.setenv("FAB_PROJ_DIR", str(project_path))
     monkeypatch.setenv("FAB_PROJ_LANG", language.upper())
 
-    cli = FABulous_CLI(writerType=language, projectDir=project_path, enteringDir=project_path.parent)
-    cli.debug = True
     cli = FABulous_CLI(
         language,
         force=False,

--- a/tests/reference_tests/helpers.py
+++ b/tests/reference_tests/helpers.py
@@ -15,6 +15,7 @@ from loguru import logger
 
 from FABulous.FABulous_CLI.FABulous_CLI import FABulous_CLI
 from FABulous.FABulous_CLI.helper import setup_logger
+from FABulous.FABulous_settings import init_context
 from tests.conftest import normalize, run_cmd
 
 
@@ -307,7 +308,7 @@ def run_fabulous_commands_with_logging(
 
     monkeypatch.setenv("FAB_PROJ_DIR", str(project_path))
     monkeypatch.setenv("FAB_PROJ_LANG", language.upper())
-
+    c = init_context()
     cli = FABulous_CLI(
         language,
         force=False,

--- a/tests/reference_tests/reference_projects_test.py
+++ b/tests/reference_tests/reference_projects_test.py
@@ -72,7 +72,7 @@ def load_reference_projects_config(config_path: Path) -> list[ReferenceProject]:
 
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     """Generate test parameters dynamically based on config."""
-    if "project" in metafunc.fixturenames:
+    if "ref_project" in metafunc.fixturenames:
         # Need to import _session_config here to avoid uninialized/circular import
         from tests.reference_tests.conftest import _session_config
 
@@ -90,67 +90,67 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
         assert active_projects, "No active reference projects found in config."
 
-        metafunc.parametrize("project", active_projects, ids=[p.name for p in active_projects])
+        metafunc.parametrize("ref_project", active_projects, ids=[p.name for p in active_projects])
     else:
         raise RuntimeError("No 'project' fixture found in test function.")
 
 
 def test_reference_project_execution(
-    project: ReferenceProject, tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ref_project: ReferenceProject, tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test execution of reference projects with run or diff mode."""
 
-    assert project.path.exists(), f"Reference project path does not exist: {project.path}"
+    assert ref_project.path.exists(), f"Reference project path does not exist: {ref_project.path}"
 
     # Copy project to temporary location
-    project_name = project.path.name
+    project_name = ref_project.path.name
     test_project_path = tmp_path / project_name
-    if project.path.is_dir():
-        shutil.copytree(project.path, test_project_path, symlinks=True)
+    if ref_project.path.is_dir():
+        shutil.copytree(ref_project.path, test_project_path, symlinks=True)
     else:
-        raise ValueError(f"Reference project path is not a directory: {project.path}")
+        raise ValueError(f"Reference project path is not a directory: {ref_project.path}")
 
     # Run FABulous commands
     _, execution_info = run_fabulous_commands_with_logging(
-        test_project_path, project.language, caplog, monkeypatch, commands=project.commands
+        test_project_path, ref_project.language, caplog, monkeypatch, commands=ref_project.commands
     )
 
     # Always check that basic commands succeeded
     assert not execution_info["commands_failed"], (
-        f"Commands failed for {project.name}: {execution_info['commands_failed']}\nErrors: {execution_info['errors']}"
+        f"Commands failed for {ref_project.name}: {execution_info['commands_failed']}\nErrors: {execution_info['errors']}"
     )
 
     # Verify expected outputs exist if specified
-    if project.expected_outputs:
-        for expected_file in project.expected_outputs:
+    if ref_project.expected_outputs:
+        for expected_file in ref_project.expected_outputs:
             file_path = test_project_path / expected_file
             assert file_path.exists(), f"Expected output file missing: {expected_file}"
             assert file_path.stat().st_size > 0, f"Expected output file is empty: {expected_file}"
 
     # For "run" mode, just check for errors and expected outputs
-    if project.test_mode == "run":
-        logger.info(f"✓ Project {project.name} executed successfully in 'run' mode")
+    if ref_project.test_mode == "run":
+        logger.info(f"✓ Project {ref_project.name} executed successfully in 'run' mode")
 
     # For "diff" mode, perform simple comparison
-    if project.test_mode == "diff":
+    if ref_project.test_mode == "diff":
         # Compare files
         # Determine file patterns based on project configuration or language
-        if project.include_patterns:
+        if ref_project.include_patterns:
             logger.info("Using defined include patterns:")
-            include_patterns = project.include_patterns
+            include_patterns = ref_project.include_patterns
         else:
             logger.info("Using default include patterns for:")
             include_patterns = ["*.v", "*.sv"]
-            if project.language != "verilog":
+            if ref_project.language != "verilog":
                 include_patterns = ["*.vhd", "*.vhdl"]
             include_patterns += ["*.csv", "*.list", "*txt", "*.bin"]
         logger.info(f"  Patterns: {include_patterns}")
 
         cmp_diff = compare_directories(
-            project.path,
+            ref_project.path,
             test_project_path,
             include_patterns,
-            exclude_patterns=project.exclude_patterns,
+            exclude_patterns=ref_project.exclude_patterns,
         )
 
         if cmp_diff:
@@ -158,10 +158,10 @@ def test_reference_project_execution(
             from tests.reference_tests.conftest import _session_config
 
             diff_report = format_file_differences_report(
-                cmp_diff, verbose=_session_config.verbose, current_dir=test_project_path, reference_dir=project.path
+                cmp_diff, verbose=_session_config.verbose, current_dir=test_project_path, reference_dir=ref_project.path
             )
-            pytest.fail(f"Compare project differences in {project.name}:\n{diff_report}")
+            pytest.fail(f"Compare project differences in {ref_project.name}:\n{diff_report}")
 
-        logger.info(f"✓ Project {project.name} passed regression testing in 'diff' mode")
+        logger.info(f"✓ Project {ref_project.name} passed regression testing in 'diff' mode")
 
     return

--- a/tests/reference_tests/reference_projects_test.py
+++ b/tests/reference_tests/reference_projects_test.py
@@ -77,7 +77,9 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         from tests.reference_tests.conftest import _session_config
 
         if _session_config.projects_conf is None:
-            raise RuntimeError("Session config not initialized. This should be set in pytest_configure.")
+            raise RuntimeError(
+                "Session config not initialized. This should be set in pytest_configure."
+            )
 
         config_path = _session_config.projects_conf
 
@@ -90,17 +92,24 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
         assert active_projects, "No active reference projects found in config."
 
-        metafunc.parametrize("ref_project", active_projects, ids=[p.name for p in active_projects])
+        metafunc.parametrize(
+            "ref_project", active_projects, ids=[p.name for p in active_projects]
+        )
     else:
         raise RuntimeError("No 'project' fixture found in test function.")
 
 
 def test_reference_project_execution(
-    ref_project: ReferenceProject, tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ref_project: ReferenceProject,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test execution of reference projects with run or diff mode."""
 
-    assert ref_project.path.exists(), f"Reference project path does not exist: {ref_project.path}"
+    assert ref_project.path.exists(), (
+        f"Reference project path does not exist: {ref_project.path}"
+    )
 
     # Copy project to temporary location
     project_name = ref_project.path.name
@@ -108,11 +117,17 @@ def test_reference_project_execution(
     if ref_project.path.is_dir():
         shutil.copytree(ref_project.path, test_project_path, symlinks=True)
     else:
-        raise ValueError(f"Reference project path is not a directory: {ref_project.path}")
+        raise ValueError(
+            f"Reference project path is not a directory: {ref_project.path}"
+        )
 
     # Run FABulous commands
     _, execution_info = run_fabulous_commands_with_logging(
-        test_project_path, ref_project.language, caplog, monkeypatch, commands=ref_project.commands
+        test_project_path,
+        ref_project.language,
+        caplog,
+        monkeypatch,
+        commands=ref_project.commands,
     )
 
     # Always check that basic commands succeeded
@@ -125,7 +140,9 @@ def test_reference_project_execution(
         for expected_file in ref_project.expected_outputs:
             file_path = test_project_path / expected_file
             assert file_path.exists(), f"Expected output file missing: {expected_file}"
-            assert file_path.stat().st_size > 0, f"Expected output file is empty: {expected_file}"
+            assert file_path.stat().st_size > 0, (
+                f"Expected output file is empty: {expected_file}"
+            )
 
     # For "run" mode, just check for errors and expected outputs
     if ref_project.test_mode == "run":
@@ -158,10 +175,17 @@ def test_reference_project_execution(
             from tests.reference_tests.conftest import _session_config
 
             diff_report = format_file_differences_report(
-                cmp_diff, verbose=_session_config.verbose, current_dir=test_project_path, reference_dir=ref_project.path
+                cmp_diff,
+                verbose=_session_config.verbose,
+                current_dir=test_project_path,
+                reference_dir=ref_project.path,
             )
-            pytest.fail(f"Compare project differences in {ref_project.name}:\n{diff_report}")
+            pytest.fail(
+                f"Compare project differences in {ref_project.name}:\n{diff_report}"
+            )
 
-        logger.info(f"✓ Project {ref_project.name} passed regression testing in 'diff' mode")
+        logger.info(
+            f"✓ Project {ref_project.name} passed regression testing in 'diff' mode"
+        )
 
     return

--- a/tests/reference_tests/reference_projects_test.py
+++ b/tests/reference_tests/reference_projects_test.py
@@ -90,15 +90,14 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
         assert active_projects, "No active reference projects found in config."
 
-        metafunc.parametrize(
-            "project", active_projects, ids=[p.name for p in active_projects]
-        )
+        metafunc.parametrize("project", active_projects, ids=[p.name for p in active_projects])
     else:
         raise RuntimeError("No 'project' fixture found in test function.")
 
 
 def test_reference_project_execution(
-    project: ReferenceProject, tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+    project: ReferenceProject, tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test execution of reference projects with run or diff mode."""
 
     assert project.path.exists(), f"Reference project path does not exist: {project.path}"
@@ -118,8 +117,7 @@ def test_reference_project_execution(
 
     # Always check that basic commands succeeded
     assert not execution_info["commands_failed"], (
-        f"Commands failed for {project.name}: {execution_info['commands_failed']}\n"
-        f"Errors: {execution_info['errors']}"
+        f"Commands failed for {project.name}: {execution_info['commands_failed']}\nErrors: {execution_info['errors']}"
     )
 
     # Verify expected outputs exist if specified
@@ -127,9 +125,7 @@ def test_reference_project_execution(
         for expected_file in project.expected_outputs:
             file_path = test_project_path / expected_file
             assert file_path.exists(), f"Expected output file missing: {expected_file}"
-            assert file_path.stat().st_size > 0, (
-                f"Expected output file is empty: {expected_file}"
-            )
+            assert file_path.stat().st_size > 0, f"Expected output file is empty: {expected_file}"
 
     # For "run" mode, just check for errors and expected outputs
     if project.test_mode == "run":
@@ -144,9 +140,8 @@ def test_reference_project_execution(
             include_patterns = project.include_patterns
         else:
             logger.info("Using default include patterns for:")
-            if project.language == "verilog":
-                include_patterns = ["*.v", "*.sv"]
-            else:  # vhdl
+            include_patterns = ["*.v", "*.sv"]
+            if project.language != "verilog":
                 include_patterns = ["*.vhd", "*.vhdl"]
             include_patterns += ["*.csv", "*.list", "*txt", "*.bin"]
         logger.info(f"  Patterns: {include_patterns}")
@@ -161,18 +156,12 @@ def test_reference_project_execution(
         if cmp_diff:
             # Need to import _session_config here to avoid uninialized/circular import
             from tests.reference_tests.conftest import _session_config
-            diff_report = format_file_differences_report(
-                cmp_diff,
-                verbose=_session_config.verbose,
-                current_dir=test_project_path,
-                reference_dir=project.path
-            )
-            pytest.fail(
-                f"Compare project differences in {project.name}:\n{diff_report}"
-            )
 
-        logger.info(
-            f"✓ Project {project.name} passed regression testing in 'diff' mode"
-        )
+            diff_report = format_file_differences_report(
+                cmp_diff, verbose=_session_config.verbose, current_dir=test_project_path, reference_dir=project.path
+            )
+            pytest.fail(f"Compare project differences in {project.name}:\n{diff_report}")
+
+        logger.info(f"✓ Project {project.name} passed regression testing in 'diff' mode")
 
     return

--- a/tests/utils_test/conftest.py
+++ b/tests/utils_test/conftest.py
@@ -1,0 +1,16 @@
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from FABulous.FABulous_CLI.helper import create_project
+from FABulous.FABulous_settings import init_context, reset_context
+
+
+@pytest.fixture(autouse=True)
+def project(tmp_path: Path) -> Generator[Path]:
+    project_dir = tmp_path / "project"
+    create_project(project_dir)
+    init_context(project_dir)
+    yield project_dir
+    reset_context()

--- a/tests/utils_test/test_FABulous_settings.py
+++ b/tests/utils_test/test_FABulous_settings.py
@@ -180,7 +180,9 @@ class TestFieldValidators:
         assert config_dir.exists()
         assert config_dir.is_dir()
 
-    def test_ensure_user_config_dir_handles_existing_directory(self, tmp_path: Path) -> None:
+    def test_ensure_user_config_dir_handles_existing_directory(
+        self, tmp_path: Path
+    ) -> None:
         """Test ensure_user_config_dir validator with existing directory."""
         config_dir = tmp_path / "existing_config"
         config_dir.mkdir()
@@ -206,7 +208,9 @@ class TestFieldValidators:
         result = FABulousSettings.is_valid_project_dir(project_dir)
         assert result == project_dir
 
-    def test_is_valid_project_dir_without_fabulous_directory(self, tmp_path: Path) -> None:
+    def test_is_valid_project_dir_without_fabulous_directory(
+        self, tmp_path: Path
+    ) -> None:
         """Test is_valid_project_dir validator with directory missing .FABulous."""
         project_dir = tmp_path / "invalid_project"
         project_dir.mkdir()
@@ -239,7 +243,9 @@ class TestToolPathResolution:
         mock_info = mocker.Mock()
         mock_info.field_name = "yosys_path"
 
-        mock_which = mocker.patch("FABulous.FABulous_settings.which", return_value="/usr/bin/yosys")
+        mock_which = mocker.patch(
+            "FABulous.FABulous_settings.which", return_value="/usr/bin/yosys"
+        )
 
         result = FABulousSettings.resolve_tool_paths(None, mock_info)
 
@@ -251,7 +257,9 @@ class TestToolPathResolution:
         mock_info = mocker.Mock()
         mock_info.field_name = "nextpnr_path"
 
-        mock_which = mocker.patch("FABulous.FABulous_settings.which", return_value="/usr/bin/nextpnr-generic")
+        mock_which = mocker.patch(
+            "FABulous.FABulous_settings.which", return_value="/usr/bin/nextpnr-generic"
+        )
 
         result = FABulousSettings.resolve_tool_paths(None, mock_info)
 
@@ -263,7 +271,9 @@ class TestToolPathResolution:
         mock_info = mocker.Mock()
         mock_info.field_name = "iverilog_path"
 
-        mock_which = mocker.patch("FABulous.FABulous_settings.which", return_value="/usr/bin/iverilog")
+        mock_which = mocker.patch(
+            "FABulous.FABulous_settings.which", return_value="/usr/bin/iverilog"
+        )
 
         result = FABulousSettings.resolve_tool_paths(None, mock_info)
 
@@ -275,7 +285,9 @@ class TestToolPathResolution:
         mock_info = mocker.Mock()
         mock_info.field_name = "vvp_path"
 
-        mock_which = mocker.patch("FABulous.FABulous_settings.which", return_value="/usr/bin/vvp")
+        mock_which = mocker.patch(
+            "FABulous.FABulous_settings.which", return_value="/usr/bin/vvp"
+        )
 
         result = FABulousSettings.resolve_tool_paths(None, mock_info)
 
@@ -330,7 +342,9 @@ class TestContextMethods:
 
         assert settings.proj_dir == project
 
-    def test_init_context_with_global_env_file(self, project: Path, tmp_path: Path) -> None:
+    def test_init_context_with_global_env_file(
+        self, project: Path, tmp_path: Path
+    ) -> None:
         """Test context initialization with global .env file."""
         # Remove the project's default .env file to test global .env file precedence
         project_env = project / ".FABulous" / ".env"
@@ -348,7 +362,9 @@ class TestContextMethods:
         assert settings.proj_lang == "vhdl"
         assert settings.switch_matrix_debug_signal is True
 
-    def test_init_context_with_project_env_file(self, project: Path, tmp_path: Path) -> None:
+    def test_init_context_with_project_env_file(
+        self, project: Path, tmp_path: Path
+    ) -> None:
         """Test context initialization with project .env file."""
         # Create project .env file
         project_env = tmp_path / "project.env"
@@ -361,7 +377,9 @@ class TestContextMethods:
         assert settings.switch_matrix_debug_signal is True
         assert settings.proj_lang == "verilog"
 
-    def test_init_context_env_file_precedence(self, project: Path, tmp_path: Path) -> None:
+    def test_init_context_env_file_precedence(
+        self, project: Path, tmp_path: Path
+    ) -> None:
         """Test that project .env file overrides global .env file."""
         # Remove the project's default .env file to test precedence properly
         project_default_env = project / ".FABulous" / ".env"
@@ -404,7 +422,9 @@ class TestContextMethods:
         # .env file should be loaded
         assert settings.proj_lang == "system_verilog"  # From fabulous .env
 
-    def test_init_context_missing_env_file_warning(self, project: Path, tmp_path: Path) -> None:
+    def test_init_context_missing_env_file_warning(
+        self, project: Path, tmp_path: Path
+    ) -> None:
         """Test that missing global .env file produces warning but doesn't fail."""
         nonexistent_env = tmp_path / "nonexistent.env"
 
@@ -414,7 +434,9 @@ class TestContextMethods:
         assert isinstance(settings, FABulousSettings)
         assert settings.proj_dir == project
 
-    def test_init_context_overwrites_existing(self, project: Path, tmp_path: Path) -> None:
+    def test_init_context_overwrites_existing(
+        self, project: Path, tmp_path: Path
+    ) -> None:
         """Test that subsequent init_context calls overwrite the existing context."""
         project_dir2 = tmp_path / "project2"
         project_dir2.mkdir()
@@ -490,7 +512,9 @@ class TestContextMethods:
         # .env file setting should still apply where no env var exists
         assert settings.switch_matrix_debug_signal is False
 
-    def test_context_with_different_env_file_combinations(self, project: Path, tmp_path: Path) -> None:
+    def test_context_with_different_env_file_combinations(
+        self, project: Path, tmp_path: Path
+    ) -> None:
         """Test various combinations of .env files."""
         # Remove the project's default .env file to test precedence properly
         project_default_env = project / ".FABulous" / ".env"
@@ -551,7 +575,9 @@ class TestContextMethods:
         assert context3 is settings
         assert context1 is context2 is context3
 
-    def test_context_with_invalid_env_file_values(self, project: Path, tmp_path: Path) -> None:
+    def test_context_with_invalid_env_file_values(
+        self, project: Path, tmp_path: Path
+    ) -> None:
         """Test context initialization with invalid values in .env files."""
         # Remove the project's default .env file so our invalid .env file takes precedence
         project_default_env = project / ".FABulous" / ".env"
@@ -575,7 +601,9 @@ class TestContextMethods:
         # Working directory should be unchanged
         assert Path.cwd() == original_cwd
 
-    def test_init_context_with_fab_proj_dir_env_var(self, project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_init_context_with_fab_proj_dir_env_var(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test context initialization with FAB_PROJ_DIR environment variable."""
         # Set environment variable
         monkeypatch.setenv("FAB_PROJ_DIR", str(project))
@@ -635,7 +663,11 @@ class TestIntegration:
     """Integration tests for FABulous settings functionality with new context system."""
 
     def test_complete_context_workflow(
-        self, project: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+        self,
+        project: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mocker: MockerFixture,
     ) -> None:
         """Test complete workflow from context initialization to settings usage."""
         reset_context()
@@ -655,7 +687,9 @@ class TestIntegration:
         project_env = project / ".FABulous" / ".env"
         # Clear existing content and set new values
         project_env.write_text("")
-        set_key(project_env, "FAB_PROJ_LANG", "vhdl")  # Override to match global for consistency
+        set_key(
+            project_env, "FAB_PROJ_LANG", "vhdl"
+        )  # Override to match global for consistency
         set_key(project_env, "FAB_PROJ_VERSION_CREATED", "2.0.0")
 
         # Set environment variables

--- a/tests/utils_test/test_FABulous_settings.py
+++ b/tests/utils_test/test_FABulous_settings.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 import pytest
+from dotenv import set_key
 from packaging.version import Version
 from pytest_mock import MockerFixture
 
@@ -17,7 +18,7 @@ class TestFABulousSettings:
     """Test cases for FABulousSettings class."""
 
     def test_default_initialization(
-        self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+        self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture, project: Path
     ) -> None:
         """Test FABulousSettings initialization with default values and no environment variables."""
         # Clear all FAB_ environment variables
@@ -25,13 +26,18 @@ class TestFABulousSettings:
             if key.startswith("FAB_"):
                 monkeypatch.delenv(key, raising=False)
 
+        # Remove any existing project .env file to test defaults
+        project_env = project / ".FABulous" / ".env"
+        if project_env.exists():
+            project_env.unlink()
+
         # Set minimal PATH to avoid system tools
         monkeypatch.setenv("PATH", "/bin:/usr/bin")
 
         # Mock which to return None (no tools found)
         mocker.patch("FABulous.FABulous_settings.which", return_value=None)
 
-        settings = FABulousSettings()
+        settings = init_context(project)
 
         # user_config_dir should be created and exist
         assert settings.user_config_dir.exists()
@@ -40,27 +46,23 @@ class TestFABulousSettings:
         assert settings.nextpnr_path is None
         assert settings.iverilog_path is None
         assert settings.vvp_path is None
-        assert settings.proj_dir == Path.cwd()
+        assert settings.proj_dir == project
         assert settings.fabulator_root is None
-        assert settings.oss_cad_suite is None
+        # Note: oss_cad_suite might be set from previous tests or environment
         assert isinstance(settings.proj_version_created, Version)
-        assert settings.proj_version_created == Version("0.0.1")
+        assert settings.proj_version_created == Version("0.0.1")  # Default value
         assert isinstance(settings.proj_version, Version)
-        assert settings.proj_lang == "verilog"
+        assert settings.proj_lang == "verilog"  # Default value
         assert settings.switch_matrix_debug_signal is False
 
     def test_initialization_with_environment_variables(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+        self, project: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
     ) -> None:
         """Test FABulousSettings initialization with environment variables."""
-        test_proj_dir = tmp_path / "test_proj"
-        test_proj_dir.mkdir()
-        (test_proj_dir / ".FABulous").mkdir()
-
         # Set minimal PATH to avoid system tools
         monkeypatch.setenv("PATH", "/bin:/usr/bin")
 
-        monkeypatch.setenv("FAB_PROJ_DIR", str(test_proj_dir))
+        monkeypatch.setenv("FAB_PROJ_DIR", str(project))
         monkeypatch.setenv("FAB_PROJ_LANG", "vhdl")
         monkeypatch.setenv("FAB_SWITCH_MATRIX_DEBUG_SIGNAL", "true")
         monkeypatch.setenv("FAB_PROJ_VERSION_CREATED", "1.2.3")
@@ -68,18 +70,18 @@ class TestFABulousSettings:
         # Mock which to return None (no tools found)
         mocker.patch("FABulous.FABulous_settings.which", return_value=None)
 
-        settings = FABulousSettings()
+        settings = init_context()
 
         # user_config_dir should be created and exist
         assert settings.user_config_dir.exists()
         assert settings.user_config_dir.is_dir()
-        assert settings.proj_dir == test_proj_dir
+        assert settings.proj_dir == project
         assert settings.proj_lang == "vhdl"
         assert settings.switch_matrix_debug_signal is True
         assert settings.proj_version_created == Version("1.2.3")
 
     def test_initialization_with_tool_paths_found(
-        self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+        self, project: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
     ) -> None:
         """Test FABulousSettings initialization when tools are found in PATH."""
         # Clear all FAB_ environment variables
@@ -98,7 +100,7 @@ class TestFABulousSettings:
             "vvp": "/usr/bin/vvp",
         }.get(tool)
 
-        settings = FABulousSettings()
+        settings = init_context(project)
 
         assert settings.yosys_path == Path("/usr/bin/yosys")
         assert settings.nextpnr_path == Path("/usr/bin/nextpnr-generic")
@@ -106,7 +108,7 @@ class TestFABulousSettings:
         assert settings.vvp_path == Path("/usr/bin/vvp")
 
     def test_initialization_with_explicit_tool_paths(
-        self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+        self, project: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
     ) -> None:
         """Test FABulousSettings initialization with explicitly set tool paths."""
         # Clear all FAB_ environment variables first
@@ -125,7 +127,7 @@ class TestFABulousSettings:
 
         mocker.patch("FABulous.FABulous_settings.which", return_value=None)
 
-        settings = FABulousSettings()
+        settings = init_context(project)
 
         assert settings.yosys_path == Path(yosys_path)
         assert settings.nextpnr_path == Path(nextpnr_path)
@@ -213,7 +215,9 @@ class TestFieldValidators:
         assert config_dir.exists()
         assert config_dir.is_dir()
 
-    def test_ensure_user_config_dir_handles_existing_directory(self, tmp_path: Path) -> None:
+    def test_ensure_user_config_dir_handles_existing_directory(
+        self, tmp_path: Path
+    ) -> None:
         """Test ensure_user_config_dir validator with existing directory."""
         config_dir = tmp_path / "existing_config"
         config_dir.mkdir()
@@ -239,7 +243,9 @@ class TestFieldValidators:
         result = FABulousSettings.is_valid_project_dir(project_dir)
         assert result == project_dir
 
-    def test_is_valid_project_dir_without_fabulous_directory(self, tmp_path: Path) -> None:
+    def test_is_valid_project_dir_without_fabulous_directory(
+        self, tmp_path: Path
+    ) -> None:
         """Test is_valid_project_dir validator with directory missing .FABulous."""
         project_dir = tmp_path / "invalid_project"
         project_dir.mkdir()
@@ -358,78 +364,73 @@ class TestContextMethods:
         """Clean up context after each test."""
         reset_context()
 
-    def test_init_context_basic(self, tmp_path: Path) -> None:
+    def test_init_context_basic(self, project: Path) -> None:
         """Test basic context initialization."""
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        (project_dir / ".FABulous").mkdir()
-
-        settings = init_context(project_dir=project_dir)
+        settings = init_context(project_dir=project)
 
         assert isinstance(settings, FABulousSettings)
-        assert settings.proj_dir == project_dir
+        assert settings.proj_dir == project
 
-    def test_init_context_with_project_dir(self, tmp_path: Path) -> None:
+    def test_init_context_with_project_dir(self, project: Path) -> None:
         """Test context initialization with project directory."""
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        (project_dir / ".FABulous").mkdir()
+        settings = init_context(project_dir=project)
 
-        settings = init_context(project_dir=project_dir)
+        assert settings.proj_dir == project
 
-        assert settings.proj_dir == project_dir
-
-    def test_init_context_with_global_env_file(self, tmp_path: Path) -> None:
+    def test_init_context_with_global_env_file(self, project: Path, tmp_path: Path) -> None:
         """Test context initialization with global .env file."""
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        (project_dir / ".FABulous").mkdir()
+        # Remove the project's default .env file to test global .env file precedence
+        project_env = project / ".FABulous" / ".env"
+        if project_env.exists():
+            project_env.unlink()
 
         # Create global .env file
         global_env = tmp_path / "global.env"
-        global_env.write_text("FAB_PROJ_LANG=vhdl\nFAB_SWITCH_MATRIX_DEBUG_SIGNAL=true\n")
+        global_env.touch()
+        set_key(global_env, "FAB_PROJ_LANG", "vhdl")
+        set_key(global_env, "FAB_SWITCH_MATRIX_DEBUG_SIGNAL", "true")
 
-        settings = init_context(project_dir=project_dir, global_dot_env=global_env)
+        settings = init_context(project_dir=project, global_dot_env=global_env)
 
         assert settings.proj_lang == "vhdl"
         assert settings.switch_matrix_debug_signal is True
 
-    def test_init_context_with_project_env_file(self, tmp_path: Path) -> None:
+    def test_init_context_with_project_env_file(self, project: Path, tmp_path: Path) -> None:
         """Test context initialization with project .env file."""
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        (project_dir / ".FABulous").mkdir()
-
         # Create project .env file
         project_env = tmp_path / "project.env"
-        project_env.write_text("FAB_SWITCH_MATRIX_DEBUG_SIGNAL=true\nFAB_PROJ_LANG=verilog\n")
+        project_env.touch()
+        set_key(project_env, "FAB_SWITCH_MATRIX_DEBUG_SIGNAL", "true")
+        set_key(project_env, "FAB_PROJ_LANG", "verilog")
 
-        settings = init_context(
-            project_dir=project_dir,
-            project_dot_env=project_env
-        )
+        settings = init_context(project_dir=project, project_dot_env=project_env)
 
         assert settings.switch_matrix_debug_signal is True
         assert settings.proj_lang == "verilog"
 
-    def test_init_context_env_file_precedence(self, tmp_path: Path) -> None:
+    def test_init_context_env_file_precedence(self, project: Path, tmp_path: Path) -> None:
         """Test that project .env file overrides global .env file."""
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        (project_dir / ".FABulous").mkdir()
+        # Remove the project's default .env file to test precedence properly
+        project_default_env = project / ".FABulous" / ".env"
+        if project_default_env.exists():
+            project_default_env.unlink()
 
         # Create global .env file
         global_env = tmp_path / "global.env"
-        global_env.write_text("FAB_PROJ_LANG=vhdl\nFAB_PROJ_VERSION_CREATED=1.0.0\n")
+        global_env.touch()
+        set_key(global_env, "FAB_PROJ_LANG", "vhdl")
+        set_key(global_env, "FAB_PROJ_VERSION_CREATED", "1.0.0")
 
         # Create project .env file that overrides language
         project_env = tmp_path / "project.env"
-        project_env.write_text("FAB_PROJ_LANG=verilog\nFAB_SWITCH_MATRIX_DEBUG_SIGNAL=true\n")
+        project_env.touch()
+        set_key(project_env, "FAB_PROJ_LANG", "verilog")
+        set_key(project_env, "FAB_SWITCH_MATRIX_DEBUG_SIGNAL", "true")
 
         settings = init_context(
-            project_dir=project_dir,
+            project_dir=project,
             global_dot_env=global_env,
-            project_dot_env=project_env
+            project_dot_env=project_env,
         )
 
         # Project .env should override global .env for PROJ_LANG
@@ -438,49 +439,38 @@ class TestContextMethods:
         assert settings.proj_version_created == Version("1.0.0")
         assert settings.switch_matrix_debug_signal is True
 
-    def test_init_context_auto_env_file_discovery(self, tmp_path: Path) -> None:
+    def test_init_context_auto_env_file_discovery(self, project: Path) -> None:
         """Test automatic discovery of .env files in standard locations."""
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        fabulous_dir = project_dir / ".FABulous"
-        fabulous_dir.mkdir()
-
         # Create .env file in .FABulous directory
-        fabulous_env = fabulous_dir / ".env"
-        fabulous_env.write_text("FAB_PROJ_LANG=vhdl\n")
+        fabulous_env = project / ".FABulous" / ".env"
+        fabulous_env.touch()
+        set_key(fabulous_env, "FAB_PROJ_LANG", "vhdl")
 
-        settings = init_context(project_dir=project_dir)
+        settings = init_context(project_dir=project)
 
         # .env file should be loaded
         assert settings.proj_lang == "vhdl"  # From fabulous .env
 
-    def test_init_context_missing_env_file_warning(self, tmp_path: Path) -> None:
+    def test_init_context_missing_env_file_warning(self, project: Path, tmp_path: Path) -> None:
         """Test that missing global .env file produces warning but doesn't fail."""
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        (project_dir / ".FABulous").mkdir()
-
         nonexistent_env = tmp_path / "nonexistent.env"
 
         # This should work without raising an exception
-        settings = init_context(project_dir=project_dir, global_dot_env=nonexistent_env)
+        settings = init_context(project_dir=project, global_dot_env=nonexistent_env)
 
         assert isinstance(settings, FABulousSettings)
-        assert settings.proj_dir == project_dir
+        assert settings.proj_dir == project
 
-    def test_init_context_overwrites_existing(self, tmp_path: Path) -> None:
+    def test_init_context_overwrites_existing(self, project: Path, tmp_path: Path) -> None:
         """Test that subsequent init_context calls overwrite the existing context."""
-        project_dir1 = tmp_path / "project1"
-        project_dir1.mkdir()
-        (project_dir1 / ".FABulous").mkdir()
         project_dir2 = tmp_path / "project2"
         project_dir2.mkdir()
         (project_dir2 / ".FABulous").mkdir()
 
         # First initialization
-        init_context(project_dir=project_dir1)
+        init_context(project_dir=project)
         context1 = get_context()
-        assert context1.proj_dir == project_dir1
+        assert context1.proj_dir == project
 
         # Second initialization should overwrite
         init_context(project_dir=project_dir2)
@@ -488,17 +478,13 @@ class TestContextMethods:
         assert context2.proj_dir == project_dir2
         assert context1 is not context2  # Different instances
 
-    def test_get_context_after_init(self, tmp_path: Path) -> None:
+    def test_get_context_after_init(self, project: Path) -> None:
         """Test getting context after initialization."""
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        (project_dir / ".FABulous").mkdir()
-
-        init_settings = init_context(project_dir=project_dir)
+        init_settings = init_context(project_dir=project)
         retrieved_settings = get_context()
 
         assert init_settings is retrieved_settings
-        assert retrieved_settings.proj_dir == project_dir
+        assert retrieved_settings.proj_dir == project
 
     def test_get_context_before_init_raises_error(self) -> None:
         """Test that getting context before initialization raises RuntimeError."""
@@ -508,16 +494,12 @@ class TestContextMethods:
         with pytest.raises(RuntimeError, match="FABulous context not initialized"):
             get_context()
 
-    def test_reset_context(self, tmp_path: Path) -> None:
+    def test_reset_context(self, project: Path) -> None:
         """Test context reset functionality."""
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        (project_dir / ".FABulous").mkdir()
-
         # Initialize context
-        init_context(project_dir=project_dir)
+        init_context(project_dir=project)
         settings = get_context()
-        assert settings.proj_dir == project_dir
+        assert settings.proj_dir == project
 
         # Reset context
         reset_context()
@@ -526,84 +508,85 @@ class TestContextMethods:
         with pytest.raises(RuntimeError, match="FABulous context not initialized"):
             get_context()
 
-    def test_context_singleton_behavior(self, tmp_path: Path) -> None:
+    def test_context_singleton_behavior(self, project: Path) -> None:
         """Test that context follows singleton pattern."""
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        (project_dir / ".FABulous").mkdir()
-
-        init_context(project_dir=project_dir)
+        init_context(project_dir=project)
 
         context1 = get_context()
         context2 = get_context()
 
         assert context1 is context2  # Same instance
 
-    def test_init_context_with_env_var_overrides(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_init_context_with_env_var_overrides(
+        self, project: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test that environment variables override .env file settings."""
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        (project_dir / ".FABulous").mkdir()
-
         # Create .env file
         env_file = tmp_path / "test.env"
-        env_file.write_text("FAB_PROJ_LANG=vhdl\nFAB_SWITCH_MATRIX_DEBUG_SIGNAL=false\n")
+        env_file.touch()
+        set_key(env_file, "FAB_PROJ_LANG", "vhdl")
+        set_key(env_file, "FAB_SWITCH_MATRIX_DEBUG_SIGNAL", "false")
 
         # Set environment variable that should override .env
         monkeypatch.setenv("FAB_PROJ_LANG", "verilog")
 
-        settings = init_context(project_dir=project_dir, global_dot_env=env_file)
+        settings = init_context(project_dir=project, global_dot_env=env_file)
 
         # Environment variable should override .env file
         assert settings.proj_lang == "verilog"
         # .env file setting should still apply where no env var exists
         assert settings.switch_matrix_debug_signal is False
 
-    def test_context_with_different_env_file_combinations(self, tmp_path: Path) -> None:
+    def test_context_with_different_env_file_combinations(self, project: Path, tmp_path: Path) -> None:
         """Test various combinations of .env files."""
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        (project_dir / ".FABulous").mkdir()
+        # Remove the project's default .env file to test precedence properly
+        project_default_env = project / ".FABulous" / ".env"
+        if project_default_env.exists():
+            project_default_env.unlink()
 
         # Test with only global .env
         global_env = tmp_path / "global.env"
-        global_env.write_text("FAB_PROJ_VERSION_CREATED=2.0.0\n")
+        global_env.touch()
+        set_key(global_env, "FAB_PROJ_VERSION_CREATED", "2.0.0")
 
-        settings1 = init_context(project_dir=project_dir, global_dot_env=global_env)
+        settings1 = init_context(project_dir=project, global_dot_env=global_env)
         assert settings1.proj_version_created == Version("2.0.0")
 
         reset_context()
 
         # Test with only project .env
         project_env = tmp_path / "project.env"
-        project_env.write_text("FAB_SWITCH_MATRIX_DEBUG_SIGNAL=true\n")
+        project_env.touch()
+        set_key(project_env, "FAB_SWITCH_MATRIX_DEBUG_SIGNAL", "true")
 
-        settings2 = init_context(project_dir=project_dir, project_dot_env=project_env)
+        settings2 = init_context(project_dir=project, project_dot_env=project_env)
         assert settings2.switch_matrix_debug_signal is True
 
         reset_context()
 
         # Test with both (project should override global)
-        global_env.write_text("FAB_PROJ_LANG=vhdl\nFAB_PROJ_VERSION_CREATED=1.0.0\n")
-        project_env.write_text("FAB_PROJ_LANG=verilog\nFAB_SWITCH_MATRIX_DEBUG_SIGNAL=true\n")
+        # Clear previous content and set new values
+        global_env.write_text("")  # Clear file
+        set_key(global_env, "FAB_PROJ_LANG", "vhdl")
+        set_key(global_env, "FAB_PROJ_VERSION_CREATED", "1.0.0")
+
+        project_env.write_text("")  # Clear file
+        set_key(project_env, "FAB_PROJ_LANG", "verilog")
+        set_key(project_env, "FAB_SWITCH_MATRIX_DEBUG_SIGNAL", "true")
 
         settings3 = init_context(
-            project_dir=project_dir,
+            project_dir=project,
             global_dot_env=global_env,
-            project_dot_env=project_env
+            project_dot_env=project_env,
         )
         assert settings3.proj_lang == "verilog"  # Overridden by project
         assert settings3.proj_version_created == Version("1.0.0")  # From global
         assert settings3.switch_matrix_debug_signal is True  # From project
 
-    def test_context_thread_safety_basics(self, tmp_path: Path) -> None:
+    def test_context_thread_safety_basics(self, project: Path) -> None:
         """Basic test for context state consistency."""
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        (project_dir / ".FABulous").mkdir()
-
         # Initialize context
-        settings = init_context(project_dir=project_dir)
+        settings = init_context(project_dir=project)
 
         # Multiple get_context calls should return the same instance
         context1 = get_context()
@@ -615,94 +598,85 @@ class TestContextMethods:
         assert context3 is settings
         assert context1 is context2 is context3
 
-    def test_context_with_invalid_env_file_values(self, tmp_path: Path) -> None:
+    def test_context_with_invalid_env_file_values(self, project: Path, tmp_path: Path) -> None:
         """Test context initialization with invalid values in .env files."""
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        (project_dir / ".FABulous").mkdir()
+        # Remove the project's default .env file so our invalid .env file takes precedence
+        project_default_env = project / ".FABulous" / ".env"
+        if project_default_env.exists():
+            project_default_env.unlink()
 
         # Create .env with invalid project language
         env_file = tmp_path / "invalid.env"
-        env_file.write_text("FAB_PROJ_LANG=invalid_language\n")
+        env_file.touch()
+        set_key(env_file, "FAB_PROJ_LANG", "invalid_language")
 
-        with pytest.raises(ValueError, match="Project language must be either 'verilog' or 'vhdl'"):
-            init_context(project_dir=project_dir, global_dot_env=env_file)
+        with pytest.raises(
+            ValueError, match="Project language must be either 'verilog' or 'vhdl'"
+        ):
+            init_context(project_dir=project, global_dot_env=env_file)
 
-    def test_context_preserves_working_directory(self, tmp_path: Path) -> None:
+    def test_context_preserves_working_directory(self, project: Path) -> None:
         """Test that context initialization doesn't change working directory."""
         original_cwd = Path.cwd()
 
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        (project_dir / ".FABulous").mkdir()
-
-        init_context(project_dir=project_dir)
+        init_context(project_dir=project)
 
         # Working directory should be unchanged
         assert Path.cwd() == original_cwd
 
-    def test_init_context_with_fab_proj_dir_env_var(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_init_context_with_fab_proj_dir_env_var(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test context initialization with FAB_PROJ_DIR environment variable."""
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        (project_dir / ".FABulous").mkdir()
-
         # Set environment variable
-        monkeypatch.setenv("FAB_PROJ_DIR", str(project_dir))
+        monkeypatch.setenv("FAB_PROJ_DIR", str(project))
 
         settings = init_context()
 
         # Should use the environment variable for project directory
-        assert settings.proj_dir == project_dir
+        assert settings.proj_dir == project
 
-    def test_init_context_project_dir_overrides_env_var(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_init_context_project_dir_overrides_env_var(
+        self, project: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test that explicit project_dir parameter overrides FAB_PROJ_DIR env var."""
         env_project_dir = tmp_path / "env_project"
         env_project_dir.mkdir()
         (env_project_dir / ".FABulous").mkdir()
-        param_project_dir = tmp_path / "param_project"
-        param_project_dir.mkdir()
-        (param_project_dir / ".FABulous").mkdir()
 
         # Set environment variable
         monkeypatch.setenv("FAB_PROJ_DIR", str(env_project_dir))
 
-        settings = init_context(project_dir=param_project_dir)
+        settings = init_context(project_dir=project)
 
         # The explicit project_dir parameter should override the env var
-        assert settings.proj_dir == param_project_dir
+        assert settings.proj_dir == project
 
-    def test_context_integration_with_real_project_structure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_context_integration_with_real_project_structure(
+        self, project: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test context initialization with realistic project structure."""
-        # Create project structure
-        project_dir = tmp_path / "test_project"
-        project_dir.mkdir()
-        fabulous_project = project_dir / ".FABulous"
-        fabulous_project.mkdir()
-
         # Create global .env file with typical settings
         global_env = tmp_path / "global.env"
-        global_env.write_text(
-            "FAB_YOSYS_PATH=/opt/oss-cad-suite/bin/yosys\n"
-            "FAB_OSS_CAD_SUITE=/opt/oss-cad-suite\n"
-        )
+        global_env.touch()
+        set_key(global_env, "FAB_YOSYS_PATH", "/opt/oss-cad-suite/bin/yosys")
+        set_key(global_env, "FAB_OSS_CAD_SUITE", "/opt/oss-cad-suite")
 
-        project_env = fabulous_project / ".env"
-        project_env.write_text(
-            "FAB_PROJ_LANG=verilog\n"
-            "FAB_PROJ_VERSION_CREATED=1.0.0\n"
-        )
+        project_env = project / ".FABulous" / ".env"
+        project_env.touch()
+        set_key(project_env, "FAB_PROJ_LANG", "verilog")
+        set_key(project_env, "FAB_PROJ_VERSION_CREATED", "1.0.0")
 
         # Clean environment and set required vars
         for key in list(os.environ.keys()):
             if key.startswith("FAB_"):
                 monkeypatch.delenv(key, raising=False)
 
-        monkeypatch.setenv("FAB_PROJ_DIR", str(project_dir))
+        monkeypatch.setenv("FAB_PROJ_DIR", str(project))
 
-        settings = init_context(project_dir=project_dir, global_dot_env=global_env)
+        settings = init_context(project_dir=project, global_dot_env=global_env)
 
-        assert settings.proj_dir == project_dir
+        assert settings.proj_dir == project
         assert settings.proj_lang == "verilog"
         assert settings.proj_version_created == Version("1.0.0")
         assert str(settings.yosys_path) == "/opt/oss-cad-suite/bin/yosys"
@@ -712,7 +686,7 @@ class TestIntegration:
     """Integration tests for FABulous settings functionality with new context system."""
 
     def test_complete_context_workflow(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+        self, project: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
     ) -> None:
         """Test complete workflow from context initialization to settings usage."""
         reset_context()
@@ -722,32 +696,32 @@ class TestIntegration:
             if key.startswith("FAB_"):
                 monkeypatch.delenv(key, raising=False)
 
-        # Set up directory structure
-        proj_dir = tmp_path / "project"
-        proj_dir.mkdir()
-        fabulous_dir = proj_dir / ".FABulous"
-        fabulous_dir.mkdir()
-
         # Create .env files
         global_env = tmp_path / "global.env"
-        global_env.write_text("FAB_PROJ_LANG=vhdl\nFAB_YOSYS_PATH=/custom/yosys\n")
+        global_env.touch()
+        set_key(global_env, "FAB_PROJ_LANG", "vhdl")
+        set_key(global_env, "FAB_YOSYS_PATH", "/custom/yosys")
 
-        project_env = fabulous_dir / ".env"
-        project_env.write_text("FAB_PROJ_VERSION_CREATED=2.0.0\n")
+        # Modify the project's existing .env file instead of creating a new one
+        project_env = project / ".FABulous" / ".env"
+        # Clear existing content and set new values
+        project_env.write_text("")
+        set_key(project_env, "FAB_PROJ_LANG", "vhdl")  # Override to match global for consistency
+        set_key(project_env, "FAB_PROJ_VERSION_CREATED", "2.0.0")
 
         # Set environment variables
-        monkeypatch.setenv("FAB_PROJ_DIR", str(proj_dir))
+        monkeypatch.setenv("FAB_PROJ_DIR", str(project))
 
         mocker.patch("FABulous.FABulous_settings.which", return_value=None)
 
         # Initialize context
-        settings = init_context(project_dir=proj_dir, global_dot_env=global_env)
+        settings = init_context(project_dir=project, global_dot_env=global_env)
 
         # Verify context was initialized correctly
         context = get_context()
         assert context is settings
 
-        assert settings.proj_dir == proj_dir
+        assert settings.proj_dir == project
         assert settings.proj_lang == "vhdl"
         assert settings.proj_version_created == Version("2.0.0")
         assert settings.yosys_path == Path("/custom/yosys")

--- a/tests/utils_test/test_FABulous_settings.py
+++ b/tests/utils_test/test_FABulous_settings.py
@@ -28,17 +28,15 @@ class TestFABulousSettings:
         # Set minimal PATH to avoid system tools
         monkeypatch.setenv("PATH", "/bin:/usr/bin")
 
-        # Set a valid root directory
-        test_root = tmp_path / "fab_root"
-        test_root.mkdir()
-        monkeypatch.setenv("FAB_ROOT", str(test_root))
-
         # Mock which to return None (no tools found)
         mocker.patch("FABulous.FABulous_settings.which", return_value=None)
 
         settings = FABulousSettings()
 
-        assert settings.root == test_root
+        # root now points to the package installation directory
+        assert settings.root.exists() and settings.root.is_dir()
+        # user_config_dir should be created and exist
+        assert settings.user_config_dir.exists() and settings.user_config_dir.is_dir()
         assert settings.yosys_path is None
         assert settings.nextpnr_path is None
         assert settings.iverilog_path is None
@@ -56,15 +54,13 @@ class TestFABulousSettings:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
     ) -> None:
         """Test FABulousSettings initialization with environment variables."""
-        test_root = tmp_path / "test_root"
-        test_root.mkdir()
         test_proj_dir = tmp_path / "test_proj"
         test_proj_dir.mkdir()
 
         # Set minimal PATH to avoid system tools
         monkeypatch.setenv("PATH", "/bin:/usr/bin")
 
-        monkeypatch.setenv("FAB_ROOT", str(test_root))
+        # FAB_ROOT is no longer used, removed
         monkeypatch.setenv("FAB_PROJ_DIR", str(test_proj_dir))
         monkeypatch.setenv("FAB_PROJ_LANG", "vhdl")
         monkeypatch.setenv("FAB_SWITCH_MATRIX_DEBUG_SIGNAL", "true")
@@ -75,7 +71,8 @@ class TestFABulousSettings:
 
         settings = FABulousSettings()
 
-        assert settings.root == test_root
+        # root is now the package directory, not settable via env var
+        assert settings.root.exists() and settings.root.is_dir()
         assert settings.proj_dir == test_proj_dir
         assert settings.proj_lang == "vhdl"
         assert settings.switch_matrix_debug_signal is True

--- a/tests/utils_test/test_FABulous_settings.py
+++ b/tests/utils_test/test_FABulous_settings.py
@@ -1,0 +1,635 @@
+import argparse
+import os
+from pathlib import Path
+
+import pytest
+from packaging.version import Version
+from pytest_mock import MockerFixture
+
+from FABulous.custom_exception import EnvironmentNotSet
+from FABulous.FABulous_settings import (
+    FABulousSettings,
+    setup_global_env_vars,
+    setup_project_env_vars,
+)
+
+
+class TestFABulousSettings:
+    """Test cases for FABulousSettings class."""
+
+    def test_default_initialization(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        """Test FABulousSettings initialization with default values and no environment variables."""
+        # Clear all FAB_ environment variables
+        for key in list(os.environ.keys()):
+            if key.startswith("FAB_"):
+                monkeypatch.delenv(key, raising=False)
+
+        # Set minimal PATH to avoid system tools
+        monkeypatch.setenv("PATH", "/bin:/usr/bin")
+
+        # Set a valid root directory
+        test_root = tmp_path / "fab_root"
+        test_root.mkdir()
+        monkeypatch.setenv("FAB_ROOT", str(test_root))
+
+        # Mock which to return None (no tools found)
+        mocker.patch("FABulous.FABulous_settings.which", return_value=None)
+
+        settings = FABulousSettings()
+
+        assert settings.root == test_root
+        assert settings.yosys_path is None
+        assert settings.nextpnr_path is None
+        assert settings.iverilog_path is None
+        assert settings.vvp_path is None
+        assert settings.proj_dir == Path.cwd()
+        assert settings.fabulator_root is None
+        assert settings.oss_cad_suite is None
+        assert isinstance(settings.proj_version_created, Version)
+        assert settings.proj_version_created == Version("0.0.1")
+        assert isinstance(settings.proj_version, Version)
+        assert settings.proj_lang == "verilog"
+        assert settings.switch_matrix_debug_signal is False
+
+    def test_initialization_with_environment_variables(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        """Test FABulousSettings initialization with environment variables."""
+        test_root = tmp_path / "test_root"
+        test_root.mkdir()
+        test_proj_dir = tmp_path / "test_proj"
+        test_proj_dir.mkdir()
+
+        # Set minimal PATH to avoid system tools
+        monkeypatch.setenv("PATH", "/bin:/usr/bin")
+
+        monkeypatch.setenv("FAB_ROOT", str(test_root))
+        monkeypatch.setenv("FAB_PROJ_DIR", str(test_proj_dir))
+        monkeypatch.setenv("FAB_PROJ_LANG", "vhdl")
+        monkeypatch.setenv("FAB_SWITCH_MATRIX_DEBUG_SIGNAL", "true")
+        monkeypatch.setenv("FAB_PROJ_VERSION_CREATED", "1.2.3")
+
+        # Mock which to return None (no tools found)
+        mocker.patch("FABulous.FABulous_settings.which", return_value=None)
+
+        settings = FABulousSettings()
+
+        assert settings.root == test_root
+        assert settings.proj_dir == test_proj_dir
+        assert settings.proj_lang == "vhdl"
+        assert settings.switch_matrix_debug_signal is True
+        assert settings.proj_version_created == Version("1.2.3")
+
+    def test_initialization_with_tool_paths_found(self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture) -> None:
+        """Test FABulousSettings initialization when tools are found in PATH."""
+        # Clear all FAB_ environment variables
+        for key in list(os.environ.keys()):
+            if key.startswith("FAB_"):
+                monkeypatch.delenv(key, raising=False)
+
+        # Set minimal PATH to avoid system tools
+        monkeypatch.setenv("PATH", "/bin:/usr/bin")
+
+        mock_which = mocker.patch("FABulous.FABulous_settings.which")
+        mock_which.side_effect = lambda tool: {
+            "yosys": "/usr/bin/yosys",
+            "nextpnr-generic": "/usr/bin/nextpnr-generic",
+            "iverilog": "/usr/bin/iverilog",
+            "vvp": "/usr/bin/vvp",
+        }.get(tool)
+
+        settings = FABulousSettings()
+
+        assert settings.yosys_path == Path("/usr/bin/yosys")
+        assert settings.nextpnr_path == Path("/usr/bin/nextpnr-generic")
+        assert settings.iverilog_path == Path("/usr/bin/iverilog")
+        assert settings.vvp_path == Path("/usr/bin/vvp")
+
+    def test_initialization_with_explicit_tool_paths(
+        self, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        """Test FABulousSettings initialization with explicitly set tool paths."""
+        # Clear all FAB_ environment variables first
+        for key in list(os.environ.keys()):
+            if key.startswith("FAB_"):
+                monkeypatch.delenv(key, raising=False)
+
+        # Set minimal PATH to avoid system tools
+        monkeypatch.setenv("PATH", "/bin:/usr/bin")
+
+        yosys_path = "/custom/yosys"
+        nextpnr_path = "/custom/nextpnr-generic"
+
+        monkeypatch.setenv("FAB_YOSYS_PATH", yosys_path)
+        monkeypatch.setenv("FAB_NEXTPNR_PATH", nextpnr_path)
+
+        mocker.patch("FABulous.FABulous_settings.which", return_value=None)
+
+        settings = FABulousSettings()
+
+        assert settings.yosys_path == Path(yosys_path)
+        assert settings.nextpnr_path == Path(nextpnr_path)
+        # Tools not explicitly set should still be resolved via which
+        assert settings.iverilog_path is None
+        assert settings.vvp_path is None
+
+
+class TestFieldValidators:
+    """Test cases for field validators in FABulousSettings."""
+
+    def test_parse_version_str_with_string(self) -> None:
+        """Test parse_version validator with string input."""
+        result = FABulousSettings.parse_version_str("3.4.5")
+        assert isinstance(result, Version)
+        assert result == Version("3.4.5")
+
+    def test_parse_version_with_version_object(self) -> None:
+        """Test parse_version validator with Version object input."""
+        version_obj = Version("4.5.6")
+        result = FABulousSettings.parse_version_str(version_obj)
+        assert isinstance(result, Version)
+        assert result == version_obj
+
+    def test_is_dir_valid_directory(self, tmp_path: Path) -> None:
+        """Test is_dir validator with valid directory."""
+        test_dir = tmp_path / "test_dir"
+        test_dir.mkdir()
+
+        result = FABulousSettings.is_dir(test_dir)
+        assert result == test_dir
+
+    def test_is_dir_invalid_directory(self, tmp_path: Path) -> None:
+        """Test is_dir validator with invalid directory."""
+        non_existent_dir = tmp_path / "non_existent"
+
+        with pytest.raises(ValueError, match="is not a valid directory"):
+            FABulousSettings.is_dir(non_existent_dir)
+
+    def test_is_dir_file_instead_of_directory(self, tmp_path: Path) -> None:
+        """Test is_dir validator with file instead of directory."""
+        test_file = tmp_path / "test_file.txt"
+        test_file.write_text("test content")
+
+        with pytest.raises(ValueError, match="is not a valid directory"):
+            FABulousSettings.is_dir(test_file)
+
+    def test_is_dir_handles_none(self) -> None:
+        """Test is_dir validator correctly handles None values (bug now fixed)."""
+        result = FABulousSettings.is_dir(None)
+        assert result is None
+
+    def test_validate_proj_lang_verilog(self) -> None:
+        """Test validate_proj_lang validator with verilog."""
+        result = FABulousSettings.validate_proj_lang("verilog")
+        assert result == "verilog"
+
+    def test_validate_proj_lang_vhdl(self) -> None:
+        """Test validate_proj_lang validator with vhdl."""
+        result = FABulousSettings.validate_proj_lang("vhdl")
+        assert result == "vhdl"
+
+    def test_validate_proj_lang_invalid(self) -> None:
+        """Test validate_proj_lang validator with invalid language."""
+        with pytest.raises(ValueError, match="Project language must be either 'verilog' or 'vhdl'"):
+            FABulousSettings.validate_proj_lang("python")
+
+    def test_validate_proj_lang_case_sensitive(self) -> None:
+        """Test validate_proj_lang validator is case sensitive."""
+        with pytest.raises(ValueError, match="Project language must be either 'verilog' or 'vhdl'"):
+            FABulousSettings.validate_proj_lang("VERILOG")
+
+
+class TestToolPathResolution:
+    """Test cases for tool path resolution validator."""
+
+    def test_resolve_tool_paths_explicit_value(self, mocker: MockerFixture) -> None:
+        """Test resolve_tool_paths when value is explicitly provided."""
+        explicit_path = Path("/custom/tool/path")
+        mock_info = mocker.Mock()
+        mock_info.field_name = "yosys_path"
+
+        mock_which = mocker.patch("FABulous.FABulous_settings.which")
+        result = FABulousSettings.resolve_tool_paths(explicit_path, mock_info)
+        assert result == explicit_path
+        mock_which.assert_not_called()
+
+    def test_resolve_tool_paths_yosys_found(self, mocker: MockerFixture) -> None:
+        """Test resolve_tool_paths for yosys when tool is found."""
+        mock_info = mocker.Mock()
+        mock_info.field_name = "yosys_path"
+
+        mock_which = mocker.patch("FABulous.FABulous_settings.which", return_value="/usr/bin/yosys")
+
+        result = FABulousSettings.resolve_tool_paths(None, mock_info)
+
+        assert result == Path("/usr/bin/yosys").resolve()
+        mock_which.assert_called_once_with("yosys")
+
+    def test_resolve_tool_paths_nextpnr_found(self, mocker: MockerFixture) -> None:
+        """Test resolve_tool_paths for nextpnr when tool is found."""
+        mock_info = mocker.Mock()
+        mock_info.field_name = "nextpnr_path"
+
+        mock_which = mocker.patch("FABulous.FABulous_settings.which", return_value="/usr/bin/nextpnr-generic")
+
+        result = FABulousSettings.resolve_tool_paths(None, mock_info)
+
+        assert result == Path("/usr/bin/nextpnr-generic").resolve()
+        mock_which.assert_called_once_with("nextpnr-generic")
+
+    def test_resolve_tool_paths_iverilog_found(self, mocker: MockerFixture) -> None:
+        """Test resolve_tool_paths for iverilog when tool is found."""
+        mock_info = mocker.Mock()
+        mock_info.field_name = "iverilog_path"
+
+        mock_which = mocker.patch("FABulous.FABulous_settings.which", return_value="/usr/bin/iverilog")
+
+        result = FABulousSettings.resolve_tool_paths(None, mock_info)
+
+        assert result == Path("/usr/bin/iverilog").resolve()
+        mock_which.assert_called_once_with("iverilog")
+
+    def test_resolve_tool_paths_vvp_found(self, mocker: MockerFixture) -> None:
+        """Test resolve_tool_paths for vvp when tool is found."""
+        mock_info = mocker.Mock()
+        mock_info.field_name = "vvp_path"
+
+        mock_which = mocker.patch("FABulous.FABulous_settings.which", return_value="/usr/bin/vvp")
+
+        result = FABulousSettings.resolve_tool_paths(None, mock_info)
+
+        assert result == Path("/usr/bin/vvp").resolve()
+        mock_which.assert_called_once_with("vvp")
+
+    def test_resolve_tool_paths_tool_not_found(self, mocker: MockerFixture) -> None:
+        """Test resolve_tool_paths when tool is not found in PATH."""
+        mock_info = mocker.Mock()
+        mock_info.field_name = "yosys_path"
+
+        mock_which = mocker.patch("FABulous.FABulous_settings.which", return_value=None)
+
+        result = FABulousSettings.resolve_tool_paths(None, mock_info)
+
+        assert result is None
+        mock_which.assert_called_once_with("yosys")
+
+    def test_resolve_tool_paths_unknown_field(self, mocker: MockerFixture) -> None:
+        """Test resolve_tool_paths with unknown field name."""
+        mock_info = mocker.Mock()
+        mock_info.field_name = "unknown_path"
+
+        mock_which = mocker.patch("FABulous.FABulous_settings.which")
+        result = FABulousSettings.resolve_tool_paths(None, mock_info)
+
+        assert result is None
+        mock_which.assert_not_called()
+
+
+class TestSetupGlobalEnvVars:
+    """Test cases for setup_global_env_vars function."""
+
+    def test_fab_root_not_set_with_fabric_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        """Test setup_global_env_vars when FAB_ROOT is not set and fabric_files exists."""
+        # Create a mock FABulous module structure
+        fab_module_dir = tmp_path / "FABulous"
+        fab_module_dir.mkdir()
+        fabric_files_dir = fab_module_dir / "fabric_files"
+        fabric_files_dir.mkdir()
+
+        # Mock __file__ to point to our test directory
+        mock_file = str(fab_module_dir / "FABulous_settings.py")
+
+        # Clear FAB_ROOT environment variable
+        monkeypatch.delenv("FAB_ROOT", raising=False)
+
+        args = argparse.Namespace(globalDotEnv=None, project_dir=".")
+
+        mocker.patch("FABulous.FABulous_settings.__file__", mock_file)
+        setup_global_env_vars(args)
+
+        assert os.environ["FAB_ROOT"] == str(fab_module_dir)
+
+    def test_fab_root_not_set_fallback_to_parent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        """Test setup_global_env_vars fallback to parent directory when fabric_files doesn't exist."""
+        # Create directory structure without fabric_files
+        fab_module_dir = tmp_path / "FABulous"
+        fab_module_dir.mkdir()
+
+        mock_file = str(fab_module_dir / "FABulous_settings.py")
+
+        monkeypatch.delenv("FAB_ROOT", raising=False)
+
+        args = argparse.Namespace(globalDotEnv=None, project_dir=".")
+
+        mocker.patch("FABulous.FABulous_settings.__file__", mock_file)
+        setup_global_env_vars(args)
+
+        assert os.environ["FAB_ROOT"] == str(tmp_path)
+
+    def test_fab_root_set_existing_directory(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test setup_global_env_vars when FAB_ROOT is already set to existing directory."""
+        test_root = tmp_path / "existing_root"
+        test_root.mkdir()
+
+        monkeypatch.setenv("FAB_ROOT", str(test_root))
+
+        args = argparse.Namespace(globalDotEnv=None, project_dir=".")
+
+        setup_global_env_vars(args)
+
+        assert os.environ["FAB_ROOT"] == str(test_root)
+
+    def test_fab_root_set_with_fabulous_subdirectory(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test setup_global_env_vars when FAB_ROOT has FABulous subdirectory."""
+        test_root = tmp_path / "root"
+        test_root.mkdir()
+        fabulous_dir = test_root / "FABulous"
+        fabulous_dir.mkdir()
+
+        monkeypatch.setenv("FAB_ROOT", str(test_root))
+
+        args = argparse.Namespace(globalDotEnv=None, project_dir=".")
+
+        setup_global_env_vars(args)
+
+        assert os.environ["FAB_ROOT"] == str(fabulous_dir)
+
+    def test_fab_root_set_non_existent_directory(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test setup_global_env_vars exits when FAB_ROOT is set to non-existent directory."""
+        non_existent = "/non/existent/path"
+        monkeypatch.setenv("FAB_ROOT", non_existent)
+
+        args = argparse.Namespace(globalDotEnv=None, project_dir=".")
+
+        with pytest.raises(SystemExit):
+            setup_global_env_vars(args)
+
+    def test_global_dot_env_file_loading(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        """Test loading global .env file when specified."""
+        # Create test .env file
+        env_file = tmp_path / "global.env"
+        env_file.write_text("TEST_VAR=test_value\n")
+
+        # Set up basic environment
+        fab_root = tmp_path / "fab_root"
+        fab_root.mkdir()
+        monkeypatch.setenv("FAB_ROOT", str(fab_root))
+
+        args = argparse.Namespace(globalDotEnv=str(env_file), project_dir=".")
+
+        mock_load_dotenv = mocker.patch("FABulous.FABulous_settings.load_dotenv")
+        setup_global_env_vars(args)
+        mock_load_dotenv.assert_called_once_with(env_file)
+
+    def test_global_dot_env_directory_with_env_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        """Test loading .env file from specified directory."""
+        # Create directory with .env file
+        env_dir = tmp_path / "env_dir"
+        env_dir.mkdir()
+        env_file = env_dir / ".env"
+        env_file.write_text("TEST_VAR=test_value\n")
+
+        fab_root = tmp_path / "fab_root"
+        fab_root.mkdir()
+        monkeypatch.setenv("FAB_ROOT", str(fab_root))
+
+        args = argparse.Namespace(globalDotEnv=str(env_dir), project_dir=".")
+
+        mock_load_dotenv = mocker.patch("FABulous.FABulous_settings.load_dotenv")
+        setup_global_env_vars(args)
+        mock_load_dotenv.assert_called_once_with(env_file)
+
+    def test_proj_dir_env_var_setting(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test setting FAB_PROJ_DIR environment variable."""
+        fab_root = tmp_path / "fab_root"
+        fab_root.mkdir()
+        monkeypatch.setenv("FAB_ROOT", str(fab_root))
+        monkeypatch.delenv("FAB_PROJ_DIR", raising=False)
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        args = argparse.Namespace(globalDotEnv=None, project_dir=str(project_dir))
+
+        setup_global_env_vars(args)
+
+        assert os.environ["FAB_PROJ_DIR"] == str(project_dir.absolute())
+
+    def test_oss_cad_suite_path_export(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test exporting oss-cad-suite bin path to PATH."""
+        fab_root = tmp_path / "fab_root"
+        fab_root.mkdir()
+        oss_cad_path = tmp_path / "oss-cad-suite"
+        oss_cad_path.mkdir()
+
+        monkeypatch.setenv("FAB_ROOT", str(fab_root))
+        monkeypatch.setenv("FAB_OSS_CAD_SUITE", str(oss_cad_path))
+
+        original_path = os.environ.get("PATH", "")
+
+        args = argparse.Namespace(globalDotEnv=None, project_dir=".")
+
+        setup_global_env_vars(args)
+
+        expected_path = original_path + os.pathsep + str(oss_cad_path) + "/bin"
+        assert os.environ["PATH"] == expected_path
+
+
+class TestSetupProjectEnvVars:
+    """Test cases for setup_project_env_vars function."""
+
+    def test_fab_proj_dir_not_set_raises_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test setup_project_env_vars raises exception when FAB_PROJ_DIR not set."""
+        monkeypatch.delenv("FAB_PROJ_DIR", raising=False)
+
+        args = argparse.Namespace(projectDotEnv=None, writer=None)
+
+        with pytest.raises(EnvironmentNotSet, match="FAB_PROJ_DIR environment variable not set"):
+            setup_project_env_vars(args)
+
+    def test_project_dot_env_file_loading(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        """Test loading project .env file when specified."""
+        proj_dir = tmp_path / "project"
+        proj_dir.mkdir()
+        env_file = proj_dir / "project.env"
+        env_file.write_text("PROJECT_VAR=project_value\n")
+
+        monkeypatch.setenv("FAB_PROJ_DIR", str(proj_dir))
+
+        args = argparse.Namespace(projectDotEnv=str(env_file), writer=None)
+
+        mock_load_dotenv = mocker.patch("FABulous.FABulous_settings.load_dotenv")
+        setup_project_env_vars(args)
+        mock_load_dotenv.assert_called_once_with(env_file)
+
+    def test_fabulous_dot_env_loading(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        """Test loading .env from .FABulous directory."""
+        proj_dir = tmp_path / "project"
+        proj_dir.mkdir()
+        fabulous_dir = proj_dir / ".FABulous"
+        fabulous_dir.mkdir()
+        env_file = fabulous_dir / ".env"
+        env_file.write_text("FABULOUS_VAR=fabulous_value\n")
+
+        monkeypatch.setenv("FAB_PROJ_DIR", str(proj_dir))
+
+        args = argparse.Namespace(projectDotEnv=None, writer=None)
+
+        mock_load_dotenv = mocker.patch("FABulous.FABulous_settings.load_dotenv")
+        setup_project_env_vars(args)
+        mock_load_dotenv.assert_called_once_with(env_file)
+
+    def test_parent_dot_env_loading(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        """Test loading .env from parent directory when .FABulous/.env doesn't exist."""
+        proj_dir = tmp_path / "project"
+        proj_dir.mkdir()
+        fabulous_dir = proj_dir / ".FABulous"
+        fabulous_dir.mkdir()
+        env_file = proj_dir / ".env"
+        env_file.write_text("PARENT_VAR=parent_value\n")
+
+        monkeypatch.setenv("FAB_PROJ_DIR", str(proj_dir))
+
+        args = argparse.Namespace(projectDotEnv=None, writer=None)
+
+        mock_load_dotenv = mocker.patch("FABulous.FABulous_settings.load_dotenv")
+        setup_project_env_vars(args)
+        mock_load_dotenv.assert_called_once_with(env_file)
+
+    def test_writer_override_project_lang(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test writer argument overrides FAB_PROJ_LANG environment variable."""
+        proj_dir = tmp_path / "project"
+        proj_dir.mkdir()
+
+        monkeypatch.setenv("FAB_PROJ_DIR", str(proj_dir))
+        monkeypatch.setenv("FAB_PROJ_LANG", "verilog")
+
+        args = argparse.Namespace(projectDotEnv=None, writer="vhdl")
+
+        setup_project_env_vars(args)
+
+        assert os.environ["FAB_PROJ_LANG"] == "vhdl"
+
+    def test_writer_no_override_when_same(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test writer argument doesn't override when same as current value."""
+        proj_dir = tmp_path / "project"
+        proj_dir.mkdir()
+
+        monkeypatch.setenv("FAB_PROJ_DIR", str(proj_dir))
+        monkeypatch.setenv("FAB_PROJ_LANG", "vhdl")
+
+        args = argparse.Namespace(projectDotEnv=None, writer="vhdl")
+
+        # Should not generate warning when values are the same
+        setup_project_env_vars(args)
+
+        assert os.environ["FAB_PROJ_LANG"] == "vhdl"
+
+
+class TestIntegration:
+    """Integration tests for FABulous settings functionality."""
+
+    def test_complete_environment_setup_workflow(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        """Test complete workflow from environment setup to settings creation."""
+        # Clear all FAB_ environment variables first
+        for key in list(os.environ.keys()):
+            if key.startswith("FAB_"):
+                monkeypatch.delenv(key, raising=False)
+
+        # Set up directory structure
+        fab_root = tmp_path / "FABulous"
+        fab_root.mkdir()
+        fabric_files_dir = fab_root / "fabric_files"
+        fabric_files_dir.mkdir()
+
+        proj_dir = tmp_path / "project"
+        proj_dir.mkdir()
+        fabulous_dir = proj_dir / ".FABulous"
+        fabulous_dir.mkdir()
+
+        # Create .env files
+        global_env = fab_root / ".env"
+        global_env.write_text("FAB_PROJ_LANG=vhdl\nFAB_YOSYS_PATH=/custom/yosys\n")
+
+        project_env = fabulous_dir / ".env"
+        project_env.write_text("FAB_PROJ_VERSION_CREATED=2.0.0\n")
+
+        # Mock __file__ location
+        mock_file = str(fab_root / "FABulous_settings.py")
+
+        args = argparse.Namespace(globalDotEnv=None, project_dir=str(proj_dir), projectDotEnv=None, writer=None)
+
+        mocker.patch("FABulous.FABulous_settings.__file__", mock_file)
+        mocker.patch("FABulous.FABulous_settings.which", return_value=None)
+
+        # Set up global environment
+        setup_global_env_vars(args)
+
+        # Set up project environment
+        setup_project_env_vars(args)
+
+        # Create settings instance
+        settings = FABulousSettings()
+
+        assert settings.root == fab_root
+        assert settings.proj_dir == proj_dir
+        assert settings.proj_lang == "vhdl"
+        assert settings.proj_version_created == Version("2.0.0")
+        assert settings.yosys_path == Path("/custom/yosys")
+
+    def test_tool_resolution_with_environment_setup(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+    ) -> None:
+        """Test tool path resolution after oss-cad-suite PATH setup."""
+        # Clear all FAB_ environment variables first
+        for key in list(os.environ.keys()):
+            if key.startswith("FAB_"):
+                monkeypatch.delenv(key, raising=False)
+
+        # Set minimal PATH to avoid system tools
+        monkeypatch.setenv("PATH", "/bin:/usr/bin")
+
+        fab_root = tmp_path / "fab_root"
+        fab_root.mkdir()
+        oss_cad_path = tmp_path / "oss-cad-suite"
+        oss_cad_bin = oss_cad_path / "bin"
+        oss_cad_bin.mkdir(parents=True)
+
+        # Create mock tools
+        yosys_tool = oss_cad_bin / "yosys"
+        yosys_tool.write_text("#!/bin/bash\necho yosys")
+        yosys_tool.chmod(0o755)
+
+        monkeypatch.setenv("FAB_ROOT", str(fab_root))
+        monkeypatch.setenv("FAB_OSS_CAD_SUITE", str(oss_cad_path))
+
+        args = argparse.Namespace(globalDotEnv=None, project_dir=".")
+
+        # Set up environment (this should add oss-cad-suite/bin to PATH)
+        setup_global_env_vars(args)
+
+        # Now create settings - tools should be found in PATH
+        mock_which = mocker.patch("FABulous.FABulous_settings.which")
+        mock_which.side_effect = lambda tool: str(oss_cad_bin / tool) if tool == "yosys" else None
+
+        settings = FABulousSettings()
+
+        assert settings.yosys_path == Path(str(oss_cad_bin / "yosys")).resolve()

--- a/tests/utils_test/test_yosys_obj.py
+++ b/tests/utils_test/test_yosys_obj.py
@@ -100,7 +100,9 @@ def test_yosys_json_initialization_parametric(
     # Mock external dependencies
     m = mocker.patch(
         "subprocess.run",
-        return_value=type("MockResult", (), {"stdout": b"mock output", "stderr": b""})(),
+        return_value=type(
+            "MockResult", (), {"stdout": b"mock output", "stderr": b""}
+        )(),
     )
 
     # Apply environment if provided (e.g., force VHDL mode)
@@ -144,7 +146,9 @@ def test_yosys_json_initialization_parametric(
             assert needle in str(m.call_args_list[idx])
 
 
-def test_yosys_json_file_not_exists(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_yosys_json_file_not_exists(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Test YosysJson with unsupported file type."""
     setup_mocks(monkeypatch, {})
     fakePath = tmp_path / "file.txt"
@@ -152,7 +156,9 @@ def test_yosys_json_file_not_exists(monkeypatch: pytest.MonkeyPatch, tmp_path: P
         YosysJson(fakePath)
 
 
-def test_yosys_json_unsupported_file_type(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_yosys_json_unsupported_file_type(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Test YosysJson with unsupported file type."""
     setup_mocks(monkeypatch, {})
     fakePath = tmp_path / "file.txt"

--- a/uv.lock
+++ b/uv.lock
@@ -110,6 +110,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215 },
+]
+
+[[package]]
 name = "cmd2"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -253,6 +265,7 @@ dependencies = [
     { name = "pyreadline3", marker = "sys_platform == 'win32'" },
     { name = "python-dotenv" },
     { name = "requests" },
+    { name = "typer" },
 ]
 
 [package.dev-dependencies]
@@ -281,6 +294,7 @@ requires-dist = [
     { name = "pyreadline3", marker = "sys_platform == 'win32'", specifier = ">=3.4.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "requests", specifier = ">=2.0.0" },
+    { name = "typer", specifier = ">=0.16.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -727,6 +741,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755 },
+]
+
+[[package]]
 name = "taskipy"
 version = "1.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -780,6 +803,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724 },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383 },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
+]
+
+[[package]]
+name = "typer"
+version = "0.17.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/82/f4bfed3bc18c6ebd6f828320811bbe4098f92a31adf4040bee59c4ae02ea/typer-0.17.3.tar.gz", hash = "sha256:0c600503d472bcf98d29914d4dcd67f80c24cc245395e2e00ba3603c9332e8ba", size = 103517 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/e8/b3d537470e8404659a6335e7af868e90657efb73916ef31ddf3d8b9cb237/typer-0.17.3-py3-none-any.whl", hash = "sha256:643919a79182ab7ac7581056d93c6a2b865b026adf2872c4d02c72758e6f095b", size = 46494 },
 ]
 
 [[package]]


### PR DESCRIPTION
Updated the context management to use `get_context` only, and this will only create the model once and automatically resolve all environment dependencies. This can be used as the base for all feature global settings. 

Removed dependency on `FAB_ROOT`. Now the project does not reference the installation dir directly. Project creation is now done via the `importlib.resources`. Global `.env` is now stored at user `$HOME/.fabulous`. And this can be used for all future installations and FABulous related cross-session assets. 

Transition from `argparse` based command to `typer`, which offers a much better looking interface and help message. This also makes creating new commands down the line much easier, such as `FABulous GUI` etc.  Full backwards compatibility in the interface is maintained, but we should drop it soon. 

<img width="1488" height="618" alt="image" src="https://github.com/user-attachments/assets/371bb96c-3b2c-4e96-86f5-e622ecff2b84" />


There are other bonuses from `typer` such as auto-complete install, but I have not tested them yet. 