### PR TITLE
chore: better error message with switch matrix construction

### DIFF
--- a/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
@@ -25,6 +25,7 @@ from fabulous.fabric_definition.define import (
     Direction,
     MultiplexerStyle,
 )
+from fabulous.fabric_definition.port import Port
 from fabulous.fabric_definition.supertile import SuperTile
 from fabulous.fabric_definition.tile import Tile
 from fabulous.fabric_generator.code_generator.code_generator import CodeGenerator
@@ -36,6 +37,50 @@ from fabulous.fabric_generator.gen_fabric.gen_helper import (
     list2CSV,
 )
 from fabulous.fabric_generator.parser.parse_switchmatrix import parseList, parseMatrix
+
+
+def _unconnected_port_diagnostic(ports: list[Port], port_name: str) -> str:
+    """Explain an unconnected switch matrix port caused by NULL-wire expansion.
+
+    A NULL-terminated spanning wire expands to ``wires x distance`` nested
+    wires (see `Port.expandPortInfoByName`). When the switch matrix leaves some
+    of those nested wires unconnected, the bare wire name is unhelpful, so this
+    traces the wire back to its originating port and explains the expansion.
+
+    Parameters
+    ----------
+    ports : list[Port]
+        The ports of the tile whose switch matrix is being generated.
+    port_name : str
+        The expanded wire name that has no connections.
+
+    Returns
+    -------
+    str
+        A diagnostic message to append to the base error, or an empty string
+        when `port_name` is not a nested wire of a NULL-terminated spanning
+        wire.
+    """
+    for port in ports:
+        expanded = port.expandPortInfoByName()
+        if port_name not in expanded:
+            continue
+        distance = abs(port.xOffset) + abs(port.yOffset)
+        isNullTerminated = port.sourceName == "NULL" or port.destinationName == "NULL"
+        if not (isNullTerminated and distance > 1):
+            return ""
+        return (
+            f"\n  '{port_name}' is one of {len(expanded)} nested wires expanded "
+            f"from wire spec '{port.name}' (wires={port.wireCount}, "
+            f"distance={distance}). A NULL-terminated wire connects all nested "
+            f"wires: wires x distance = {port.wireCount} x {distance} = "
+            f"{len(expanded)} ({expanded[0]}..{expanded[-1]}). The switch matrix "
+            f"connects fewer than {len(expanded)} of them. Either connect all "
+            f"{len(expanded)} nested wires, or name both ends of the wire "
+            f"(instead of NULL) for a direct {port.wireCount}-wire "
+            "point-to-point bus."
+        )
+    return ""
 
 
 def genTileSwitchMatrix(
@@ -125,7 +170,8 @@ def genTileSwitchMatrix(
     noConfigBits = 0
     for port_name in connections:
         if not connections[port_name]:
-            raise ValueError(f"{port_name} not connected to anything!")
+            hint = _unconnected_port_diagnostic(tile.portsInfo, port_name)
+            raise ValueError(f"{port_name} not connected to anything!{hint}")
         mux_size = len(connections[port_name])
         if mux_size >= 2:
             noConfigBits += (mux_size - 1).bit_length()

--- a/fabulous/fabric_generator/parser/parse_csv.py
+++ b/fabulous/fabric_generator/parser/parse_csv.py
@@ -66,6 +66,17 @@ def parsePortLine(line: str) -> tuple[list[Port], tuple[str, str] | None]:
     kind, start, x, y, end, count = line.split(",")[:6]
     x, y, count = int(x), int(y), int(count)
 
+    # The trailing digits are read back as that index. A name that ends in a digit is
+    # ambiguous once expanded.
+    for wireName in (start, end):
+        if wireName != "NULL" and wireName[-1:].isdigit():
+            raise InvalidPortType(
+                f"Wire name '{wireName}' ends in a digit, which is ambiguous: "
+                "wire expansion appends the index as a trailing digit, so a name "
+                "ending in a digit cannot be distinguished from an indexed wire. "
+                "Rename the wire so it does not end in a digit."
+            )
+
     if kind in ("NORTH", "SOUTH", "EAST", "WEST"):
         # Directional wire: OUTPUT port at start side, INPUT port at opposite side
         direction = Direction[kind]

--- a/tests/fabric_gen_test/parser_test/test_parse_csv.py
+++ b/tests/fabric_gen_test/parser_test/test_parse_csv.py
@@ -1,0 +1,128 @@
+"""Tests for parsing tile port lines from CSV fabric definitions."""
+
+import pytest
+
+from fabulous.custom_exception import InvalidPortType
+from fabulous.fabric_definition.define import IO, Direction, Side
+from fabulous.fabric_generator.parser.parse_csv import parsePortLine
+
+# (kind, physical side of the OUTPUT/start port, physical side of the INPUT/end port)
+DIRECTIONAL_CASES = [
+    ("NORTH", Side.NORTH, Side.SOUTH),
+    ("SOUTH", Side.SOUTH, Side.NORTH),
+    ("EAST", Side.EAST, Side.WEST),
+    ("WEST", Side.WEST, Side.EAST),
+]
+
+
+class TestDirectionalPorts:
+    """NORTH/SOUTH/EAST/WEST lines produce an OUTPUT/INPUT port pair."""
+
+    @pytest.mark.parametrize(("kind", "startSide", "endSide"), DIRECTIONAL_CASES)
+    def test_two_ports_with_expected_io_and_sides(
+        self, kind: str, startSide: Side, endSide: Side
+    ) -> None:
+        ports, commonWirePair = parsePortLine(f"{kind},N1BEG,0,-1,N1END,4")
+
+        assert len(ports) == 2
+        output, input_ = ports
+
+        assert output.inOut is IO.OUTPUT
+        assert output.name == "N1BEG"
+        assert output.sideOfTile is startSide
+
+        assert input_.inOut is IO.INPUT
+        assert input_.name == "N1END"
+        assert input_.sideOfTile is endSide
+
+        assert commonWirePair == ("N1BEG", "N1END")
+
+    @pytest.mark.parametrize("kind", [c[0] for c in DIRECTIONAL_CASES])
+    def test_shared_attributes_carry_through(self, kind: str) -> None:
+        ports, _ = parsePortLine(f"{kind},N2BEG,0,-2,N2END,8")
+
+        for port in ports:
+            assert port.wireDirection is Direction[kind]
+            assert port.sourceName == "N2BEG"
+            assert port.destinationName == "N2END"
+            assert port.xOffset == 0
+            assert port.yOffset == -2
+            assert port.wireCount == 8
+
+    def test_null_destination_keeps_name_and_pairs(self) -> None:
+        ports, commonWirePair = parsePortLine("SOUTH,S4BEG,0,4,NULL,4")
+
+        assert ports[1].name == "NULL"
+        assert commonWirePair == ("S4BEG", "NULL")
+
+
+class TestJumpPorts:
+    """JUMP lines stay within a tile, so both ports sit on Side.ANY."""
+
+    def test_two_ports_on_any_side(self) -> None:
+        ports, _ = parsePortLine("JUMP,J_SR_BEG,0,0,J_SR_END,1")
+
+        assert len(ports) == 2
+        output, input_ = ports
+
+        assert output.inOut is IO.OUTPUT
+        assert output.name == "J_SR_BEG"
+        assert input_.inOut is IO.INPUT
+        assert input_.name == "J_SR_END"
+
+        assert all(p.wireDirection is Direction.JUMP for p in ports)
+        assert all(p.sideOfTile is Side.ANY for p in ports)
+
+    def test_no_common_wire_pair(self) -> None:
+        _, commonWirePair = parsePortLine("JUMP,J_SR_BEG,0,0,J_SR_END,1")
+
+        assert commonWirePair is None
+
+
+class TestUnknownPortType:
+    """Lines that are not a known wire direction are rejected."""
+
+    @pytest.mark.parametrize("kind", ["BEL", "MATRIX", "north", "FOO"])
+    def test_raises_invalid_port_type(self, kind: str) -> None:
+        with pytest.raises(InvalidPortType, match="Unknown port type"):
+            parsePortLine(f"{kind},SRC_BEG,0,0,DST_END,1")
+
+
+class TestPortNameTrailingDigit:
+    """A declared port name must not end in a digit.
+
+    Trailing digits are reserved for the index that wire expansion appends
+    (``N1BEG`` -> `N1BEG0`, `N1BEG1` ...). A declared name that already
+    ends in a digit (e.g. ``X0_Y4_2_X0_Y3``) becomes ambiguous once the index
+    is appended, because downstream the trailing digits are read back as a bit
+    index. Reject such names at the parsing boundary.
+    """
+
+    @pytest.mark.parametrize("kind", ["NORTH", "SOUTH", "EAST", "WEST", "JUMP"])
+    def test_source_name_ending_in_digit_raises(self, kind: str) -> None:
+        line = f"{kind},X0_Y4_2_X0_Y3,0,0,DST_END,1"
+        with pytest.raises(InvalidPortType, match="digit"):
+            parsePortLine(line)
+
+    @pytest.mark.parametrize("kind", ["NORTH", "SOUTH", "EAST", "WEST", "JUMP"])
+    def test_destination_name_ending_in_digit_raises(self, kind: str) -> None:
+        line = f"{kind},SRC_BEG,0,0,X0_Y4_2_X0_Y3,1"
+        with pytest.raises(InvalidPortType, match="digit"):
+            parsePortLine(line)
+
+    def test_single_trailing_digit_raises(self) -> None:
+        with pytest.raises(InvalidPortType, match="digit"):
+            parsePortLine("JUMP,BUS3,0,0,J_END,1")
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "JUMP,J_SR_BEG,0,0,J_SR_END,1",
+            "NORTH,N1BEG,0,-1,N1END,4",
+            "SOUTH,S4BEG,0,4,NULL,4",
+            "NORTH,NULL,0,-1,N1END,4",
+        ],
+    )
+    def test_valid_names_do_not_raise(self, line: str) -> None:
+        ports, _ = parsePortLine(line)
+        assert ports

--- a/tests/fabric_gen_test/switchmatrix_test/test_gen_switchmatrix.py
+++ b/tests/fabric_gen_test/switchmatrix_test/test_gen_switchmatrix.py
@@ -15,9 +15,11 @@ from fabulous.fabric_definition.supertile import SuperTile
 from fabulous.fabric_definition.tile import Tile
 from fabulous.fabric_generator.code_generator.code_generator import CodeGenerator
 from fabulous.fabric_generator.gen_fabric.gen_switchmatrix import (
+    _unconnected_port_diagnostic,
     gen_super_tile_switch_matrix,
     genTileSwitchMatrix,
 )
+from fabulous.fabric_generator.parser.parse_csv import parsePortLine
 from tests.conftest import make_empty_tile, make_muladd_bel, sjump_port
 from tests.fabric_gen_test.conftest import (
     create_switchmatrix_csv,
@@ -233,3 +235,39 @@ class TestSuperTileSwitchMatrixConstants:
         )
         assert "SUPER_B0_input = {DSP_bot_x0,VCC0}" in rtl
         assert "cus_mux21 inst_cus_mux21_SUPER_B0" in rtl
+
+
+class TestUnconnectedPortDiagnostic:
+    """The 'not connected to anything' error should explain NULL-wire expansion.
+
+    A NULL-terminated spanning wire expands to ``wires x distance`` nested wires.
+    When a switch matrix leaves some of those nested wires unconnected, the
+    diagnostic should point back to the originating wire spec instead of just
+    naming the bare expanded wire.
+    """
+
+    def test_null_terminated_spanning_wire_explains_expansion(self) -> None:
+        ports, _ = parsePortLine("SOUTH,X1_Y1_2_X1_Y4_port,0,3,NULL,16")
+
+        hint = _unconnected_port_diagnostic(ports, "X1_Y1_2_X1_Y4_port16")
+
+        assert "X1_Y1_2_X1_Y4_port" in hint
+        assert "48" in hint  # wires (16) x distance (3)
+        assert "16" in hint  # original wire count
+        assert "3" in hint  # distance
+        assert "both ends" in hint
+
+    def test_both_ends_named_wire_gives_no_hint(self) -> None:
+        ports, _ = parsePortLine("NORTH,N4BEG,0,-4,N4END,4")
+
+        assert _unconnected_port_diagnostic(ports, "N4BEG0") == ""
+
+    def test_null_terminated_single_distance_gives_no_hint(self) -> None:
+        ports, _ = parsePortLine("NORTH,NULL,0,-1,N1END,4")
+
+        assert _unconnected_port_diagnostic(ports, "N1END0") == ""
+
+    def test_unknown_port_name_gives_no_hint(self) -> None:
+        ports, _ = parsePortLine("SOUTH,X1_Y1_2_X1_Y4_port,0,3,NULL,16")
+
+        assert _unconnected_port_diagnostic(ports, "not_a_real_wire0") == ""


### PR DESCRIPTION
Address #863

We ideally should allow this. We could move our appending to become `__<digit>`.  But if we move to a "bus"- based model, this will not be an issue either. 

Extending testing.