### PR TITLE
feat(fabric): add typed Mux/MuxPack graph layer to SwitchMatrix

### DIFF
--- a/fabulous/fabric_definition/supertile.py
+++ b/fabulous/fabric_definition/supertile.py
@@ -253,7 +253,7 @@ class SuperTile:
     @property
     def supertile_matrix_config_bits(self) -> int:
         """Return the supertile switch matrix config-bit count (0 if no matrix)."""
-        return 0 if self.switch_matrix is None else self.switch_matrix.no_config_bits
+        return 0 if self.switch_matrix is None else self.switch_matrix.total_config_bits
 
     @property
     def max_width(self) -> int:

--- a/fabulous/fabric_definition/switch_matrix.py
+++ b/fabulous/fabric_definition/switch_matrix.py
@@ -7,22 +7,24 @@ into this dataclass in canonical port/BEL order. RTL generation
 lives in `fabulous.fabric_generator.gen_fabric.gen_switchmatrix`.
 """
 
-from __future__ import annotations
-
 import re
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from itertools import zip_longest
+from pathlib import Path
+from typing import NamedTuple, Self
 
 from loguru import logger
 
 from fabulous.custom_exception import InvalidFileType, InvalidSwitchMatrixDefinition
-from fabulous.fabric_definition.define import Direction
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-    from fabulous.fabric_definition.bel import Bel
-    from fabulous.fabric_definition.port import Port
+from fabulous.fabric_definition.bel import Bel
+from fabulous.fabric_definition.define import IO, Direction
+from fabulous.fabric_definition.port import (
+    GenericPort,
+    Port,
+    SharedPort,
+    SlicedPort,
+)
 
 
 def switch_matrix_signal_order(
@@ -68,41 +70,348 @@ def switch_matrix_signal_order(
     return list(dict.fromkeys(sources)), list(dict.fromkeys(dests))
 
 
+class SliceRange(NamedTuple):
+    """Named tuple representing an inclusive bit slice range.
+
+    Attributes
+    ----------
+    start : int
+        The start index of the slice
+    end : int
+        The end index of the slice
+    """
+
+    start: int
+    end: int
+
+
+@dataclass
+class SlicedSignal:
+    """A signal representing a slice of a port.
+
+    Attributes
+    ----------
+    port : GenericPort
+        The port being sliced
+    slice_range : SliceRange
+        The range of the slice (start, end)
+    """
+
+    port: GenericPort
+    slice_range: SliceRange
+
+    def serialize(self) -> dict:
+        """Serialize the sliced signal to a dictionary."""
+        return {
+            "port": self.port.serialize(),
+            "slice_range": self.slice_range._asdict(),
+        }
+
+
+class Mux:
+    """Represents a multiplexer in the switch matrix.
+
+    A multiplexer selects one of several input signals to route to a single
+    output based on configuration bits.
+
+    Parameters
+    ----------
+    output : GenericPort
+        The output port of the multiplexer
+    inputs : list[GenericPort]
+        List of input ports to select from
+    prefix : str, optional
+        Prefix for the mux name. Defaults to ""
+
+    Raises
+    ------
+    ValueError
+        If input port widths don't match output port width
+    """
+
+    _output: GenericPort
+    _inputs: list[GenericPort]
+    _width: int
+
+    def __init__(
+        self, output: GenericPort, inputs: list[GenericPort], prefix: str = ""
+    ) -> None:
+        for p in inputs:
+            if p.width != output.width:
+                raise ValueError(
+                    f"All inputs {inputs} and output {output} must have the same width"
+                )
+
+        self._name = f"{prefix}{output.name}"
+        self._inputs = list(inputs)
+        self._output = output
+        self._width = output.width
+
+    def __repr__(self) -> str:
+        """Return a string representation of the multiplexer."""
+        if len(self.inputs) == 0:
+            return f"Mux({self.output.name} <- [no inputs] (cfg: -))"
+        input_names = [f"{i.name}" for i in self.inputs]
+        return (
+            f"Mux({self.output.name} <- [{', '.join(input_names)}] "
+            f"(cfg: {self.config_bits} bits))"
+        )
+
+    @property
+    def name(self) -> str:
+        """Get the name of the multiplexer."""
+        return self._name
+
+    @property
+    def inputs(self) -> tuple[GenericPort, ...]:
+        """Get the tuple of input ports."""
+        return tuple(self._inputs)
+
+    @property
+    def output(self) -> GenericPort:
+        """Get the output port."""
+        return self._output
+
+    @property
+    def width(self) -> int:
+        """Get the bit width of the ports."""
+        return self._width
+
+    @property
+    def config_bits(self) -> int:
+        """Get the number of configuration bits needed.
+
+        Returns
+        -------
+        int
+            Number of bits needed to select from N inputs: ceil(log2(N))
+
+        Raises
+        ------
+        ValueError
+            If the mux has no inputs
+        """
+        if len(self.inputs) == 0:
+            raise ValueError("Invalid Mux, no inputs")
+        return (len(self.inputs) - 1).bit_length()
+
+    def extend_inputs(self, inputs: Iterable[GenericPort]) -> None:
+        """Add more input ports to the multiplexer.
+
+        Parameters
+        ----------
+        inputs : Iterable[GenericPort]
+            Input ports to add
+
+        Raises
+        ------
+        TypeError
+            If an input is not a Port type
+        ValueError
+            If input width doesn't match output width
+        """
+        for i in inputs:
+            if not isinstance(i, GenericPort):
+                raise TypeError("Input must be a Port")
+
+            if i.width != self.output.width:
+                raise ValueError(
+                    f"All inputs and output must have the same width "
+                    f"input port {i} != output port {self.output}"
+                )
+            self._inputs.append(i)
+
+    def get_flatten_mux(self) -> list[tuple[str, tuple[str, ...]]]:
+        """Get the flattened mux inputs and output.
+
+        Returns
+        -------
+        list[tuple[str, tuple[str, ...]]]
+            List of (output_name, (input_names...)) tuples for each bit.
+        """
+        expanded_input_lists = [input_port.expand() for input_port in self.inputs]
+
+        # Group items by position using zip_longest
+        grouped_inputs: list[tuple[str, ...]] = []
+        for group in zip_longest(*expanded_input_lists):
+            # Filter out None values that zip_longest adds for shorter lists
+            grouped_inputs.append(tuple([item for item in group if item is not None]))
+        if isinstance(self.output, SharedPort):
+            return list(zip(self.output.share_expand(), grouped_inputs, strict=False))
+        return list(zip(self.output.expand(), grouped_inputs, strict=False))
+
+    def serialize(self) -> dict:
+        """Serialize the mux to a dictionary."""
+        return {
+            "output": self.output.serialize(),
+            "inputs": [input_port.serialize() for input_port in self.inputs],
+        }
+
+
+class MuxPack:
+    """High-level interface for building multiplexers with slicing support.
+
+    MuxPack provides a convenient interface for constructing switch matrix
+    connections using Verilog-style slicing notation and the //= operator.
+
+    Parameters
+    ----------
+    port : GenericPort
+        The port to create a mux pack for
+
+    Attributes
+    ----------
+    port : list[Mux]
+        The per-bit multiplexers backing this mux pack
+    og_port : GenericPort
+        The original port the mux pack was created for
+
+    Examples
+    --------
+    >>> output_pack = MuxPack(output_port)
+    >>> input_pack = MuxPack(input_port)
+    >>> output_pack //= input_pack  # Connect all bits
+    >>> output_pack[3:0] //= input_pack[7:4]  # Connect slices
+    """
+
+    port: list[Mux]
+    og_port: GenericPort
+    _last_get: "MuxPack"
+
+    def __init__(self, port: GenericPort) -> None:
+        self.port = []
+        self.og_port = port
+        for i in range(port.width):
+            self.port.append(Mux(SlicedPort(self.og_port, high=i, low=i), []))
+
+    def __getitem__(self, key: slice | int) -> "MuxPack":
+        """Return a MuxPack view for the given slice or index."""
+        if isinstance(key, slice):
+            if key.step is not None:
+                raise ValueError("Cannot slice with step")
+            if key.start is None:
+                raise ValueError(
+                    "You must specify a start index. If you are trying to do "
+                    "sig[0:4] you should write sig[4:0]"
+                )
+            if key.start < key.stop:
+                raise ValueError(
+                    "Start index must be less than stop index, the slicing is "
+                    "following the Verilog convention"
+                )
+            if abs(key.start - key.stop) > self.og_port.width:
+                raise ValueError("Slice width is greater than bit width")
+            self._last_get = MuxPack(self.og_port)
+            # Verilog descending slice [hi:lo] is inclusive of both ends; the
+            # backing list is ascending by bit index, so take bits lo..hi.
+            self._last_get.port = self.port[key.stop : key.start + 1]
+            return self._last_get
+        if isinstance(key, int):
+            if key >= self.og_port.width:
+                raise ValueError("Index out of range")
+            self._last_get = MuxPack(self.og_port)
+            self._last_get.port = [self.port[key]]
+            return self._last_get
+        raise ValueError("Invalid slicing for MuxPack")
+
+    def __setitem__(self, key: slice | int, value: "MuxPack") -> None:
+        """Reject direct assignment in favour of the //= operator."""
+        if self._last_get is value:
+            return
+        raise TypeError(
+            "Cannot perform direct assignment on MuxPort. "
+            "Use the //= operator for connecting ports"
+        )
+
+    def __ifloordiv__(
+        self, other: "MuxPack | list[MuxPack] | tuple[MuxPack, ...]"
+    ) -> Self:
+        """Connect ports into the muxes using the //= operator."""
+        if isinstance(other, (list, tuple)):
+            try:
+                r = list(
+                    zip(*[i.port for i in other if isinstance(i, MuxPack)], strict=True)
+                )
+            except ValueError:
+                raise ValueError(
+                    f"not all the object in the list have the same width {other}"
+                ) from None
+            for o, i in zip(self.port, r, strict=False):
+                o.extend_inputs([j.output for j in i])
+        elif isinstance(other, MuxPack):
+            for k, o in enumerate(self.port):
+                o.extend_inputs([other.port[k].output])
+        else:
+            raise ValueError("Invalid type for Mux construction")  # noqa: TRY004
+
+        return self
+
+
 @dataclass(frozen=True)
 class SwitchMatrix:
-    """Encapsulates a tile's switch matrix: source file and connectivity.
+    """Encapsulates a tile's switch matrix as its `Mux` objects.
 
-    Read once and immutable: the connectivity is fixed at construction, so the
-    same object can be safely shared or deep-copied across fabric-grid placements.
+    Read once and immutable: the muxes are fixed at construction and are the
+    single source of truth, so the same object can be safely shared or
+    deep-copied across fabric-grid placements. `connections` and
+    `total_config_bits` are derived views over the muxes; the muxes preserve the
+    canonical order the parser produced, so those views reproduce it exactly.
 
     Attributes
     ----------
     matrix_file : Path
         Source file for the switch matrix (`.csv`, `.list`, or hand-written
         HDL).
-    connections : dict[str, list[str]]
-        Mux output port -> list of mux input signals. Empty for hand-written HDL.
+    muxes_dict : dict[GenericPort, Mux]
+        Output port -> its multiplexer, in canonical order. Holds every
+        connection including single-input (direct), zero-input (unused), and
+        constant muxes. Empty for hand-written HDL.
     preserve_list_order : bool
         Whether the mux-input order is significant (MSB-first `.list` order)
         rather than the canonical dest-column order. Recorded once at read time
         and reused when exporting so a round trip is faithful. Default False.
     hdl_config_bits : int | None
         Config-bit count declared by a hand-written HDL matrix. None for parsed
-        matrices, whose `no_config_bits` is derived from `connections` instead.
+        matrices, whose `total_config_bits` is derived from the muxes instead.
     """
 
     matrix_file: Path
-    connections: dict[str, list[str]]
+    muxes_dict: dict[GenericPort, Mux] = field(
+        default_factory=dict, compare=False, repr=False
+    )
     preserve_list_order: bool = False
     hdl_config_bits: int | None = None
 
     @property
-    def no_config_bits(self) -> int:
+    def muxes(self) -> list[Mux]:
+        """Return every multiplexer in canonical order."""
+        return list(self.muxes_dict.values())
+
+    @property
+    def connections(self) -> dict[str, list[str]]:
+        """Derive the `{mux_output: [mux_inputs]}` name map from the muxes.
+
+        This is the flat, name-keyed view the RTL, bitstream-spec, and
+        nextpnr-model generators consume; it is regenerated from the muxes on
+        each access and preserves their canonical order.
+
+        Returns
+        -------
+        dict[str, list[str]]
+            Mux output name -> ordered list of mux input names.
+        """
+        return {
+            mux.output.name: [i.name for i in mux.inputs]
+            for mux in self.muxes_dict.values()
+        }
+
+    @property
+    def total_config_bits(self) -> int:
         """Number of configuration bits required by this switch matrix.
 
-        Derived on demand from `connections` (so it tracks any change to them);
-        a hand-written HDL matrix has no parsed connections and instead reports
-        the count declared in its header (`hdl_config_bits`).
+        Derived on demand from the muxes (so it tracks any change to them); a
+        hand-written HDL matrix has no parsed muxes and instead reports the
+        count declared in its header (`hdl_config_bits`).
 
         Returns
         -------
@@ -111,7 +420,123 @@ class SwitchMatrix:
         """
         if self.hdl_config_bits is not None:
             return self.hdl_config_bits
-        return self._count_config_bits(self.connections)
+        return sum(
+            mux.config_bits for mux in self.muxes_dict.values() if len(mux.inputs) >= 2
+        )
+
+    @classmethod
+    def from_connections(
+        cls,
+        matrix_file: Path,
+        connections: dict[str, list[str]],
+        preserve_list_order: bool = False,
+        hdl_config_bits: int | None = None,
+    ) -> "SwitchMatrix":
+        """Build a SwitchMatrix from a `{mux_output: [mux_inputs]}` name map.
+
+        Each output name becomes a width-1 `Mux` whose inputs are width-1 ports,
+        in the map's iteration order, so the resulting muxes carry the exact
+        canonical order of `connections`.
+
+        Parameters
+        ----------
+        matrix_file : Path
+            Source file the connections were read from.
+        connections : dict[str, list[str]]
+            Mux output name -> ordered list of mux input names.
+        preserve_list_order : bool, optional
+            Whether the mux-input order is the significant MSB-first `.list`
+            order. Defaults to False.
+        hdl_config_bits : int | None, optional
+            Config-bit count for a hand-written HDL matrix. Defaults to None.
+
+        Returns
+        -------
+        SwitchMatrix
+            The constructed switch matrix.
+        """
+        muxes_dict: dict[GenericPort, Mux] = {}
+        for dest, sources in connections.items():
+            output_port = Port(name=dest, io_direction=IO.OUTPUT, width=1)
+            input_ports: list[GenericPort] = [
+                Port(name=src, io_direction=IO.INPUT, width=1) for src in sources
+            ]
+            muxes_dict[output_port] = Mux(output_port, input_ports)
+        return cls(
+            matrix_file=matrix_file,
+            muxes_dict=muxes_dict,
+            preserve_list_order=preserve_list_order,
+            hdl_config_bits=hdl_config_bits,
+        )
+
+    def __getitem__(self, key: GenericPort) -> Mux:
+        """Return the multiplexer driving the given output port."""
+        if key in self.muxes_dict:
+            return self.muxes_dict[key]
+        raise KeyError(f"Output port {key} does not exist in the switch matrix")
+
+    def get_outputs(self) -> list[GenericPort]:
+        """Get all output ports in the switch matrix."""
+        return [mux.output for mux in self.muxes_dict.values()]
+
+    def get_inputs(self) -> list[GenericPort]:
+        """Get all unique input ports in the switch matrix."""
+        deduplicating_input: set[GenericPort] = set()
+
+        result_list: list[GenericPort] = []
+        for mux in self.muxes_dict.values():
+            for i in mux.inputs:
+                if i not in deduplicating_input:
+                    deduplicating_input.add(i)
+                    result_list.append(i)
+        return result_list
+
+    def get_port_users(self, port: GenericPort) -> list[GenericPort]:
+        """Get all mux outputs that use the given port as an input.
+
+        Parameters
+        ----------
+        port : GenericPort
+            The port to find users for
+
+        Returns
+        -------
+        list[GenericPort]
+            List of output ports that use the given port as input
+        """
+        sink_list: set[GenericPort] = set()
+        for mux in self.muxes_dict.values():
+            for i in mux.inputs:
+                if i == port:
+                    sink_list.add(mux.output)
+        return list(sink_list)
+
+    def get_port_drivers(self, port: GenericPort) -> list[GenericPort]:
+        """Get all input ports that can drive the given output port.
+
+        Parameters
+        ----------
+        port : GenericPort
+            The output port to find drivers for
+
+        Returns
+        -------
+        list[GenericPort]
+            List of input ports that can drive the given port
+        """
+        source_list: set[GenericPort] = set()
+        for mux in self.muxes_dict.values():
+            if mux.output == port:
+                for i in mux.inputs:
+                    source_list.add(i)
+        return list(source_list)
+
+    def serialize(self) -> dict:
+        """Serialize the switch matrix to a dictionary."""
+        return {
+            "muxes": [mux.serialize() for mux in self.muxes],
+            "config_bits": self.total_config_bits,
+        }
 
     @classmethod
     def from_file(
@@ -121,7 +546,7 @@ class SwitchMatrix:
         ports: list[Port] | None = None,
         bels: list[Bel] | None = None,
         preserve_list_order: bool = False,
-    ) -> SwitchMatrix:
+    ) -> "SwitchMatrix":
         """Construct a SwitchMatrix by parsing the given source file.
 
         The matrix is read once into its canonical form. A `.csv` is already
@@ -199,7 +624,7 @@ class SwitchMatrix:
                     "still reserved). nextpnr cannot route through it; you are "
                     "responsible for ensuring the HDL matches the fabric's ports."
                 )
-                return cls(
+                return cls.from_connections(
                     matrix_file=path,
                     connections={},
                     preserve_list_order=preserve_list_order,
@@ -209,7 +634,7 @@ class SwitchMatrix:
                 raise InvalidFileType(
                     f"Unrecognised switch matrix file extension: {path.suffix}"
                 )
-        return cls(
+        return cls.from_connections(
             matrix_file=path,
             connections=connections,
             preserve_list_order=preserve_list_order,
@@ -387,27 +812,6 @@ class SwitchMatrix:
                     continue
                 inputs = mux_inputs[::-1]
                 f.write(f"{{{len(mux_inputs)}}}{mux_output},[{'|'.join(inputs)}]\n")
-
-    @staticmethod
-    def _count_config_bits(connections: dict[str, list[str]]) -> int:
-        """Count config bits needed to select each mux's inputs.
-
-        Parameters
-        ----------
-        connections : dict[str, list[str]]
-            Mux output -> mux inputs.
-
-        Returns
-        -------
-        int
-            Total select bits summed over every mux (a mux with fewer than two
-            inputs needs none).
-        """
-        total = 0
-        for sources in connections.values():
-            if len(sources) >= 2:
-                total += (len(sources) - 1).bit_length()
-        return total
 
     @staticmethod
     def _extract_config_bits_from_hdl(path: Path) -> int:

--- a/fabulous/fabric_definition/tile.py
+++ b/fabulous/fabric_definition/tile.py
@@ -334,7 +334,7 @@ class Tile:
         int
             Total number of global configuration bits for the tile.
         """
-        ret = self.switch_matrix.no_config_bits
+        ret = self.switch_matrix.total_config_bits
 
         for b in self.bels:
             ret += b.config_bit

--- a/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
@@ -126,7 +126,7 @@ def genTileSwitchMatrix(
         if not connections[port_name]:
             hint = _unconnected_port_diagnostic(tile.portsInfo, port_name)
             raise ValueError(f"{port_name} not connected to anything!{hint}")
-    noConfigBits = tile.switch_matrix.no_config_bits
+    noConfigBits = tile.switch_matrix.total_config_bits
 
     # we pass the NumberOfConfigBits as a comment in the beginning of the file.
     # This simplifies it to generate the configuration port only if needed later when
@@ -453,7 +453,7 @@ def gen_super_tile_switch_matrix(
     if superTile.switch_matrix is None:
         return
 
-    noConfigBits = superTile.switch_matrix.no_config_bits
+    noConfigBits = superTile.switch_matrix.total_config_bits
     module_name = f"{superTile.name}_switch_matrix"
 
     # Connectivity (destination -> [sources]) held on the supertile.

--- a/fabulous/fabric_generator/parser/parse_csv.py
+++ b/fabulous/fabric_generator/parser/parse_csv.py
@@ -3,6 +3,7 @@
 import re
 from copy import deepcopy
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from loguru import logger
 
@@ -22,11 +23,9 @@ from fabulous.fabric_definition.define import (
     ConfigBitMode,
     Direction,
     MultiplexerStyle,
-    Side,
 )
 from fabulous.fabric_definition.fabric import Fabric
 from fabulous.fabric_definition.gen_io import Gen_IO
-from fabulous.fabric_definition.port import NULL_PORT_NAME, TilePort
 from fabulous.fabric_definition.supertile import SuperTile
 from fabulous.fabric_definition.switch_matrix import SwitchMatrix
 from fabulous.fabric_definition.tile import Tile
@@ -35,188 +34,11 @@ from fabulous.fabric_generator.gen_fabric.fabric_automation import (
     generateCustomTileConfig,
     generateSwitchmatrixList,
 )
+from fabulous.fabric_generator.parser.parse_switchmatrix import parse_port_line
 from fabulous.fabulous_settings import get_context
 
-
-def parse_port_line(line: str) -> tuple[list[TilePort], tuple[str, str] | None]:
-    """Parse a single line of the port configuration from the CSV file.
-
-    Parameters
-    ----------
-    line : str
-        CSV line containing port configuration data.
-
-    Raises
-    ------
-    InvalidPortType
-        If the port definition is invalid.
-
-    Returns
-    -------
-    tuple[list[TilePort], tuple[str, str] | None]
-        A tuple containing a list of parsed ports and an optional common wire pair.
-    """
-    fields: list[str] = line.split(",")
-    port_type = fields[0]
-
-    try:
-        wire_direction = Direction[port_type]
-    except KeyError:
-        raise InvalidPortType(f"Unknown port type: {port_type}") from None
-
-    if len(fields) < 6:
-        raise InvalidPortType(
-            f"Invalid port definition line {line!r}: port type {port_type!r} "
-            "requires 6 comma-separated fields (DIRECTION, source_name, "
-            "x_offset, y_offset, destination_name, wire_count), "
-            f"got {len(fields)}."
-        )
-
-    source_name = fields[1]
-    x_offset = int(fields[2])
-    y_offset = int(fields[3])
-    destination_name = fields[4]
-    wire_count = int(fields[5])
-
-    # The trailing digits are read back as that index. A name that ends in a
-    # digit is ambiguous once expanded.
-    for wire_name in (source_name, destination_name):
-        if wire_name != NULL_PORT_NAME and wire_name[-1:].isdigit():
-            raise InvalidPortType(
-                f"Wire name '{wire_name}' ends in a digit, which is ambiguous: "
-                "wire expansion appends the index as a trailing digit, so a name "
-                "ending in a digit cannot be distinguished from an indexed wire. "
-                "Rename the wire so it does not end in a digit."
-            )
-
-    ports: list[TilePort] = []
-    common_wire_pair: tuple[str, str] | None
-
-    if wire_direction in (
-        Direction.NORTH,
-        Direction.EAST,
-        Direction.SOUTH,
-        Direction.WEST,
-    ):
-        # Output port (source side)
-        ports.append(
-            TilePort(
-                name=source_name,
-                io_direction=IO.OUTPUT,
-                width=wire_count,
-                side_of_tile=Side[port_type],
-                wire_direction=wire_direction,
-                source_name=source_name,
-                x_offset=x_offset,
-                y_offset=y_offset,
-                destination_name=destination_name,
-                wire_count=wire_count,
-            )
-        )
-
-        # Input port (destination side)
-        ports.append(
-            TilePort(
-                name=destination_name,
-                io_direction=IO.INPUT,
-                width=wire_count,
-                side_of_tile=Side[port_type].opposite,
-                wire_direction=wire_direction,
-                source_name=source_name,
-                x_offset=x_offset,
-                y_offset=y_offset,
-                destination_name=destination_name,
-                wire_count=wire_count,
-            )
-        )
-        common_wire_pair = (f"{source_name}", f"{destination_name}")
-
-    elif wire_direction is Direction.JUMP:
-        # Output port
-        ports.append(
-            TilePort(
-                name=source_name,
-                io_direction=IO.OUTPUT,
-                width=wire_count,
-                side_of_tile=Side.ANY,
-                wire_direction=Direction.JUMP,
-                source_name=source_name,
-                x_offset=x_offset,
-                y_offset=y_offset,
-                destination_name=destination_name,
-                wire_count=wire_count,
-            )
-        )
-        # Input port
-        ports.append(
-            TilePort(
-                name=destination_name,
-                io_direction=IO.INPUT,
-                width=wire_count,
-                side_of_tile=Side.ANY,
-                wire_direction=Direction.JUMP,
-                source_name=source_name,
-                x_offset=x_offset,
-                y_offset=y_offset,
-                destination_name=destination_name,
-                wire_count=wire_count,
-            )
-        )
-        common_wire_pair = None
-
-    elif wire_direction is Direction.SJUMP:
-        # SJUMP,source,0,0,NULL,n  -> OUTPUT: signal exits tile toward supertile SM
-        # SJUMP,NULL,0,0,dest,n    -> INPUT: signal enters tile from supertile SM
-        # An SJUMP line is one-way: exactly one of source/destination must be NULL.
-        if (source_name == NULL_PORT_NAME) == (destination_name == NULL_PORT_NAME):
-            raise InvalidPortType(
-                f"Invalid SJUMP line '{line.strip()}': exactly one of source and "
-                "destination must be NULL (use 'SJUMP,src,0,0,NULL,n' for an output "
-                "or 'SJUMP,NULL,0,0,dst,n' for an input)."
-            )
-        # SJUMP wires terminate at the supertile switch matrix and carry no
-        # spatial offset; a nonzero offset is a definition error, not silently 0.
-        if x_offset != 0 or y_offset != 0:
-            raise InvalidPortType(
-                f"Invalid SJUMP line '{line.strip()}': X/Y offset must be 0,0 "
-                f"(got {x_offset},{y_offset})."
-            )
-
-        if source_name != NULL_PORT_NAME:
-            ports.append(
-                TilePort(
-                    name=source_name,
-                    io_direction=IO.OUTPUT,
-                    width=wire_count,
-                    side_of_tile=Side.ANY,
-                    wire_direction=Direction.SJUMP,
-                    source_name=source_name,
-                    x_offset=0,
-                    y_offset=0,
-                    destination_name=NULL_PORT_NAME,
-                    wire_count=wire_count,
-                )
-            )
-        if destination_name != NULL_PORT_NAME:
-            ports.append(
-                TilePort(
-                    name=destination_name,
-                    io_direction=IO.INPUT,
-                    width=wire_count,
-                    side_of_tile=Side.ANY,
-                    wire_direction=Direction.SJUMP,
-                    source_name=NULL_PORT_NAME,
-                    x_offset=0,
-                    y_offset=0,
-                    destination_name=destination_name,
-                    wire_count=wire_count,
-                )
-            )
-        common_wire_pair = None
-
-    else:
-        raise InvalidPortType(f"Unknown port type: {port_type}")
-    return (ports, common_wire_pair)
+if TYPE_CHECKING:
+    from fabulous.fabric_definition.port import TilePort
 
 
 def parseTilesCSV(

--- a/fabulous/fabric_generator/parser/parse_switchmatrix.py
+++ b/fabulous/fabric_generator/parser/parse_switchmatrix.py
@@ -14,8 +14,13 @@ from loguru import logger
 
 from fabulous.custom_exception import (
     InvalidListFileDefinition,
+    InvalidPortType,
     InvalidSwitchMatrixDefinition,
 )
+from fabulous.fabric_definition.define import IO, Direction, Side
+from fabulous.fabric_definition.port import NULL_PORT_NAME, TilePort
+
+oppositeDic = {"NORTH": "SOUTH", "SOUTH": "NORTH", "EAST": "WEST", "WEST": "EAST"}
 
 
 def parseMatrix(
@@ -240,3 +245,184 @@ def parseList(
         return dict(grouped)
 
     return unique_pairs
+
+
+def parse_port_line(line: str) -> tuple[list[TilePort], tuple[str, str] | None]:
+    """Parse a single line of the port configuration from the CSV file.
+
+    Parameters
+    ----------
+    line : str
+        CSV line containing port configuration data.
+
+    Raises
+    ------
+    InvalidPortType
+        If the port definition is invalid.
+
+    Returns
+    -------
+    tuple[list[TilePort], tuple[str, str] | None]
+        A tuple containing a list of parsed ports and an optional common wire pair.
+    """
+    fields: list[str] = line.split(",")
+    port_type = fields[0]
+
+    try:
+        wire_direction = Direction[port_type]
+    except KeyError:
+        raise InvalidPortType(f"Unknown port type: {port_type}") from None
+
+    if len(fields) < 6:
+        raise InvalidPortType(
+            f"Invalid port definition line {line!r}: port type {port_type!r} "
+            "requires 6 comma-separated fields (DIRECTION, source_name, "
+            "x_offset, y_offset, destination_name, wire_count), "
+            f"got {len(fields)}."
+        )
+
+    source_name = fields[1]
+    x_offset = int(fields[2])
+    y_offset = int(fields[3])
+    destination_name = fields[4]
+    wire_count = int(fields[5])
+
+    # The trailing digits are read back as that index. A name that ends in a
+    # digit is ambiguous once expanded.
+    for wire_name in (source_name, destination_name):
+        if wire_name != NULL_PORT_NAME and wire_name[-1:].isdigit():
+            raise InvalidPortType(
+                f"Wire name '{wire_name}' ends in a digit, which is ambiguous: "
+                "wire expansion appends the index as a trailing digit, so a name "
+                "ending in a digit cannot be distinguished from an indexed wire. "
+                "Rename the wire so it does not end in a digit."
+            )
+
+    ports: list[TilePort] = []
+    commonWirePair: tuple[str, str] | None
+
+    if wire_direction in (
+        Direction.NORTH,
+        Direction.EAST,
+        Direction.SOUTH,
+        Direction.WEST,
+    ):
+        # Output port (source side)
+        ports.append(
+            TilePort(
+                name=source_name,
+                io_direction=IO.OUTPUT,
+                width=wire_count,
+                side_of_tile=Side[port_type],
+                wire_direction=wire_direction,
+                source_name=source_name,
+                x_offset=x_offset,
+                y_offset=y_offset,
+                destination_name=destination_name,
+                wire_count=wire_count,
+            )
+        )
+
+        # Input port (destination side)
+        ports.append(
+            TilePort(
+                name=destination_name,
+                io_direction=IO.INPUT,
+                width=wire_count,
+                side_of_tile=Side[port_type].opposite,
+                wire_direction=wire_direction,
+                source_name=source_name,
+                x_offset=x_offset,
+                y_offset=y_offset,
+                destination_name=destination_name,
+                wire_count=wire_count,
+            )
+        )
+        commonWirePair = (f"{source_name}", f"{destination_name}")
+
+    elif wire_direction is Direction.JUMP:
+        # Output port
+        ports.append(
+            TilePort(
+                name=source_name,
+                io_direction=IO.OUTPUT,
+                width=wire_count,
+                side_of_tile=Side.ANY,
+                wire_direction=Direction.JUMP,
+                source_name=source_name,
+                x_offset=x_offset,
+                y_offset=y_offset,
+                destination_name=destination_name,
+                wire_count=wire_count,
+            )
+        )
+        # Input port
+        ports.append(
+            TilePort(
+                name=destination_name,
+                io_direction=IO.INPUT,
+                width=wire_count,
+                side_of_tile=Side.ANY,
+                wire_direction=Direction.JUMP,
+                source_name=source_name,
+                x_offset=x_offset,
+                y_offset=y_offset,
+                destination_name=destination_name,
+                wire_count=wire_count,
+            )
+        )
+        commonWirePair = None
+
+    elif wire_direction is Direction.SJUMP:
+        # SJUMP,source,0,0,NULL,n  -> OUTPUT: signal exits tile toward supertile SM
+        # SJUMP,NULL,0,0,dest,n    -> INPUT: signal enters tile from supertile SM
+        # An SJUMP line is one-way: exactly one of source/destination must be NULL.
+        if (source_name == NULL_PORT_NAME) == (destination_name == NULL_PORT_NAME):
+            raise InvalidPortType(
+                f"Invalid SJUMP line '{line.strip()}': exactly one of source and "
+                "destination must be NULL (use 'SJUMP,src,0,0,NULL,n' for an output "
+                "or 'SJUMP,NULL,0,0,dst,n' for an input)."
+            )
+        # SJUMP wires terminate at the supertile switch matrix and carry no
+        # spatial offset; a nonzero offset is a definition error, not silently 0.
+        if x_offset != 0 or y_offset != 0:
+            raise InvalidPortType(
+                f"Invalid SJUMP line '{line.strip()}': X/Y offset must be 0,0 "
+                f"(got {x_offset},{y_offset})."
+            )
+
+        if source_name != NULL_PORT_NAME:
+            ports.append(
+                TilePort(
+                    name=source_name,
+                    io_direction=IO.OUTPUT,
+                    width=wire_count,
+                    side_of_tile=Side.ANY,
+                    wire_direction=Direction.SJUMP,
+                    source_name=source_name,
+                    x_offset=0,
+                    y_offset=0,
+                    destination_name=NULL_PORT_NAME,
+                    wire_count=wire_count,
+                )
+            )
+        if destination_name != NULL_PORT_NAME:
+            ports.append(
+                TilePort(
+                    name=destination_name,
+                    io_direction=IO.INPUT,
+                    width=wire_count,
+                    side_of_tile=Side.ANY,
+                    wire_direction=Direction.SJUMP,
+                    source_name=NULL_PORT_NAME,
+                    x_offset=0,
+                    y_offset=0,
+                    destination_name=destination_name,
+                    wire_count=wire_count,
+                )
+            )
+        commonWirePair = None
+
+    else:
+        raise InvalidPortType(f"Unknown port type: {port_type}")
+    return (ports, commonWirePair)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,7 @@ def make_empty_tile(
         ports=ports or [],
         bels=[],
         tileDir=tileDir,
-        switch_matrix=SwitchMatrix(
+        switch_matrix=SwitchMatrix.from_connections(
             matrix_file=matrixDir, connections={}, hdl_config_bits=config_bits or None
         ),
         gen_ios=[],

--- a/tests/fabric_definition/test_tile.py
+++ b/tests/fabric_definition/test_tile.py
@@ -16,7 +16,7 @@ def _mk_tile(ports: list[TilePort]) -> Tile:
         ports=ports,
         bels=[],
         tileDir=Path(),
-        switch_matrix=SwitchMatrix(matrix_file=Path(), connections={}),
+        switch_matrix=SwitchMatrix.from_connections(matrix_file=Path(), connections={}),
         gen_ios=[],
         userCLK=False,
     )

--- a/tests/fabric_gen_test/conftest.py
+++ b/tests/fabric_gen_test/conftest.py
@@ -53,7 +53,7 @@ def mk_tile(tmp_path: Path) -> Callable[[str], Tile]:
     """
 
     def _create(name: str) -> Tile:
-        switch_matrix = SwitchMatrix(
+        switch_matrix = SwitchMatrix.from_connections(
             matrix_file=tmp_path / f"{name}.list", connections={}
         )
         return Tile(name, [], [], tmp_path, switch_matrix, [], False)

--- a/tests/fabric_gen_test/fabric_test/test_gen_supertile.py
+++ b/tests/fabric_gen_test/fabric_test/test_gen_supertile.py
@@ -334,7 +334,9 @@ class TestBelExternalPorts:
             ports=[],
             bels=[bel],
             tileDir=Path(),
-            switch_matrix=SwitchMatrix(matrix_file=Path(), connections={}),
+            switch_matrix=SwitchMatrix.from_connections(
+                matrix_file=Path(), connections={}
+            ),
             gen_ios=[],
             userCLK=False,
         )
@@ -370,7 +372,9 @@ class TestInterTileRouting:
             ],
             bels=[],
             tileDir=Path(),
-            switch_matrix=SwitchMatrix(matrix_file=Path(), connections={}),
+            switch_matrix=SwitchMatrix.from_connections(
+                matrix_file=Path(), connections={}
+            ),
             gen_ios=[],
             userCLK=False,
         )
@@ -392,7 +396,9 @@ class TestInterTileRouting:
             ],
             bels=[],
             tileDir=Path(),
-            switch_matrix=SwitchMatrix(matrix_file=Path(), connections={}),
+            switch_matrix=SwitchMatrix.from_connections(
+                matrix_file=Path(), connections={}
+            ),
             gen_ios=[],
             userCLK=False,
         )

--- a/tests/fabric_gen_test/switchmatrix_test/test_gen_switchmatrix.py
+++ b/tests/fabric_gen_test/switchmatrix_test/test_gen_switchmatrix.py
@@ -21,8 +21,11 @@ from fabulous.fabric_generator.gen_fabric.gen_switchmatrix import (
     gen_super_tile_switch_matrix,
     genTileSwitchMatrix,
 )
-from fabulous.fabric_generator.parser.parse_csv import parse_port_line, parseFabricCSV
-from fabulous.fabric_generator.parser.parse_switchmatrix import parseMatrix
+from fabulous.fabric_generator.parser.parse_csv import parseFabricCSV
+from fabulous.fabric_generator.parser.parse_switchmatrix import (
+    parse_port_line,
+    parseMatrix,
+)
 from fabulous.fabulous_settings import init_context
 from tests.conftest import make_empty_tile, make_muladd_bel, sjump_port
 from tests.fabric_gen_test.conftest import (
@@ -77,7 +80,7 @@ class TestListExport:
     """to_list_file writes one compact `{N}output,[inputs]` line per mux."""
 
     def test_compact_per_mux_format_round_trips(self, tmp_path: Path) -> None:
-        sm = SwitchMatrix(
+        sm = SwitchMatrix.from_connections(
             matrix_file=Path("x.csv"),
             connections={"A_I": ["X", "Y"], "B_I": ["Z"], "C_I": []},
         )
@@ -98,7 +101,7 @@ class TestListExport:
         bel = make_muladd_bel(
             [("A", IO.INPUT), ("X", IO.OUTPUT), ("Y", IO.OUTPUT), ("Z", IO.OUTPUT)]
         )
-        sm = SwitchMatrix(
+        sm = SwitchMatrix.from_connections(
             matrix_file=Path("x.csv"),
             connections={"A": ["Z", "Y", "X"]},
             preserve_list_order=True,
@@ -128,7 +131,7 @@ class TestCsvExportReaderDecides:
     ) -> None:
         # B's order [X, Y] differs from the global column order [Y, Z, X].
         conns = {"A": ["Y", "Z"], "B": ["X", "Y"]}
-        sm = SwitchMatrix(matrix_file=Path("x.csv"), connections=conns)
+        sm = SwitchMatrix.from_connections(matrix_file=Path("x.csv"), connections=conns)
         out = tmp_path / "m.csv"
         sm.to_csv_file(out, "T")
         # preserve read honours the encoded position -> exact per-mux order
@@ -174,12 +177,12 @@ class TestHdlSwitchMatrix:
         v.write_text("// NumberOfConfigBits: 7\nmodule T(); endmodule\n")
         sm = SwitchMatrix.from_file(v, "T")
         assert sm.connections == {}
-        assert sm.no_config_bits == 7
+        assert sm.total_config_bits == 7
 
     def test_missing_config_bits_defaults_to_zero(self, tmp_path: Path) -> None:
         v = tmp_path / "T_switch_matrix.vhdl"
         v.write_text("entity T is end T;\n")
-        assert SwitchMatrix.from_file(v, "T").no_config_bits == 0
+        assert SwitchMatrix.from_file(v, "T").total_config_bits == 0
 
     def test_generation_skips_hdl_matrix(self, tmp_path: Path) -> None:
         v = tmp_path / "T_switch_matrix.v"

--- a/tests/gds_flow_test/step_test/test_fabric_area_opt.py
+++ b/tests/gds_flow_test/step_test/test_fabric_area_opt.py
@@ -358,7 +358,7 @@ def _make_tile(name: str) -> Tile:
         ports=[],
         bels=[],
         tileDir=Path(),
-        switch_matrix=SwitchMatrix(matrix_file=Path(), connections={}),
+        switch_matrix=SwitchMatrix.from_connections(matrix_file=Path(), connections={}),
         gen_ios=[],
         userCLK=False,
     )


### PR DESCRIPTION
Stacked PRs:
 * #961
 * #960
 * #959
 * #958
 * __->__#957
 * #956


--- --- ---

### feat(fabric): add typed Mux/MuxPack graph layer to SwitchMatrix


Combine this branch's typed switch-matrix model with upstream's parse-once
SwitchMatrix (#926). Upstream already made SwitchMatrix read-once and immutable
with a `connections` name-map; this adds the layer it lacks:

- Mux / MuxPack / SlicedSignal / SliceRange over the typed GenericPort model,
  including the //= connection operator for generic-mux construction.
- muxes_dict is the authoritative stored state; `connections`, `no_config_bits`,
  and `config_bits` are derived views over the muxes, so the canonical order and
  config-bit counts upstream computed are reproduced exactly (byte-identical
  RTL / bitstream / nextpnr output).
- from_connections() builds muxes from a name-map; from_file() routes through it,
  keeping upstream's parse, validation, and .csv/.list export unchanged.
- graph queries (get_port_drivers/users/inputs/outputs, __getitem__) and
  serialize() for the fabric model.

Consumers that read .connections keep working unchanged; test fixtures move from
the SwitchMatrix(connections=...) constructor to SwitchMatrix.from_connections().

Also move `parse_port_line` from parse_csv into parse_switchmatrix. Port-line
parsing produces the ports the switch matrix is validated and built against, so
it belongs beside the rest of the switch-matrix parsing rather than in the
tile-CSV parser; parse_csv now imports it.
