### PR TITLE
fix(gen_switchmatrix): drive generic mux input vector

### DIFF
--- a/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
@@ -374,12 +374,15 @@ def _gen_switch_matrix_body(
 
             portsPairs.append(("X", f"{portName}"))
 
+            # we add the input signal in reversed order
+            # Both multiplexer styles index this vector, so it is driven for both.
+            writer.addAssignScalar(
+                f"{portName}_input",
+                connections[portName][::-1],
+                delay=default_pip_delay,
+            )
+
             if multiplexer_style == MultiplexerStyle.CUSTOM:
-                writer.addAssignScalar(
-                    f"{portName}_input",
-                    connections[portName][::-1],
-                    delay=default_pip_delay,
-                )
                 writer.addInstantiation(
                     compName=muxComponentName,
                     compInsName=f"inst_{muxComponentName}_{portName}",

--- a/tests/fabric_gen_test/conftest.py
+++ b/tests/fabric_gen_test/conftest.py
@@ -16,7 +16,8 @@ from fabulous.fabric_definition.fabric import Fabric
 from fabulous.fabric_definition.tile import Tile
 from fabulous.fabric_definition.yosys_obj import YosysJson
 from fabulous.fabric_generator.code_generator.code_generator import CodeGenerator
-from fabulous.fabulous_settings import get_context
+from fabulous.fabric_generator.parser.parse_csv import parseFabricCSV
+from fabulous.fabulous_settings import get_context, init_context
 
 
 class FabricConfig(NamedTuple):
@@ -73,6 +74,61 @@ def default_tile(mocker: MockerFixture) -> Tile:
     tile.name = "DefaultTile"
     tile.globalConfigBits = 127
     return tile
+
+
+def find_switch_matrix_tile(fabric: Fabric) -> Tile:
+    """Return the first fabric tile whose switch matrix is parseable.
+
+    Tiles whose `matrixDir` is a `.list` or `.csv` file drive the real
+    switch-matrix generation path; Verilog/VHDL matrix files are skipped.
+
+    Parameters
+    ----------
+    fabric : Fabric
+        The parsed fabric to search.
+
+    Returns
+    -------
+    Tile
+        The first tile with a `.list` or `.csv` switch matrix.
+
+    Raises
+    ------
+    ValueError
+        If no tile has a parseable switch matrix.
+    """
+    for tile in fabric.tileDic.values():
+        if tile.matrixDir.suffix in (".list", ".csv"):
+            return tile
+    raise ValueError("no tile with a parseable switch matrix in fabric")
+
+
+@pytest.fixture
+def parsed_default_fabric(project: Path) -> Fabric:
+    """Parse the default project fabric through the real parser stack.
+
+    Unlike `default_fabric`, this returns a fully parsed `Fabric` with real
+    tiles, ports and switch matrices, suitable for exercising generation end
+    to end.
+
+    Parameters
+    ----------
+    project : Path
+        Temp directory of a freshly created default project.
+
+    Returns
+    -------
+    Fabric
+        The parsed fabric of the default project.
+    """
+    init_context(project)
+    return parseFabricCSV(str(project / "fabric.csv"))
+
+
+@pytest.fixture
+def switch_matrix_tile(parsed_default_fabric: Fabric) -> Tile:
+    """Return a default-project tile with a parseable switch matrix."""
+    return find_switch_matrix_tile(parsed_default_fabric)
 
 
 @pytest.fixture(

--- a/tests/fabric_gen_test/switchmatrix_test/test_gen_switchmatrix_generic.py
+++ b/tests/fabric_gen_test/switchmatrix_test/test_gen_switchmatrix_generic.py
@@ -1,0 +1,84 @@
+"""Tests for the generic-style switch-matrix multiplexer path.
+
+A generic mux selects a source by indexing the `{portName}_input` vector with
+the relevant `ConfigBits`. That vector must be driven from the connection list
+(reversed, so `input[i]` is `connections[i]`); otherwise the mux indexes an
+undriven wire. These tests run the real generation path over a default-project
+tile and assert every declared input vector is driven.
+"""
+
+import re
+from collections.abc import Callable
+
+from fabulous.fabric_definition.define import MultiplexerStyle
+from fabulous.fabric_definition.tile import Tile
+from fabulous.fabric_generator.code_generator.code_generator import CodeGenerator
+from fabulous.fabric_generator.gen_fabric.gen_switchmatrix import genTileSwitchMatrix
+
+_INPUT_DECL = re.compile(r"\b(\w+)_input\s*;")
+_INPUT_ASSIGN = re.compile(r"assign\s+(\w+)_input\s*=")
+
+
+def _generate(
+    tile: Tile,
+    writer: CodeGenerator,
+    style: MultiplexerStyle,
+) -> str:
+    """Generate the switch-matrix HDL for `tile` and return it."""
+    genTileSwitchMatrix(writer, tile, False, multiplexer_style=style)
+    return writer.outFileName.read_text()
+
+
+class TestGenericMultiplexerInputVector:
+    """Generic-style muxes must drive every declared `{portName}_input` vector."""
+
+    def test_every_generic_input_vector_is_driven(
+        self,
+        switch_matrix_tile: Tile,
+        code_generator_factory: Callable[[str, str], CodeGenerator],
+    ) -> None:
+        """Each `_input` vector declared for a generic mux is also assigned.
+
+        The undriven-input regression declared the vector but never assigned
+        it, leaving the mux indexing a floating wire. Every declared vector
+        must have a matching `assign`.
+        """
+        hdl = _generate(
+            switch_matrix_tile,
+            code_generator_factory(".v", "generic"),
+            MultiplexerStyle.GENERIC,
+        )
+
+        declared = set(_INPUT_DECL.findall(hdl))
+        assigned = set(_INPUT_ASSIGN.findall(hdl))
+        # The tile must actually exercise the mux path, otherwise this is vacuous.
+        assert declared, "expected at least one configurable mux in the tile"
+        assert declared == assigned, (
+            f"input vectors declared but not driven: {sorted(declared - assigned)}"
+        )
+
+    def test_generic_matches_custom_input_drive(
+        self,
+        switch_matrix_tile: Tile,
+        code_generator_factory: Callable[[str, str], CodeGenerator],
+    ) -> None:
+        """Generic and custom styles drive the same set of `_input` vectors.
+
+        The first generation rewrites the `.list` matrix to `.csv` in place;
+        the second reads that `.csv`, so both styles see identical connections.
+        """
+        custom_hdl = _generate(
+            switch_matrix_tile,
+            code_generator_factory(".v", "custom"),
+            MultiplexerStyle.CUSTOM,
+        )
+        generic_hdl = _generate(
+            switch_matrix_tile,
+            code_generator_factory(".v", "generic"),
+            MultiplexerStyle.GENERIC,
+        )
+
+        custom_assigns = set(_INPUT_ASSIGN.findall(custom_hdl))
+        generic_assigns = set(_INPUT_ASSIGN.findall(generic_hdl))
+        assert custom_assigns
+        assert custom_assigns == generic_assigns


### PR DESCRIPTION
The generic multiplexer path declared a {portName}_input vector but only assigned it inside the CUSTOM branch, so generic-style switch matrices indexed an undriven wire. Lift the input-vector assignment out of the CUSTOM-only branch so both styles drive it from the reversed connection list.

Add real-fabric helpers (parsed_default_fabric, switch_matrix_tile, find_switch_matrix_tile) to the fabric_gen conftest and a test asserting every declared generic input vector is driven.

