### PR TITLE
fix(gen_switchmatrix): fix generic switch matrix config bit slicing

### DIFF
--- a/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
@@ -365,10 +365,17 @@ def genTileSwitchMatrix(
                     )
             else:
                 # generic multiplexer
+                select_width = paddedMuxSize.bit_length() - 1
+                if select_width == 1:
+                    select_index = f"ConfigBits[{configBitstreamPosition}]"
+                else:
+                    select_index = (
+                        f"ConfigBits[{configBitstreamPosition + select_width - 1}:"
+                        f"{configBitstreamPosition}]"
+                    )
                 writer.addAssignScalar(
                     portName,
-                    f"{portName}_input[ConfigBits[{configBitstreamPosition - 1}:"
-                    f"{configBitstreamPosition}]]",
+                    f"{portName}_input[{select_index}]",
                 )
 
             # update the configuration bitstream position


### PR DESCRIPTION
## Summary

Fix an invalid bit-slice generated by the generic switch matrix path.

With `multiplexerStyle = generic`, the first configurable mux could end up using `ConfigBits[-1:0]`, which is not valid Verilog. This change corrects the selection-bit indexing so single-bit muxes use `ConfigBits[pos]` and wider muxes use a valid descending slice.

## Related Issues

None.

## Testing

Checked the generic switch matrix generation logic and confirmed the first mux no longer produces a negative bit slice.

## Checklist

- [ ✓] I have read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ✓] I agree that my contribution is licensed under the project's [Apache License 2.0](../LICENSE).
- [ ✓] I have run `pre-commit run --all-files` and `pytest` locally.
- [ ✓] I have updated documentation where relevant.