### PR TITLE
chore: set fixed oss-cad-suite version

### DIFF
--- a/.github/actions/prepare_FABulous_container/action.yaml
+++ b/.github/actions/prepare_FABulous_container/action.yaml
@@ -62,12 +62,12 @@ runs:
           # Fallback to a fixed version if API call fails
           if [ "$VERSION" = "unknown" ] || [ "$VERSION" = "null" ] || [ -z "$VERSION" ]; then
             echo "Warning: Failed to get OSS CAD Suite version from API, using fallback"
-            VERSION="2026-05-12"  # Use a recent stable version as fallback
+            VERSION="2026-06-29"  # Yosys master broke FABulous; last known-good release
           fi
 
         else
           echo "Get latest known working OSS CAD Suite version."
-          VERSION="2026-05-12"  # Use a recent stable version as fallback
+          VERSION="2026-06-29"  # Yosys master broke FABulous; last known-good release
         fi
 
         echo "Using OSS CAD Suite version: $VERSION"

--- a/fabulous/fabulous_cli/helper.py
+++ b/fabulous/fabulous_cli/helper.py
@@ -40,6 +40,10 @@ if TYPE_CHECKING:
 
 MAX_BITBYTES = 16384
 
+# Yosys master broke FABulous; pin the OSS-CAD-Suite install to a known-good
+# release. Set to None to track the latest nightly again.
+OSS_CAD_SUITE_VERSION: str | None = "2026-06-29"
+
 
 def setup_logger(verbosity: int, debug: bool, log_file: Path = Path()) -> None:
     """Set up the loguru logger with custom formatting based on verbosity level.
@@ -545,9 +549,15 @@ def install_oss_cad_suite(destination_folder: Path, update: bool = False) -> Non
         If no valid archive is found for the current OS and architecture.
         If the file format of the downloaded archive is unsupported.
     """
-    github_releases_url = (
-        "https://api.github.com/repos/YosysHQ/oss-cad-suite-build/releases/latest"
-    )
+    if OSS_CAD_SUITE_VERSION is None:
+        github_releases_url = (
+            "https://api.github.com/repos/YosysHQ/oss-cad-suite-build/releases/latest"
+        )
+    else:
+        github_releases_url = (
+            "https://api.github.com/repos/YosysHQ/oss-cad-suite-build/releases/tags/"
+            f"{OSS_CAD_SUITE_VERSION}"
+        )
     response = requests.get(github_releases_url)
     system = platform.system().lower()
     machine = platform.machine().lower()


### PR DESCRIPTION
Set all OSS-CAD-Suite versions fix to 2026-06-29, since newer Yosys versions change the FABulous integration.
