### PR TITLE
feat: add MultiClkDomains fabric param to bitstream spec

### DIFF
--- a/fabulous/fabric_cad/gen_bitstream_spec.py
+++ b/fabulous/fabric_cad/gen_bitstream_spec.py
@@ -73,6 +73,7 @@ def generateBitstreamSpec(fabric: Fabric) -> dict[str, dict]:
             "DesyncBit": fabric.desync_flag,
             "SyncHeaderHex": fabric.syncHeaderHex,
             "IncludeBorderRows": border_rows_have_config_bits(fabric),
+            "MultiClkDomains": fabric.multiClkDomains,
             "FABulousVersion": version("FABulous-FPGA"),
         },
     }

--- a/fabulous/fabric_definition/fabric.py
+++ b/fabulous/fabric_definition/fabric.py
@@ -67,6 +67,9 @@ class Fabric:
         Whether the fabric has super tile.
     disableUserCLK : bool
         Whether to disable UserCLK generation in the fabric.
+    multiClkDomains : bool
+        Whether the fabric uses multiple clock domains. When True, CLK features
+        are kept in the bitstream instead of being filtered out.
     syncHeaderHex : str
         Hex string of the 20-byte sync header written at the start of every
         binary bitstream.
@@ -106,6 +109,7 @@ class Fabric:
     numberOfBRAMs: int = 10
     superTileEnable: bool = True
     disableUserCLK: bool = False
+    multiClkDomains: bool = False
     syncHeaderHex: str = "00AAFF01000000010000000000000000FAB0FAB1"
 
     tileDic: dict[str, Tile] = field(default_factory=dict)
@@ -463,6 +467,7 @@ class Fabric:
         fabric += f"multiplexerStyle: {self.multiplexerStyle}\n"
         fabric += f"superTileEnable: {self.superTileEnable}\n"
         fabric += f"disableUserCLK: {self.disableUserCLK}\n"
+        fabric += f"multiClkDomains: {self.multiClkDomains}\n"
         fabric += f"tileDic: {list(self.tileDic.keys())}\n"
         return fabric
 

--- a/fabulous/fabric_generator/parser/parse_csv.py
+++ b/fabulous/fabric_generator/parser/parse_csv.py
@@ -825,6 +825,7 @@ def parseFabricCSV(fileName: str) -> Fabric:
     multiplexerStyle = MultiplexerStyle.CUSTOM
     superTileEnable = True
     disableUserCLK = False
+    multiClkDomains = False
 
     for i in parameters:
         i = i.split(",")
@@ -880,6 +881,8 @@ def parseFabricCSV(fileName: str) -> Fabric:
             superTileEnable = i[1] == "TRUE"
         elif i[0].startswith("DisableUserCLK"):
             disableUserCLK = i[1] == "TRUE"
+        elif i[0].startswith("MultiClkDomains"):
+            multiClkDomains = i[1] == "TRUE"
         elif i[0].startswith("PreserveListOrder"):
             # Consumed and validated by the pre-scan above (it must be known
             # before any tile is parsed); accepted here so it is not rejected.
@@ -947,6 +950,7 @@ def parseFabricCSV(fileName: str) -> Fabric:
         numberOfBRAMs=int(height / 2),
         superTileEnable=superTileEnable,
         disableUserCLK=disableUserCLK,
+        multiClkDomains=multiClkDomains,
         tileDic=tileDic,
         superTileDic=superTileDic,
         unusedTileDic=unusedTileDic,

--- a/tests/fabric_cad_test/test_gen_bitstream_spec.py
+++ b/tests/fabric_cad_test/test_gen_bitstream_spec.py
@@ -116,6 +116,7 @@ def test_spec_is_internally_consistent(generated_fabric: Fabric) -> None:
     assert arch["DesyncBit"] == fabric.desync_flag
     # the flag must mirror the detector on the actual fabric
     assert arch["IncludeBorderRows"] == border_rows_have_config_bits(fabric)
+    assert arch["MultiClkDomains"] == fabric.multiClkDomains
 
     # TileMap covers the whole grid; NULL cells are mapped but carry no specs
     assert set(spec["TileMap"]) == _all_tile_locations(fabric)
@@ -146,6 +147,20 @@ def test_border_rows_excluded_for_demo_fabric(generated_fabric: Fabric) -> None:
     """The demo fabric terminates top/bottom rows, so the flag stays off."""
     spec = generateBitstreamSpec(generated_fabric)
     assert spec["ArchSpecs"]["IncludeBorderRows"] is False
+
+
+def test_multi_clk_domains_defaults_off(generated_fabric: Fabric) -> None:
+    """MultiClkDomains defaults to False for a plain fabric."""
+    spec = generateBitstreamSpec(generated_fabric)
+    assert spec["ArchSpecs"]["MultiClkDomains"] is False
+
+
+def test_multi_clk_domains_flag_propagates(generated_fabric: Fabric) -> None:
+    """Setting the fabric flag propagates into the spec's ArchSpecs."""
+    fabric = generated_fabric
+    fabric.multiClkDomains = True
+    spec = generateBitstreamSpec(fabric)
+    assert spec["ArchSpecs"]["MultiClkDomains"] is True
 
 
 def test_config_tile_in_border_row_sets_flag(generated_fabric: Fabric) -> None:


### PR DESCRIPTION
New fabric parameter multiClkDomains (default false), settable via the MultiClkDomains fabric CSV param. It is emitted into the bitstream spec's ArchSpecs as MultiClkDomains so bit_gen keeps CLK features for fabrics with multiple clock domains instead of filtering them out.