### PR TITLE
chore[ci]: Set repository scope for token generaion for release please workflow

### DIFF
--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -20,6 +20,7 @@ jobs:
         app-id: ${{ vars.RP_APP_ID }}
         private-key: ${{ secrets.RP_APP_PK }}
         owner: ${{ github.repository_owner }}
+        repositories: ${{ github.event.repository.name }}
     - uses: googleapis/release-please-action@v4
       id: release
       with:


### PR DESCRIPTION
This might fix the error for the token generation, since no scope for the token was defined,
so it tried to generate a token for the whole Organization, which is not allowed for the APP.