### PR TITLE
ci: dismiss stale approvals only on real diff changes

### DIFF
--- a/.github/workflows/dismiss-stale-approvals.yml
+++ b/.github/workflows/dismiss-stale-approvals.yml
@@ -1,0 +1,19 @@
+name: Dismiss stale pull request approvals
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  dismiss-stale-approvals:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dismiss stale pull request approvals
+        uses: withgraphite/dismiss-stale-approvals@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Adds a `dismiss-stale-approvals` workflow using [`withgraphite/dismiss-stale-approvals`](https://github.com/withgraphite/dismiss-stale-approvals). It compares the `git range-diff` between pushes and only dismisses approvals when the code **actually** changed, so a pure rebase (identical diff) keeps existing approvals.

## Why

Rebasing a PR currently invalidates an existing approval even when the diff is unchanged, forcing needless re-review.

## ⚠️ Required companion change (repo admin, not in this PR)

This workflow alone does **not** fix the rebase problem. On `main`, GitHub's built-in `dismiss_stale_reviews` is already **off**, so the setting actually invalidating approvals after a rebase is:

- **`require_last_push_approval: true`** ("Require approval of the most recent reviewable push")

That setting invalidates the approval on *any* new push, regardless of dismissal logic, and cannot be overridden by a workflow. To get "rebase keeps approval", an admin needs to **turn off `require_last_push_approval`** on the `main` branch protection. This action is the intended replacement guard: with last-push-approval off, it still dismisses approvals when a push carries real code changes.

Summary of the intended end state:
- `require_last_push_approval` → **false** (admin change, manual)
- this action → dismisses only on genuine post-approval diff changes

## Notes

- Pinned to `@main` per the action's docs (latest release is `v0.1.2` if we'd rather pin to a tag).
