### PR TITLE
fix(docs): uv support for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,13 +5,15 @@ build:
   tools:
     python: "3.12"
 
-python:
-  # Install our python package before building the docs
-  install:
-    - requirements: docs/requirements.txt
-
-#conda:
-#  environment: docs/environment.yml
+  jobs:
+    post_create_environment:
+      # Install uv
+      - pip install uv
+    post_install:
+      # Install dependencies with 'docs' dependency group
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv pip install ./docs
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -21,3 +23,4 @@ sphinx:
 formats:
   - pdf
   - epub
+


### PR DESCRIPTION
Switch to uv bricked the RTD build. 
This should fix it. 

And should also add docs preview for PRs. 