### PR TITLE
feat(fabric_cad): add per-type IO pad placement estimates

### DIFF
--- a/docs/source/user_guide/using_doc/pnr/nextpnr.md
+++ b/docs/source/user_guide/using_doc/pnr/nextpnr.md
@@ -285,25 +285,41 @@ matching nextpnr's original hard-coded values. By default, FABulous writes
 `delayOffset` equal to `delayScale`.
 :::
 
-### `FABULOUS_LC` placement estimate
+### Per-type placement estimates
 
-After the two scaling keys, FABulous appends one representative `FABULOUS_LC`
-block, the same timing-arc lines as `bel.v3.txt`, minus the `BelBegin`/pin
-lines:
+After the scaling keys, FABulous appends one representative block per timed
+BEL type, delimited by `BelBegin,<type>`/`BelEnd` and containing the same
+timing-arc lines as `bel.v3.txt` (minus the pin lines): `FABULOUS_LC`, the
+registered output pads (`OutPass4_frame_config`, `OutPass4_frame_config_mux`,
+`SetupHold` arcs on `I0`-`I3`), and the registered input pads
+(`InPass4_frame_config`, `InPass4_frame_config_mux`, `ClkToOut` arcs on
+`O0`-`O3`):
 
 ```{code-block} text
 delayScale=3.0
 delayOffset=3.0
+...
+BelBegin,FABULOUS_LC
 Clock,CLK,FF=1
 Delay,I0,O,3.0,FF=0
 ...
 SetupHold,I0,CLK,2.5,0.1,FF=1
 ClkToOut,Q,CLK,1.0,FF=1
+BelEnd
+BelBegin,OutPass4_frame_config
+SetupHold,I0,CLK,2.5,0.1
+...
+BelEnd
+BelBegin,InPass4_frame_config
+ClkToOut,O0,CLK,2.5
+...
+BelEnd
 ```
 
-nextpnr applies BEL timing in two passes: this one representative block steers
-placement (every `FABULOUS_LC` is estimated with it), then after placement each
-BEL's own `bel.v3.txt` arcs replace it, so the routed report is per-instance.
+nextpnr applies BEL timing in two passes: these representative blocks steer
+placement (every instance of a type is estimated with its type's block), then
+after placement each BEL's own `bel.v3.txt` arcs replace them, so the routed
+report is per-instance.
 
 :::{note}
 `bel.v3.txt` and `placement_estimate.txt` are written

--- a/fabulous/fabric_cad/gen_npnr_model.py
+++ b/fabulous/fabric_cad/gen_npnr_model.py
@@ -20,7 +20,7 @@ from fabulous.fabric_definition.bel import Bel
 from fabulous.fabric_definition.fabric import Fabric
 
 # Dummy BEL timing values (ns), mirroring nextpnr's historical hardcoded
-# constants (fabulous.cc, update_cell_timing).
+# constants (fabulous.cc, seed_default_estimates).
 LUT_DELAY = 3.0
 CARRY_CICO_DELAY = 0.2
 CARRY_I_DELAY = 1.0
@@ -44,9 +44,9 @@ CARRY_PREDICT_DELAY = 0.5
 # Arbitrary placeholder pip delay used when no delay_model is supplied.
 DUMMY_PIP_DELAY = 8
 
-# Representative FABULOUS_LC timing arcs for nextpnr's placement estimate.
-# Static while every LC instance shares these constants (I0-I3 LUT4); a real
-# per-instance timing model would regenerate this.
+# Representative per-type timing arcs for nextpnr's placement estimate.
+# Static while every instance of a type shares these constants (I0-I3 LUT4);
+# a real per-instance timing model would regenerate this.
 _LC_LUT_INPUTS = ("I0", "I1", "I2", "I3")
 LC_ESTIMATE_LINES: list[str] = [
     "Clock,CLK,FF=1",
@@ -60,9 +60,11 @@ LC_ESTIMATE_LINES: list[str] = [
     f"ClkToOut,Q,CLK,{FF_CLK_TO_Q},FF=1",
 ]
 
+
 # Full static placement_estimate.txt content: nextpnr placer/router tunables
-# plus the representative FABULOUS_LC estimate. All values reproduce nextpnr's
-# historical hardcoded defaults, so P&R behaviour is unchanged.
+# plus one representative estimate block per timed BEL type. All values
+# reproduce nextpnr's historical hardcoded defaults, so P&R behaviour is
+# unchanged.
 PLACEMENT_ESTIMATE_TEXT: str = (
     "\n".join(
         [
@@ -71,7 +73,21 @@ PLACEMENT_ESTIMATE_TEXT: str = (
             f"delayEpsilon={DELAY_EPSILON}",
             f"ripupPenalty={RIPUP_PENALTY}",
             f"carryPredictDelay={CARRY_PREDICT_DELAY}",
+            "BelBegin,FABULOUS_LC",
             *LC_ESTIMATE_LINES,
+            "BelEnd",
+            "BelBegin,OutPass4_frame_config",
+            *[f"SetupHold,I{p},CLK,{IO_SETUP},{IO_HOLD}" for p in range(4)],
+            "BelEnd",
+            "BelBegin,OutPass4_frame_config_mux",
+            *[f"SetupHold,I{p},CLK,{IO_SETUP},{IO_HOLD}" for p in range(4)],
+            "BelEnd",
+            "BelBegin,InPass4_frame_config",
+            *[f"ClkToOut,O{p},CLK,{IO_CLK_TO_OUT}" for p in range(4)],
+            "BelEnd",
+            "BelBegin,InPass4_frame_config_mux",
+            *[f"ClkToOut,O{p},CLK,{IO_CLK_TO_OUT}" for p in range(4)],
+            "BelEnd",
         ]
     )
     + "\n"

--- a/tests/fabric_gen_test/test_gen_npnr_model.py
+++ b/tests/fabric_gen_test/test_gen_npnr_model.py
@@ -57,12 +57,13 @@ def test_belLines_unknown_type_emits_no_timing_arcs() -> None:
         assert not any(line.startswith(keyword) for line in v3_lines)
 
 
-def test_placement_estimate_text_has_tunables_and_lc_block() -> None:
-    """The static placement_estimate.txt carries the tunables and one LC block.
+def test_placement_estimate_text_has_tunables_and_type_blocks() -> None:
+    """The static placement_estimate.txt carries the tunables and one
+    BelBegin/BelEnd estimate block per timed BEL type.
 
     Values reproduce nextpnr's historical hardcoded defaults, so P&R behaviour
-    is unchanged. It is a fixed constant while every LC instance shares the
-    same timing; a real per-instance model would regenerate it.
+    is unchanged. It is a fixed constant while every instance of a type shares
+    the same timing; a real per-instance model would regenerate it.
     """
     text = PLACEMENT_ESTIMATE_TEXT
     assert "delayScale=3.0" in text
@@ -71,12 +72,27 @@ def test_placement_estimate_text_has_tunables_and_lc_block() -> None:
     assert "ripupPenalty=0.5" in text
     assert "carryPredictDelay=0.5" in text
 
+    # One estimate block per timed BEL type.
+    for bel_type in (
+        "FABULOUS_LC",
+        "OutPass4_frame_config",
+        "OutPass4_frame_config_mux",
+        "InPass4_frame_config",
+        "InPass4_frame_config_mux",
+    ):
+        assert f"BelBegin,{bel_type}\n" in text
+    assert text.count("BelBegin,") == text.count("BelEnd")
+
     # The representative FABULOUS_LC arcs, in bel.v3 arc format.
     assert "Clock,CLK,FF=1" in text
     assert "Delay,I0,O,3.0,FF=0" in text
     assert "Delay,Ci,Co,0.2,Ci/Co?" in text
     assert "SetupHold,I0,CLK,2.5,0.1,FF=1" in text
     assert "ClkToOut,Q,CLK,1.0,FF=1" in text
+
+    # The representative IO register arcs.
+    assert "SetupHold,I0,CLK,2.5,0.1\n" in text
+    assert "ClkToOut,O0,CLK,2.5" in text
 
 
 def test_genNextpnrModel_bel_timing_unaffected_by_real_pip_delay(


### PR DESCRIPTION
The initial bel v3. only added estimates for the FABULOUS_LC, this now allows to add estimates for all BEL types.

Registered pads (InPass4/OutPass4_frame_config[_mux]) had no placement-estimate arcs, so nextpnr fell back to zero-delay estimates for pad-facing paths. Emit one BelBegin/BelEnd block per timed BEL type using nextpnr's historical default constants; P&R behaviour unchanged for FABULOUS_LC.