### PR TITLE
fix(gen): emit VHDL component declarations for supertile HDL

### DIFF
--- a/fabulous/fabric_generator/gen_fabric/gen_fabric.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_fabric.py
@@ -141,16 +141,20 @@ def generateFabric(writer: CodeGenerator, fabric: Fabric) -> None:
         # Declare a component per entity the fabric body instantiates: regular
         # tiles by their own name, supertiles by the wrapper name. Subtiles are
         # instantiated inside the wrapper, not the fabric, so they are skipped.
-        # tileDir holds the CSV path, so its parent is the tile/supertile folder.
+        # Every tile HDL lives at Tile/<name>/<name>.vhdl under the project root
+        # (fabric_dir is the fabric.csv, so its parent is that root). This is
+        # correct for both per-tile CSVs and the legacy inline fabric.csv, where
+        # every tileDir is the fabric.csv itself rather than a per-tile directory.
+        tileRoot = fabric.fabric_dir.parent / "Tile"
         for tile in fabric.tileDic.values():
             if tile.partOfSuperTile:
                 continue
             writer.addComponentDeclarationForFile(
-                str(tile.tileDir.parent / f"{tile.name}.vhdl")
+                str(tileRoot / tile.name / f"{tile.name}.vhdl")
             )
         for superTile in fabric.superTileDic.values():
             writer.addComponentDeclarationForFile(
-                str(superTile.tileDir.parent / f"{superTile.name}.vhdl")
+                str(tileRoot / superTile.name / f"{superTile.name}.vhdl")
             )
 
     # VHDL signal declarations

--- a/fabulous/fabric_generator/gen_fabric/gen_fabric.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_fabric.py
@@ -14,7 +14,6 @@ Key features:
 """
 
 from collections.abc import Generator
-from pathlib import Path
 
 from fabulous.fabric_definition.define import IO, ConfigBitMode, Direction
 from fabulous.fabric_definition.fabric import Fabric
@@ -139,21 +138,20 @@ def generateFabric(writer: CodeGenerator, fabric: Fabric) -> None:
     writer.addNewLine()
 
     if isinstance(writer, VHDLCodeGenerator):
-        added = set()
-        for t in fabric.tileDic:
-            name = t.split("_")[0]
-            if name in added:
+        # Declare a component per entity the fabric body instantiates: regular
+        # tiles by their own name, supertiles by the wrapper name. Subtiles are
+        # instantiated inside the wrapper, not the fabric, so they are skipped.
+        # tileDir holds the CSV path, so its parent is the tile/supertile folder.
+        for tile in fabric.tileDic.values():
+            if tile.partOfSuperTile:
                 continue
-            if name not in fabric.superTileDic:
-                writer.addComponentDeclarationForFile(
-                    f"{Path(writer.outFileName).parent.parent}/Tile/{t}/{t}.vhdl"
-                )
-                added.add(t)
-            else:
-                writer.addComponentDeclarationForFile(
-                    f"{Path(writer.outFileName).parent.parent}/Tile/{name}/{name}.vhdl"
-                )
-                added.add(name)
+            writer.addComponentDeclarationForFile(
+                str(tile.tileDir.parent / f"{tile.name}.vhdl")
+            )
+        for superTile in fabric.superTileDic.values():
+            writer.addComponentDeclarationForFile(
+                str(superTile.tileDir.parent / f"{superTile.name}.vhdl")
+            )
 
     # VHDL signal declarations
     writer.addComment("signal declarations", onNewLine=True, end="\n")

--- a/fabulous/fabric_generator/gen_fabric/gen_tile.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_tile.py
@@ -628,6 +628,13 @@ def generateSuperTile(
         If True, the UserCLK port will not be generated or connected
     config_bit_mode : ConfigBitMode
         The configuration bit mode to use (frame-based or FlipFlop chain)
+
+    Raises
+    ------
+    FileNotFoundError
+        If the supertile's switch matrix or ConfigMem HDL file is expected
+        (per the instantiation conditions) but missing; run matrix / config_mem
+        generation first.
     """
     writer.addHeader(f"{superTile.name}")
     writer.addParameterStart(indentLevel=1)
@@ -764,12 +771,37 @@ def generateSuperTile(
     writer.addNewLine()
 
     if isinstance(writer, VHDLCodeGenerator):
+        basePath = Path(writer.outFileName).parent
         for t in superTile.tiles:
             # This is only relevant to VHDL code generation,
             # will not affect Verilog code generation
-            writer.addComponentDeclarationForFile(
-                f"{Path(writer.outFileName).parent}/{t.name}/{t.name}.vhdl"
-            )
+            writer.addComponentDeclarationForFile(f"{basePath}/{t.name}/{t.name}.vhdl")
+        # The wrapper instantiates the supertile-level BELs directly, so declare
+        # each BEL's component once (mirroring generateTile).
+        bel_srcs_seen: list = []
+        for bel in superTile.bels:
+            if bel.src not in bel_srcs_seen:
+                bel_srcs_seen.append(bel.src)
+                writer.addComponentDeclarationForFile(bel.src)
+        # The wrapper also instantiates its own switch matrix and ConfigMem
+        # (see below), so VHDL needs their component declarations too - mirroring
+        # generateTile. Guarded by the same conditions as those instantiations.
+        if superTile.supertile_matrix_dir is not None:
+            sm_file = basePath / f"{superTile.name}_switch_matrix.vhdl"
+            if not sm_file.exists():
+                raise FileNotFoundError(
+                    f"Could not find {sm_file.name} in {basePath}. "
+                    "Need to run matrix generation first"
+                )
+            writer.addComponentDeclarationForFile(str(sm_file))
+        if st_config_bits > 0 and config_bit_mode == ConfigBitMode.FRAME_BASED:
+            cm_file = basePath / f"{superTile.name}_ConfigMem.vhdl"
+            if not cm_file.exists():
+                raise FileNotFoundError(
+                    f"Could not find {cm_file.name} in {basePath}. "
+                    "Need to run config_mem generation first"
+                )
+            writer.addComponentDeclarationForFile(str(cm_file))
 
     # find all internal connections
     internalConnections = superTile.getInternalConnections()

--- a/tests/fabric_gen_test/fabric_test/test_gen_fabric.py
+++ b/tests/fabric_gen_test/fabric_test/test_gen_fabric.py
@@ -91,6 +91,78 @@ def test_supertile_configmem_preloaded_from_master_bitstream(
     assert ".Emulate_Bitstream(Tile_X0Y1_Emulate_Bitstream)" in block
 
 
+def _stub_entity(path: Path, name: str) -> None:
+    """Write a minimal VHDL entity so `addComponentDeclarationForFile` can read it."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"entity {name} is\nend entity {name};\n")
+
+
+def _vhdl_supertile(tmp_path: Path) -> SuperTile:
+    """A DSP-like supertile plus the on-disk VHDL stubs the VHDL wrapper reads.
+
+    The VHDL wrapper copies a component declaration out of each instantiated
+    entity's file, so unlike the Verilog fixture those files must exist with a
+    parseable entity (switch matrix, ConfigMem, BEL, and each sub-tile).
+    """
+    mat = tmp_path / "supertile_matrix.list"
+    create_switchmatrix_list(mat, [("{2}SUPER_A0", "[DSP_bot_A0|DSP_bot_A1]")])
+
+    def mk(name: str, ports: list[Port]) -> Tile:
+        """Build a minimal child tile rooted at `tmp_path`."""
+        return make_empty_tile(
+            name,
+            ports,
+            tileDir=tmp_path,
+            matrixDir=tmp_path / f"{name}_switch_matrix.list",
+            pinOrderConfig={},
+        )
+
+    top = mk("DSP_top", [sjump_port("top2bot", IO.OUTPUT)])
+    bot = mk("DSP_bot", [sjump_port("A", IO.OUTPUT)])
+    bel = make_muladd_bel([("SUPER_A0", IO.INPUT)])
+    bel.src = tmp_path / "MULADD.vhdl"
+
+    _stub_entity(bel.src, "MULADD")
+    _stub_entity(tmp_path / "DSP_switch_matrix.vhdl", "DSP_switch_matrix")
+    _stub_entity(tmp_path / "DSP_ConfigMem.vhdl", "DSP_ConfigMem")
+    _stub_entity(tmp_path / "DSP_top" / "DSP_top.vhdl", "DSP_top")
+    _stub_entity(tmp_path / "DSP_bot" / "DSP_bot.vhdl", "DSP_bot")
+
+    return SuperTile(
+        name="DSP",
+        tileDir=tmp_path,
+        tiles=[top, bot],
+        tileMap=[[top], [bot]],
+        bels=[bel],
+        switch_matrix=SwitchMatrix.from_file(mat, "DSP"),
+    )
+
+
+def test_supertile_vhdl_declares_all_instantiated_components(
+    tmp_path: Path,
+    code_generator_factory: Callable[[str, str], CodeGenerator],
+) -> None:
+    """The VHDL supertile wrapper must declare every entity it instantiates.
+
+    A missing `component` is legal Verilog but rejected by VHDL analysers, which
+    is exactly what broke VHDL supertile projects: the wrapper instantiated its
+    own switch matrix, ConfigMem and BEL with no matching declaration, so NVC /
+    GHDL left the DSP tiles unbound (all-X output).
+    """
+    writer = code_generator_factory(".vhd", "DSP")
+    generateSuperTile(writer, _vhdl_supertile(tmp_path))
+    rtl = writer.outFileName.read_text()
+
+    for entity in (
+        "DSP_switch_matrix",
+        "DSP_ConfigMem",
+        "MULADD",
+        "DSP_top",
+        "DSP_bot",
+    ):
+        assert f"component {entity}" in rtl, f"{entity} component not declared"
+
+
 def test_iter_supertile_anchors_yields_top_left_anchor(tmp_path: Path) -> None:
     """Each supertile placement yields one anchor at its top-left child tile.
 


### PR DESCRIPTION
VHDL projects with a supertile switch matrix failed to generate/compile because supertile-related entities were instantiated without the matching VHDL `component` declarations (Verilog is unaffected as it needs none).

- gen_fabric: declare tile/supertile components from each tile's real tileDir instead of rebuilding a flat Tile/<name>/<name>.vhdl path via a split("_") heuristic, which mis-resolved supertile subtiles.
- gen_tile (generateSuperTile): also declare the wrapper's own switch matrix, ConfigMem, and supertile-level BEL components.