### PR TITLE
fix: Make/Taskfile does not uptate fabric files in build folder

### DIFF
--- a/fabulous/fabric_files/FABulous_project_template_verilog/Test/Makefile
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Test/Makefile
@@ -61,8 +61,8 @@ run_bitgen: mkdir_build
 	python3 makehex.py ${BUILD_DIR}/${DESIGN}.bin ${MAX_BITBYTES} ${BUILD_DIR}/${DESIGN}.hex
 
 copy_files: mkdir_build
-	find ${FAB_PROJ_ROOT}/Tile/ -name '*.v' -type f -exec cp -n {} ${FABRIC_FILES_DIR}/ \;
-	find ${FAB_PROJ_ROOT}/Fabric/ -name '*.v' -type f -exec cp -n {} ${FABRIC_FILES_DIR}/ \;
+	find ${FAB_PROJ_ROOT}/Tile/ -name '*.v' -type f -exec cp {} ${FABRIC_FILES_DIR}/ \;
+	find ${FAB_PROJ_ROOT}/Fabric/ -name '*.v' -type f -exec cp {} ${FABRIC_FILES_DIR}/ \;
 
 mkdir_build:
 	mkdir -p ${BUILD_DIR}

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Test/Taskfile.yml
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Test/Taskfile.yml
@@ -121,8 +121,8 @@ tasks:
     desc: Copy Verilog fabric files to build directory
     deps: [mkdir-build]
     cmds:
-      - find {{.FAB_PROJ_ROOT}}/Tile/ -name '*.v' -type f -exec cp -n {} {{.FABRIC_FILES_DIR}}/ \;
-      - find {{.FAB_PROJ_ROOT}}/Fabric/ -name '*.v' -type f -exec cp -n {} {{.FABRIC_FILES_DIR}}/ \;
+      - find {{.FAB_PROJ_ROOT}}/Tile/ -name '*.v' -type f -exec cp {} {{.FABRIC_FILES_DIR}}/ \;
+      - find {{.FAB_PROJ_ROOT}}/Fabric/ -name '*.v' -type f -exec cp {} {{.FABRIC_FILES_DIR}}/ \;
 
   run-simulation:
     desc: Run simulation using Icarus Verilog (iverilog)


### PR DESCRIPTION
The cp -n option silently skips files, that are already there. 
So without a 'clean' in between, the files in the build folder are not updated. 