### PR TITLE
feat: add standard-cell spec and switch-matrix construct

### DIFF
--- a/fabulous/fabric_definition/cell_spec.py
+++ b/fabulous/fabric_definition/cell_spec.py
@@ -1,0 +1,230 @@
+"""Standard-cell specifications for timing characterization.
+
+A standard-cell library (:class:`StdCellLibrary`) bundles everything the timing
+flow needs for one PDK: the liberty timing files, the Yosys techmap files, and
+the standard cells the synthesizer maps onto, grouped by the logical function
+they fill (:class:`CellFunction`). Each cell is a :class:`CellSpec` -- its name
+plus the ports a cell-mapping tool needs, with room to grow more metadata.
+
+The library is parsed (and validated) from one ``pdk::<variant>`` section of the
+project's ``Fabric/std_cell_library.yaml`` via :meth:`StdCellLibrary.load`, so a
+PDK is characterized -- or repointed -- by editing that file instead of changing
+code. Liberty/techmap paths may be absolute, relative to the project directory,
+or reference ``${VAR}`` placeholders (e.g. ``${PDK_ROOT}``, ``${PDK}``) that the
+caller resolves from the active settings. Add a section to characterize another
+PDK, and add a member to :class:`CellFunction` (with a matching ``cells`` key) to
+teach it a new cell type.
+"""
+
+import re
+from enum import StrEnum
+from pathlib import Path
+from typing import Self
+
+import yaml
+from pydantic import BaseModel, ConfigDict, RootModel, ValidationInfo, field_validator
+
+STD_CELL_LIBRARY_RELPATH = Path("Fabric") / "std_cell_library.yaml"
+"""Project-relative path to the per-PDK standard-cell library file."""
+
+_VARIABLE_PATTERN = re.compile(r"\$\{(\w+)\}")
+
+
+def _expand_variables(raw: str, variables: dict[str, str]) -> str:
+    """Substitute ``${VAR}`` placeholders in ``raw`` with ``variables`` values.
+
+    Parameters
+    ----------
+    raw : str
+        The string to expand, possibly containing ``${VAR}`` placeholders.
+    variables : dict[str, str]
+        Placeholder name to value mapping (e.g. ``{"PDK_ROOT": "/pdks"}``).
+
+    Returns
+    -------
+    str
+        ``raw`` with every placeholder replaced by its value.
+
+    Raises
+    ------
+    ValueError
+        If ``raw`` references a placeholder not present in ``variables``.
+    """
+    for name in _VARIABLE_PATTERN.findall(raw):
+        if name not in variables:
+            available = ", ".join(sorted(variables)) or "none"
+            raise ValueError(
+                f"Unknown variable '${{{name}}}' in path {raw!r}. "
+                f"Available variables: {available}."
+            )
+    return _VARIABLE_PATTERN.sub(lambda match: variables[match.group(1)], raw)
+
+
+class CellFunction(StrEnum):
+    """The logical role a standard cell fills during timing characterization.
+
+    The members are the keys of a library's ``cells`` mapping and the argument
+    to :meth:`StdCellLibrary.get`; they are the extension point for new cell
+    types.
+    """
+
+    BUFFER = "buffer"
+    TIE_HIGH = "tie_high"
+    TIE_LOW = "tie_low"
+    LATCH = "latch"
+    MUX = "mux"
+
+
+class CellSpec(BaseModel):
+    """A standard cell and the ports a cell-mapping tool needs to use it.
+
+    ``cell`` is the standard-cell name; ``input_ports`` and ``output_ports`` list
+    its ports (a buffer has one of each, a tie cell only an output, and cells
+    with several inputs/outputs list them all). Add further fields -- drive
+    strength, area, ... -- as more cell metadata is needed.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    cell: str
+    input_ports: tuple[str, ...] = ()
+    output_ports: tuple[str, ...] = ()
+
+    @property
+    def yosys_arg(self) -> str:
+        """Render the cell and its ports as a Yosys cell-mapping argument.
+
+        Returns
+        -------
+        str
+            The cell followed by its input ports then output ports, as Yosys
+            options such as ``insbuf -buf`` and ``hilomap`` expect: a buffer
+            renders ``"buf_1 A X"``, a tie cell ``"conb_1 HI"``.
+        """
+        return " ".join((self.cell, *self.input_ports, *self.output_ports))
+
+
+class StdCellLibrary(BaseModel):
+    """A PDK's standard-cell library for timing characterization.
+
+    Bundles the liberty timing files and Yosys techmap files with the cells the
+    synthesizer maps onto, grouped by function. A function may map to several
+    cells (e.g. multiple buffers); use :meth:`get` to fetch them. Liberty and
+    techmap entries accept ``${VAR}`` placeholders and relative paths, resolved
+    against the validation context supplied by :meth:`load`.
+    """
+
+    liberty_files: list[Path] = []
+    techmap_files: list[Path] = []
+    cells: dict[CellFunction, list[CellSpec]] = {}
+
+    @field_validator("liberty_files", "techmap_files", mode="before")
+    @classmethod
+    def _resolve_path_list(cls, value: object, info: ValidationInfo) -> object:
+        """Expand ``${VAR}`` placeholders and resolve relative path entries.
+
+        Placeholder values and the base directory for relative entries come from
+        the validation context (``variables`` and ``base_dir``); absolute paths
+        are left untouched.
+
+        Parameters
+        ----------
+        value : object
+            The raw field value: a path string or a list of path strings.
+        info : ValidationInfo
+            Validation context carrying ``variables`` and ``base_dir``.
+
+        Returns
+        -------
+        object
+            The list of resolved paths.
+        """
+        if value is None:
+            return []
+        if isinstance(value, (str, Path)):
+            value = [value]
+
+        context = info.context or {}
+        variables: dict[str, str] = context.get("variables", {})
+        base_dir = context.get("base_dir")
+
+        resolved: list[Path] = []
+        for entry in value:
+            path = Path(_expand_variables(str(entry), variables)).expanduser()
+            if not path.is_absolute() and base_dir is not None:
+                path = Path(base_dir) / path
+            resolved.append(path)
+        return resolved
+
+    def get(self, function: CellFunction) -> list[CellSpec]:
+        """Return the cells declared for ``function``.
+
+        Parameters
+        ----------
+        function : CellFunction
+            The logical role to look up.
+
+        Returns
+        -------
+        list[CellSpec]
+            The cells declared for ``function`` in declaration order, empty when
+            the library declares none.
+        """
+        return self.cells.get(function, [])
+
+    @classmethod
+    def load(
+        cls, project_dir: Path, pdk: str, variables: dict[str, str] | None = None
+    ) -> Self:
+        """Load the standard-cell library for ``pdk`` from the project file.
+
+        Parameters
+        ----------
+        project_dir : Path
+            Project directory containing ``Fabric/std_cell_library.yaml``.
+        pdk : str
+            Active PDK variant name, matched against a ``pdk::<name>`` section.
+        variables : dict[str, str] | None
+            Placeholder values for ``${VAR}`` references in liberty/techmap
+            paths (e.g. ``{"PDK_ROOT": ..., "PDK": ...}``); None for no
+            placeholders.
+
+        Returns
+        -------
+        Self
+            The standard-cell library for the PDK.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the standard-cell library file does not exist.
+        ValueError
+            If the file has no section for ``pdk`` or the section is malformed.
+        """
+        config_path = project_dir / STD_CELL_LIBRARY_RELPATH
+        if not config_path.exists():
+            raise FileNotFoundError(
+                f"Standard-cell library file not found at {config_path}. It ships "
+                "with the project template; add one to characterize timing."
+            )
+
+        data = yaml.safe_load(config_path.read_text()) or {}
+        section = data.get(f"pdk::{pdk}")
+        if section is None:
+            raise ValueError(
+                f"No 'pdk::{pdk}' section in {config_path}. "
+                "Add a section for this PDK to characterize its timing."
+            )
+        resolved_vars = {"PROJ_DIR": str(project_dir), **(variables or {})}
+        return cls.model_validate(
+            section,
+            context={"variables": resolved_vars, "base_dir": project_dir},
+        )
+
+
+class StdCellLibraryFile(RootModel[dict[str, StdCellLibrary]]):
+    """The on-disk standard-cell library config: ``pdk::<variant>`` sections.
+
+    Maps each ``pdk::<variant>`` section name to its :class:`StdCellLibrary`.
+    Used to emit the JSON schema for ``Fabric/std_cell_library.yaml``.
+    """

--- a/fabulous/fabric_definition/fabric.py
+++ b/fabulous/fabric_definition/fabric.py
@@ -682,6 +682,25 @@ class Fabric:
 
         return result
 
+    def get_super_tile_containing(self, tile_name: str) -> SuperTile | None:
+        """Return the SuperTile that contains the named tile, if any.
+
+        Parameters
+        ----------
+        tile_name : str
+            Name of the (sub-)tile to look up.
+
+        Returns
+        -------
+        SuperTile | None
+            The SuperTile whose constituent tiles include ``tile_name``, or None
+            if the tile is not part of any SuperTile.
+        """
+        for super_tile in self.superTileDic.values():
+            if any(tile.name == tile_name for tile in super_tile.tiles):
+                return super_tile
+        return None
+
     def get_tile_row_column_indices(self, tile_name: str) -> tuple[set[int], set[int]]:
         """Get all row and column indices where a tile type appears.
 

--- a/fabulous/fabric_definition/switch_matrix.py
+++ b/fabulous/fabric_definition/switch_matrix.py
@@ -1,0 +1,71 @@
+"""Switch matrix construct for the FABulous fabric model.
+
+A tile's switch matrix is the programmable interconnect: which sources may drive
+each destination inside the tile. The connectivity is declared in the tile's
+matrix file (a ``.csv`` adjacency matrix or a ``.list`` of pairs) and parsed by
+:mod:`fabulous.fabric_generator.parser.parse_switchmatrix`. This light dataclass
+gives that switch matrix a first-class home in the fabric model so callers work
+with a ``SwitchMatrix`` object instead of re-deriving the file dispatch and
+parsing at every site.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from fabulous.custom_exception import InvalidFileType
+
+
+@dataclass
+class SwitchMatrix:
+    """A tile's switch matrix: its programmable interconnect connectivity.
+
+    Attributes
+    ----------
+    name : str
+        Tile name. Must match the top-left header cell of a ``.csv`` matrix.
+    matrix_dir : Path
+        Path to the matrix file, either a `.csv` adjacency matrix or a
+        `.list` of connection pairs.
+    config_bits : int
+        Number of configuration bits the switch matrix occupies, by default 0.
+    """
+
+    name: str
+    matrix_dir: Path
+    config_bits: int = 0
+
+    def pips(self) -> list[tuple[str, str]]:
+        """Return the switch-matrix connection pairs as ``(source, sink)`` tuples.
+
+        Both file formats are normalized to the same list of pairs, in the order
+        the file declares them.
+
+        Returns
+        -------
+        list[tuple[str, str]]
+            One ``(source, sink)`` tuple per programmable connection.
+
+        Raises
+        ------
+        InvalidFileType
+            If the matrix file is neither a ``.csv`` nor a ``.list`` file.
+        """
+        # Function-local import keeps fabric_definition free of a module-level
+        # dependency on fabric_generator (the same pattern Tile uses for its GDS
+        # import); the parser itself only depends on custom_exception.
+        from fabulous.fabric_generator.parser.parse_switchmatrix import (
+            parseList,
+            parseMatrix,
+        )
+
+        suffix = self.matrix_dir.suffix
+        if suffix == ".csv":
+            connections = parseMatrix(self.matrix_dir, self.name)
+            return [
+                (source, sink)
+                for source, sinks in connections.items()
+                for sink in sinks
+            ]
+        if suffix == ".list":
+            return parseList(self.matrix_dir)
+        raise InvalidFileType(f"File {self.matrix_dir} is not a .csv or .list file")

--- a/fabulous/fabric_definition/tile.py
+++ b/fabulous/fabric_definition/tile.py
@@ -9,6 +9,7 @@ from fabulous.fabric_definition.bel import Bel
 from fabulous.fabric_definition.define import IO, Direction, PinSortMode, Side
 from fabulous.fabric_definition.gen_io import Gen_IO
 from fabulous.fabric_definition.port import Port
+from fabulous.fabric_definition.switch_matrix import SwitchMatrix
 from fabulous.fabric_definition.wire import Wire
 
 if TYPE_CHECKING:
@@ -310,6 +311,17 @@ class Tile:
             and p.wireDirection not in (Direction.JUMP, Direction.SJUMP)
             and p.inOut == IO.OUTPUT
         ]
+
+    @property
+    def switch_matrix(self) -> SwitchMatrix:
+        """Get the tile's switch matrix as a fabric-model construct.
+
+        Returns
+        -------
+        SwitchMatrix
+            The switch matrix wrapping this tile's matrix file and config bits.
+        """
+        return SwitchMatrix(self.name, self.matrixDir, self.matrixConfigBits)
 
     @property
     def globalConfigBits(self) -> int:

--- a/fabulous/fabric_files/FABulous_project_template_common/Fabric/std_cell_library.yaml
+++ b/fabulous/fabric_files/FABulous_project_template_common/Fabric/std_cell_library.yaml
@@ -1,0 +1,96 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/FPGA-Research/FABulous/main/schema/std_cell_library.schema.json
+#
+# Standard-cell library for timing characterization, per PDK variant.
+#
+# Each `pdk::<variant>` section is a standard-cell library: the liberty + techmap
+# files the timing flow needs, and the cells the synthesizer maps onto, grouped
+# by function. Add a section to characterize another PDK.
+#
+#   liberty_files : paths to the liberty (.lib) timing files (required).
+#   techmap_files : paths to the Yosys techmap files (optional).
+#   cells         : standard cells grouped by function. A function may list more
+#                   than one cell; the first is used. Each cell has a `cell` name
+#                   and its `input_ports` / `output_ports` lists (extend with more
+#                   fields as further cell metadata is needed). Recognized
+#                   functions: buffer (required), tie_high, tie_low.
+#
+# Paths may be absolute, relative to the project directory, or use ${VAR}
+# placeholders resolved from the active FABulous settings:
+#   ${PDK_ROOT} -> FAB_PDK_ROOT (the PDK family directory)
+#   ${PDK}      -> FAB_PDK       (the active PDK variant)
+#   ${PROJ_DIR} -> the project directory
+# The defaults below point into the PDK install via ${PDK_ROOT}/${PDK}.
+
+pdk::sky130A:
+  liberty_files:
+    - ${PDK_ROOT}/${PDK}/libs.ref/sky130_fd_sc_hd/lib/sky130_fd_sc_hd__tt_025C_1v80.lib
+  techmap_files:
+    - ${PDK_ROOT}/${PDK}/libs.tech/openlane/sky130_fd_sc_hd/latch_map.v
+    - ${PDK_ROOT}/${PDK}/libs.tech/openlane/sky130_fd_sc_hd/tribuff_map.v
+  cells:
+    buffer:
+      - cell: sky130_fd_sc_hd__buf_1
+        input_ports: [A]
+        output_ports: [X]
+    tie_high:
+      - cell: sky130_fd_sc_hd__conb_1
+        output_ports: [HI]
+    tie_low:
+      - cell: sky130_fd_sc_hd__conb_1
+        output_ports: [LO]
+
+pdk::sky130B:
+  liberty_files:
+    - ${PDK_ROOT}/${PDK}/libs.ref/sky130_fd_sc_hd/lib/sky130_fd_sc_hd__tt_025C_1v80.lib
+  techmap_files:
+    - ${PDK_ROOT}/${PDK}/libs.tech/openlane/sky130_fd_sc_hd/latch_map.v
+    - ${PDK_ROOT}/${PDK}/libs.tech/openlane/sky130_fd_sc_hd/tribuff_map.v
+  cells:
+    buffer:
+      - cell: sky130_fd_sc_hd__buf_1
+        input_ports: [A]
+        output_ports: [X]
+    tie_high:
+      - cell: sky130_fd_sc_hd__conb_1
+        output_ports: [HI]
+    tie_low:
+      - cell: sky130_fd_sc_hd__conb_1
+        output_ports: [LO]
+
+pdk::ihp-sg13g2:
+  liberty_files:
+    - ${PDK_ROOT}/${PDK}/libs.ref/sg13g2_stdcell/lib/sg13g2_stdcell_typ_1p20V_25C.lib
+  techmap_files:
+    - ${PDK_ROOT}/${PDK}/libs.tech/librelane/sg13g2_stdcell/latch_map.v
+    - ${PDK_ROOT}/${PDK}/libs.tech/librelane/sg13g2_stdcell/tribuff_map.v
+  cells:
+    buffer:
+      - cell: sg13g2_buf_1
+        input_ports: [A]
+        output_ports: [X]
+    tie_high:
+      - cell: sg13g2_tiehi
+        output_ports: [L_HI]
+    tie_low:
+      - cell: sg13g2_tielo
+        output_ports: [L_LO]
+
+pdk::gf180mcuD:
+  liberty_files:
+    - ${PDK_ROOT}/${PDK}/libs.ref/gf180mcu_fd_sc_mcu7t5v0/lib/gf180mcu_fd_sc_mcu7t5v0__tt_025C_5v00.lib
+  # The gf180mcu PDK ships no Yosys latch techmap and dfflibmap maps
+  # flip-flops only, so the project provides one for the config latches
+  # (shared with the GDS flow's SYNTH_LATCH_MAP).
+  techmap_files:
+    - ${PROJ_DIR}/Tile/include/gf180mcuD_latchmap.v
+  cells:
+    buffer:
+      - cell: gf180mcu_fd_sc_mcu7t5v0__buf_1
+        input_ports: [I]
+        output_ports: [Z]
+    tie_high:
+      - cell: gf180mcu_fd_sc_mcu7t5v0__tieh
+        output_ports: [Z]
+    tie_low:
+      - cell: gf180mcu_fd_sc_mcu7t5v0__tiel
+        output_ports: [ZN]

--- a/schema/std_cell_library.schema.json
+++ b/schema/std_cell_library.schema.json
@@ -1,0 +1,91 @@
+{
+  "$defs": {
+    "CellFunction": {
+      "description": "The logical role a standard cell fills during timing characterization.\n\nThe members are the keys of a library's ``cells`` mapping and the argument\nto :meth:`StdCellLibrary.get`; they are the extension point for new cell\ntypes.",
+      "enum": [
+        "buffer",
+        "tie_high",
+        "tie_low",
+        "latch",
+        "mux"
+      ],
+      "title": "CellFunction",
+      "type": "string"
+    },
+    "CellSpec": {
+      "description": "A standard cell and the ports a cell-mapping tool needs to use it.\n\n``cell`` is the standard-cell name; ``input_ports`` and ``output_ports`` list\nits ports (a buffer has one of each, a tie cell only an output, and cells\nwith several inputs/outputs list them all). Add further fields -- drive\nstrength, area, ... -- as more cell metadata is needed.",
+      "properties": {
+        "cell": {
+          "title": "Cell",
+          "type": "string"
+        },
+        "input_ports": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Input Ports",
+          "type": "array"
+        },
+        "output_ports": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Output Ports",
+          "type": "array"
+        }
+      },
+      "required": [
+        "cell"
+      ],
+      "title": "CellSpec",
+      "type": "object"
+    },
+    "StdCellLibrary": {
+      "description": "A PDK's standard-cell library for timing characterization.\n\nBundles the liberty timing files and Yosys techmap files with the cells the\nsynthesizer maps onto, grouped by function. A function may map to several\ncells (e.g. multiple buffers); use :meth:`get` to fetch them. Liberty and\ntechmap entries accept ``${VAR}`` placeholders and relative paths, resolved\nagainst the validation context supplied by :meth:`load`.",
+      "properties": {
+        "liberty_files": {
+          "default": [],
+          "items": {
+            "format": "path",
+            "type": "string"
+          },
+          "title": "Liberty Files",
+          "type": "array"
+        },
+        "techmap_files": {
+          "default": [],
+          "items": {
+            "format": "path",
+            "type": "string"
+          },
+          "title": "Techmap Files",
+          "type": "array"
+        },
+        "cells": {
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/$defs/CellSpec"
+            },
+            "type": "array"
+          },
+          "default": {},
+          "propertyNames": {
+            "$ref": "#/$defs/CellFunction"
+          },
+          "title": "Cells",
+          "type": "object"
+        }
+      },
+      "title": "StdCellLibrary",
+      "type": "object"
+    }
+  },
+  "additionalProperties": {
+    "$ref": "#/$defs/StdCellLibrary"
+  },
+  "description": "The on-disk standard-cell library config: ``pdk::<variant>`` sections.\n\nMaps each ``pdk::<variant>`` section name to its :class:`StdCellLibrary`.\nUsed to emit the JSON schema for ``Fabric/std_cell_library.yaml``.",
+  "title": "StdCellLibraryFile",
+  "type": "object"
+}

--- a/tests/fabric_definition/test_cell_spec.py
+++ b/tests/fabric_definition/test_cell_spec.py
@@ -1,0 +1,232 @@
+"""Tests for the standard-cell timing specifications.
+
+Covers the `CellSpec` / `StdCellLibrary` pydantic models and the loader that
+reads a PDK's library (liberty + techmap files and cells) from one section of
+the project's `Fabric/std_cell_library.yaml`, including ${VAR} / relative path
+resolution and the shipped JSON schema.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+import fabulous
+from fabulous.fabric_definition.cell_spec import (
+    CellFunction,
+    CellSpec,
+    StdCellLibrary,
+    StdCellLibraryFile,
+)
+
+
+def _write_std_cell_library(project_dir: Path, body: str) -> None:
+    """Write ``Fabric/std_cell_library.yaml`` under ``project_dir``."""
+    fabric_dir = project_dir / "Fabric"
+    fabric_dir.mkdir(parents=True, exist_ok=True)
+    (fabric_dir / "std_cell_library.yaml").write_text(body)
+
+
+def _template_fabric_dir() -> Path:
+    """Return the shipped project-template ``Fabric`` directory."""
+    return (
+        Path(fabulous.__file__).parent
+        / "fabric_files"
+        / "FABulous_project_template_common"
+        / "Fabric"
+    )
+
+
+def _repo_schema_path() -> Path:
+    """Return the repo-level standard-cell library JSON schema path."""
+    return (
+        Path(fabulous.__file__).parent.parent
+        / "schema"
+        / "std_cell_library.schema.json"
+    )
+
+
+_SKY130_SECTION = """\
+pdk::sky130A:
+  liberty_files:
+    - /pdk/sky130A/typ.lib
+  techmap_files:
+    - /pdk/sky130A/latch_map.v
+  cells:
+    buffer:
+      - cell: sky130_fd_sc_hd__buf_1
+        input_ports: [A]
+        output_ports: [X]
+      - cell: sky130_fd_sc_hd__buf_2
+        input_ports: [A]
+        output_ports: [X]
+    tie_high:
+      - cell: sky130_fd_sc_hd__conb_1
+        output_ports: [HI]
+"""
+
+
+# --------------------------------- CellSpec ---------------------------------
+
+
+def test_cell_spec_yosys_arg_buffer() -> None:
+    spec = CellSpec(cell="buf_1", input_ports=["A"], output_ports=["X"])
+
+    assert spec.yosys_arg == "buf_1 A X"
+
+
+def test_cell_spec_yosys_arg_tie_cell() -> None:
+    spec = CellSpec(cell="conb_1", output_ports=["HI"])
+
+    assert spec.yosys_arg == "conb_1 HI"
+
+
+def test_cell_spec_yosys_arg_multiple_ports() -> None:
+    spec = CellSpec(cell="mux", input_ports=["S", "A", "B"], output_ports=["Y"])
+
+    assert spec.yosys_arg == "mux S A B Y"
+
+
+# ------------------------------ StdCellLibrary ------------------------------
+
+
+def test_get_returns_all_cells_for_function() -> None:
+    library = StdCellLibrary.model_validate(
+        {
+            "cells": {
+                "buffer": [
+                    {"cell": "buf_1", "input_ports": ["A"], "output_ports": ["X"]},
+                    {"cell": "buf_2", "input_ports": ["A"], "output_ports": ["X"]},
+                ]
+            }
+        }
+    )
+
+    buffers = library.get(CellFunction.BUFFER)
+
+    assert [b.cell for b in buffers] == ["buf_1", "buf_2"]
+
+
+def test_get_missing_function_returns_empty() -> None:
+    library = StdCellLibrary.model_validate(
+        {"cells": {"buffer": [{"cell": "buf_1", "output_ports": ["X"]}]}}
+    )
+
+    assert library.get(CellFunction.TIE_LOW) == []
+
+
+def test_defaults_are_empty() -> None:
+    library = StdCellLibrary()
+
+    assert library.liberty_files == []
+    assert library.techmap_files == []
+    assert library.get(CellFunction.BUFFER) == []
+
+
+def test_load_returns_library(tmp_path: Path) -> None:
+    _write_std_cell_library(tmp_path, _SKY130_SECTION)
+
+    library = StdCellLibrary.load(tmp_path, "sky130A")
+
+    assert library.liberty_files == [Path("/pdk/sky130A/typ.lib")]
+    assert library.techmap_files == [Path("/pdk/sky130A/latch_map.v")]
+    assert [b.cell for b in library.get(CellFunction.BUFFER)] == [
+        "sky130_fd_sc_hd__buf_1",
+        "sky130_fd_sc_hd__buf_2",
+    ]
+    tie_high = library.get(CellFunction.TIE_HIGH)[0]
+    assert tie_high.yosys_arg == "sky130_fd_sc_hd__conb_1 HI"
+
+
+def test_load_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="Standard-cell library file not found"):
+        StdCellLibrary.load(tmp_path, "sky130A")
+
+
+def test_load_missing_section_raises(tmp_path: Path) -> None:
+    _write_std_cell_library(tmp_path, _SKY130_SECTION)
+
+    with pytest.raises(ValueError, match="No 'pdk::ihp-sg13g2' section"):
+        StdCellLibrary.load(tmp_path, "ihp-sg13g2")
+
+
+def test_load_unknown_cell_function_raises(tmp_path: Path) -> None:
+    _write_std_cell_library(
+        tmp_path,
+        "pdk::sky130A:\n  cells:\n    not_a_function:\n      - cell: x\n",
+    )
+
+    with pytest.raises(ValueError, match="StdCellLibrary"):
+        StdCellLibrary.load(tmp_path, "sky130A")
+
+
+# --------------------------- path resolution -------------------------------
+
+
+def _buffer_section(liberty: str) -> str:
+    """A minimal section with one buffer and the given liberty list entry."""
+    return (
+        "pdk::p:\n"
+        f"  liberty_files:\n    - {liberty}\n"
+        "  cells:\n"
+        "    buffer:\n"
+        "      - {cell: b, input_ports: [A], output_ports: [X]}\n"
+    )
+
+
+def test_expands_variables(tmp_path: Path) -> None:
+    _write_std_cell_library(tmp_path, _buffer_section("${PDK_ROOT}/${PDK}/x.lib"))
+
+    library = StdCellLibrary.load(tmp_path, "p", {"PDK_ROOT": "/pdks", "PDK": "p"})
+
+    assert library.liberty_files == [Path("/pdks/p/x.lib")]
+
+
+def test_absolute_path_unchanged(tmp_path: Path) -> None:
+    _write_std_cell_library(tmp_path, _buffer_section("/abs/x.lib"))
+
+    library = StdCellLibrary.load(tmp_path, "p", {"PDK_ROOT": "/pdks"})
+
+    assert library.liberty_files == [Path("/abs/x.lib")]
+
+
+def test_relative_path_resolved_against_project_dir(tmp_path: Path) -> None:
+    _write_std_cell_library(tmp_path, _buffer_section("cells/x.lib"))
+
+    library = StdCellLibrary.load(tmp_path, "p")
+
+    assert library.liberty_files == [tmp_path / "cells" / "x.lib"]
+
+
+def test_unknown_variable_raises(tmp_path: Path) -> None:
+    _write_std_cell_library(tmp_path, _buffer_section("${NOPE}/x.lib"))
+
+    with pytest.raises(ValueError, match="Unknown variable"):
+        StdCellLibrary.load(tmp_path, "p", {"PDK_ROOT": "/pdks"})
+
+
+# ------------------------------ shipped schema -----------------------------
+
+
+def test_shipped_schema_matches_model() -> None:
+    shipped = json.loads(_repo_schema_path().read_text())
+
+    # If this fails after a model or pydantic change, regenerate
+    # schema/std_cell_library.schema.json from StdCellLibraryFile.model_json_schema.
+    assert shipped == StdCellLibraryFile.model_json_schema()
+
+
+def test_template_sections_load() -> None:
+    project_dir = _template_fabric_dir().parent
+    sections = yaml.safe_load(
+        (_template_fabric_dir() / "std_cell_library.yaml").read_text()
+    )
+
+    for section in sections:
+        pdk = section.removeprefix("pdk::")
+        library = StdCellLibrary.load(
+            project_dir, pdk, {"PDK_ROOT": "/pdks", "PDK": pdk}
+        )
+        assert library.liberty_files
+        assert library.get(CellFunction.BUFFER)

--- a/tests/fabric_definition/test_fabric.py
+++ b/tests/fabric_definition/test_fabric.py
@@ -1,12 +1,15 @@
 """Tests for hardcoded validation checks in Fabric.__post_init__."""
 
 from collections.abc import Callable
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
 from fabulous.fabric_definition.fabric import Fabric
+from fabulous.fabric_definition.supertile import SuperTile
 from fabulous.fabric_definition.tile import Tile
+from tests.fabric_definition.conftest import make_empty_tile
 
 
 class TestFabricValidation:
@@ -120,3 +123,41 @@ class TestFabricValidation:
         else:
             fabric = make_fabric(tileDic={"test_tile": tile})
             assert len(fabric.tileDic["test_tile"].bels) == num_bels
+
+
+class TestGetSuperTileContaining:
+    """Resolve which SuperTile (if any) a tile belongs to."""
+
+    @staticmethod
+    def _make_super_tile(name: str, tile_names: list[str]) -> SuperTile:
+        tiles = [make_empty_tile(tile_name) for tile_name in tile_names]
+        return SuperTile(
+            name=name,
+            tileDir=Path(),
+            tiles=tiles,
+            tileMap=[tiles],
+        )
+
+    def test_returns_supertile_for_member_tile(
+        self, make_fabric: Callable[..., Fabric]
+    ) -> None:
+        super_tile = self._make_super_tile("SUPER_X", ["SUB_A", "SUB_B"])
+        fabric = make_fabric(superTileDic={"SUPER_X": super_tile})
+
+        assert fabric.get_super_tile_containing("SUB_A") is super_tile
+        assert fabric.get_super_tile_containing("SUB_B") is super_tile
+
+    def test_returns_none_for_non_member_tile(
+        self, make_fabric: Callable[..., Fabric]
+    ) -> None:
+        super_tile = self._make_super_tile("SUPER_X", ["SUB_A"])
+        fabric = make_fabric(superTileDic={"SUPER_X": super_tile})
+
+        assert fabric.get_super_tile_containing("OTHER") is None
+
+    def test_returns_none_without_supertiles(
+        self, make_fabric: Callable[..., Fabric]
+    ) -> None:
+        fabric = make_fabric()
+
+        assert fabric.get_super_tile_containing("ANY") is None


### PR DESCRIPTION
Part of the changes factor out from #835 

This creates a cell spec that allows us to use standard cell information for whatever purpose in the future. Flexibility has been considered. So let's say that later, if we want a Multiplex cell spec, we can inherit and extend it from the base cell spec. 