### PR TITLE
chore: Remove deprecated individually declared flag in BEL parsing

### DIFF
--- a/FABulous/fabric_definition/Bel.py
+++ b/FABulous/fabric_definition/Bel.py
@@ -51,8 +51,6 @@ class Bel:
         The feature map of the BEL.
     withUserCLK : bool
         Whether the BEL has userCLK port. Default is False.
-    individually_declared : bool
-        Indicates if ports are individually declared. Default is False.
     ports_vectors: dict[str, dict[str, tuple[IO, int]]]
         Dict structure to save vectorized port information
         {<porttype>:{<portname>:(IO, <portwidth>)}}
@@ -80,7 +78,6 @@ class Bel:
     language: str
     belFeatureMap: dict[str, dict] = field(default_factory=dict)
     withUserCLK: bool = False
-    individually_declared: bool = False
     ports_vectors: dict[str, dict[str, tuple[IO, int]]] = field(default_factory=dict)
     carry: dict[str, dict[IO, str]] = field(default_factory=dict)
     localShared: dict[str, tuple[str, IO]] = field(default_factory=dict)
@@ -97,7 +94,6 @@ class Bel:
         configBit: int,
         belMap: dict[str, dict],
         userCLK: bool,
-        individually_declared: bool,
         ports_vectors: dict[str, dict[str, tuple[IO, int]]],
         carry: dict[str, dict[IO, str]],
         localShared: dict[str, tuple[str, IO]],
@@ -115,7 +111,6 @@ class Bel:
         self.configBit = configBit
         self.belFeatureMap = belMap
         self.withUserCLK = userCLK
-        self.individually_declared = individually_declared
         self.ports_vectors = ports_vectors
         if self.src.suffix in [".sv", ".v"]:
             self.language = "verilog"

--- a/FABulous/fabric_generator/gen_fabric/gen_tile.py
+++ b/FABulous/fabric_generator/gen_fabric/gen_tile.py
@@ -374,26 +374,17 @@ def generateTile(writer: CodeGenerator, fabric: Fabric, tile: Tile) -> None:
             else:
                 portsPairs.append((port[0], port[0]))
 
-        if bel.individually_declared:
-            for portname, ports in port_dict.items():
-                for port, number in ports:
-                    # If there's a number, include it in the port name.
-                    if number:
-                        portsPairs.append((f"{portname}{number}", port))
-                    else:
-                        portsPairs.append((portname, port))
-        else:
-            for portname, ports in port_dict.items():
-                if len(ports) > 1:
-                    # Sort ports based on bit significance.
-                    ports.sort(key=lambda x: int(x[1]) if x[1].isdigit() else -1)
-                    # Concatenate the ports in the correct order.
-                    concatenated_ports = ", ".join(port for port, _ in ports[::-1])
-                    portsPairs.append((portname, f"{{{concatenated_ports}}}"))
-                else:
-                    # Single port, no need for concatenation.
-                    single_port = ports[0][0]
-                    portsPairs.append((portname, single_port))
+        for portname, ports in port_dict.items():
+            if len(ports) > 1:
+                # Sort ports based on bit significance.
+                ports.sort(key=lambda x: int(x[1]) if x[1].isdigit() else -1)
+                # Concatenate the ports in the correct order.
+                concatenated_ports = ", ".join(port for port, _ in ports[::-1])
+                portsPairs.append((portname, f"{{{concatenated_ports}}}"))
+            else:
+                # Single port, no need for concatenation.
+                single_port = ports[0][0]
+                portsPairs.append((portname, single_port))
 
         # Makes sure UserCLK is after ports.
         if userclk_pair is not None:

--- a/FABulous/fabric_generator/parser/parse_hdl.py
+++ b/FABulous/fabric_generator/parser/parse_hdl.py
@@ -173,7 +173,6 @@ def parseBelFile(
     carry: dict[str, dict[IO, str]] = {}
     carryPrefix: str = ""
     userClk = False
-    individually_declared = False
     noConfigBits = 0
     belMapDic = {}
     ports_vectors: dict[str, dict[str, tuple[IO, int]]] = {}
@@ -197,11 +196,6 @@ def parseBelFile(
             continue
         if "UserCLK" in port_name:
             userClk = True
-        if port_name[-1].isdigit():
-            # FIXME:  This is a temporary fix for the issue where the ports are
-            # individually declared. Check for the last charcter in portname is
-            # not really reliable and sould be handeled more rubust in the future.
-            individually_declared = True
         direction = IO[details.direction.upper()]
         filtered_ports[port_name] = (direction, details.bits)
 
@@ -299,7 +293,6 @@ def parseBelFile(
         configBit=noConfigBits,
         belMap=belMapDic,
         userCLK=userClk,
-        individually_declared=individually_declared,
         ports_vectors=ports_vectors,
         carry=carry,
         localShared=localSharedPorts,


### PR DESCRIPTION
The `individually_declared` flag was a legacy fix, before we had the Yosys based parsing for both, Verilog and VHDL.