### PR TITLE
chore(deps): map PyYAML and python-dotenv module names for deptry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,8 @@ DEP002 = ["go-task-bin", "FABulous-bit-gen"]
 
 [tool.deptry.package_module_name_map]
 FABulous-bit-gen = "FABulous_bit_gen"
+PyYAML = "yaml"
+python-dotenv = "dotenv"
 
 [tool.uv.sources]
 sdf-timing = { git = "https://github.com/FPGA-Research/f4pga-sdf-timing.git" }


### PR DESCRIPTION
Stacked PRs:
 * #961
 * #960
 * #959
 * #958
 * #957
 * #956
 * #955
 * __->__#954


--- --- ---

### chore(deps): map PyYAML and python-dotenv module names for deptry


deptry cannot infer that `PyYAML` provides `yaml` and `python-dotenv`
provides `dotenv` when neither package is installed in the environment it
scans, so it reports both as undeclared imports (DEP001) and as unused
declared dependencies (DEP002) at the same time. That is seven failures on
a pristine tree, which makes the deptry pre-commit hook fail for every
commit.

Declare both in `package_module_name_map`, next to the existing
`FABulous-bit-gen` entry.