### PR TITLE
feat(fabric): make Tile a composite

### DIFF
--- a/fabulous/fabric_cad/gen_bitstream_spec.py
+++ b/fabulous/fabric_cad/gen_bitstream_spec.py
@@ -78,15 +78,15 @@ def generateBitstreamSpec(fabric: Fabric) -> dict[str, dict]:
         },
     }
 
-    tileMap = {}
+    tile_map = {}
     for y, row in enumerate(fabric.tile):
         for x, tile in enumerate(row):
             if tile is not None:
-                tileMap[f"X{x}Y{y}"] = tile.name
+                tile_map[f"X{x}Y{y}"] = tile.name
             else:
-                tileMap[f"X{x}Y{y}"] = "NULL"
+                tile_map[f"X{x}Y{y}"] = "NULL"
 
-    specData["TileMap"] = tileMap
+    specData["TileMap"] = tile_map
     configMemList: list[ConfigMem] = []
     for y, row in enumerate(fabric.tile):
         for x, tile in enumerate(row):
@@ -124,9 +124,9 @@ def generateBitstreamSpec(fabric: Fabric) -> dict[str, dict]:
                     configMemPath,
                     fabric.maxFramesPerCol,
                     fabric.frameBitsPerRow,
-                    tile.globalConfigBits,
+                    tile.total_config_bits,
                 )
-            elif tile.globalConfigBits > 0:
+            elif tile.total_config_bits > 0:
                 logger.critical(
                     f"No ConfigMem csv file found for {tile.name} which "
                     "have config bits"
@@ -153,7 +153,7 @@ def generateBitstreamSpec(fabric: Fabric) -> dict[str, dict]:
                 maskDic[len(configMemList) + i] = "0" * fabric.frameBitsPerRow
 
             specData["FrameMap"][tile.name] = maskDic
-            if tile.globalConfigBits == 0:
+            if tile.total_config_bits == 0:
                 logger.info(f"No config memory for X{x}Y{y}_{tile.name}.")
                 specData["FrameMap"][tile.name] = {}
                 specData["FrameMapEncode"][tile.name] = {}

--- a/fabulous/fabric_definition/fabric.py
+++ b/fabulous/fabric_definition/fabric.py
@@ -171,7 +171,7 @@ class Fabric:
         # together must fit in 26 letters.
         for superTile in self.superTileDic.values():
             mx, my = superTile.get_master_tile_coords()
-            master_tile = superTile.tileMap[my][mx]
+            master_tile = superTile.tile_map[my][mx]
             if (
                 master_tile is not None
                 and len(master_tile.bels) + len(superTile.bels) > 26
@@ -184,13 +184,13 @@ class Fabric:
 
         # SJUMP wires route a basic tile to a BEL hosted in its supertile's
         # master tile; they are only meaningful inside a supertile. A tile that
-        # belongs to a supertile carries partOfSuperTile (set by the parser), so
+        # belongs to a supertile carries part_of_super_tile (set by the parser), so
         # reject any SJUMP-declaring tile that is not flagged as such.
         for row in self.tile:
             for tile in row:
                 if tile is None:
                     continue
-                if tile.get_sjump_ports() and not tile.partOfSuperTile:
+                if tile.get_sjump_ports() and not tile.part_of_super_tile:
                     raise ValueError(
                         f"Tile '{tile.name}' declares SJUMP wires but is not part "
                         "of any supertile. SJUMP wires route to a supertile-hosted "
@@ -349,7 +349,7 @@ class Fabric:
             if master_tile is None:
                 continue
 
-            for ly, st_row in enumerate(superTile.tileMap):
+            for ly, st_row in enumerate(superTile.tile_map):
                 for lx, st_tile in enumerate(st_row):
                     if st_tile is None:
                         continue
@@ -403,8 +403,8 @@ class Fabric:
     ) -> Generator[tuple[int, int, SuperTile], None, None]:
         """Yield `(base_fx, base_fy, superTile)` for every supertile placement.
 
-        Each supertile type's `tileMap` pattern is matched against the fabric
-        grid; `(base_fx, base_fy)` is the top-left corner of a match. Shared by
+        Each supertile type's ``tile_map`` pattern is matched against the fabric
+        grid; ``(base_fx, base_fy)`` is the top-left corner of a match. Shared by
         the SJUMP wire pass, the nextpnr model, and the bitstream spec so they all
         locate supertile instances identically.
 
@@ -431,8 +431,8 @@ class Fabric:
     def _matches_super_tile(
         self, superTile: SuperTile, base_fx: int, base_fy: int
     ) -> bool:
-        """Return whether `superTile`'s tileMap matches the grid at the base."""
-        for ly, st_row in enumerate(superTile.tileMap):
+        """Return whether ``superTile``'s tile_map matches the grid at the base."""
+        for ly, st_row in enumerate(superTile.tile_map):
             for lx, st_tile in enumerate(st_row):
                 fy = base_fy + ly
                 fx = base_fx + lx
@@ -621,7 +621,7 @@ class Fabric:
                     for st in self.superTileDic.values():
                         if st == tile:
                             # Check if fabric_tile is part of this supertile
-                            for st_row in st.tileMap:
+                            for st_row in st.tile_map:
                                 for st_tile in st_row:
                                     if st_tile and st_tile.name == fabric_tile.name:
                                         positions.append((x, y))
@@ -684,7 +684,7 @@ class Fabric:
         result: list[Tile | SuperTile] = []
 
         # Add all regular tiles from tileDic
-        result.extend([i for i in self.tileDic.values() if not i.partOfSuperTile])
+        result.extend([i for i in self.tileDic.values() if not i.part_of_super_tile])
 
         # Add all SuperTiles from superTileDic
         result.extend(self.superTileDic.values())

--- a/fabulous/fabric_definition/supertile.py
+++ b/fabulous/fabric_definition/supertile.py
@@ -30,15 +30,16 @@ class SuperTile:
         Path to the tile directory.
     tiles : list[Tile]
         The list of tiles that make up the super tile.
-    tileMap : list[list[Tile]]
+    tile_map : list[list[Tile]]
         The map of the tiles that make up the super tile
     bels : list[Bel]
         The list of bels of that the super tile contains
-    withUserCLK : bool
-        Whether the super tile has a userCLK port. Default is False.
+    with_user_clk : bool
+        Whether the super tile has a user_clk port. Default is False.
     switch_matrix : SwitchMatrix | None
         The supertile switch matrix (source file, connectivity, config bits), or
-        None if the supertile has no switch matrix.
+        None if the supertile has no switch matrix. `supertile_matrix_dir` and
+        `supertile_matrix_config_bits` are derived from it.
     master_tile_coords : tuple[int, int] | None
         Local (x, y) of the master tile. Explicitly set via the `MASTER` token
         in the supertile CSV, or computed as the last non-None tile in row-major
@@ -49,9 +50,9 @@ class SuperTile:
     name: str
     tile_dir: Path
     tiles: list[Tile]
-    tileMap: list[list[Tile]]
+    tile_map: list[list[Tile]]
     bels: list[Bel] = field(default_factory=list)
-    withUserCLK: bool = False
+    with_user_clk: bool = False
     switch_matrix: SwitchMatrix | None = None
     master_tile_coords: tuple[int, int] | None = None
 
@@ -69,25 +70,25 @@ class SuperTile:
             The dictionary of the ports around the super tile.
         """
         ports = {}
-        for y, row in enumerate(self.tileMap):
+        for y, row in enumerate(self.tile_map):
             for x, tile in enumerate(row):
-                if self.tileMap[y][x] is None:
+                if self.tile_map[y][x] is None:
                     continue
                 ports[f"{x},{y}"] = []
                 # Bottom-left origin: y+1 is north (above), y-1 is south (below)
-                if y + 1 >= len(self.tileMap) or self.tileMap[y + 1][x] is None:
-                    ports[f"{x},{y}"].append(tile.getNorthSidePorts())
-                if x + 1 >= len(self.tileMap[y]) or self.tileMap[y][x + 1] is None:
-                    ports[f"{x},{y}"].append(tile.getEastSidePorts())
-                if y - 1 < 0 or self.tileMap[y - 1][x] is None:
-                    ports[f"{x},{y}"].append(tile.getSouthSidePorts())
-                if x - 1 < 0 or self.tileMap[y][x - 1] is None:
-                    ports[f"{x},{y}"].append(tile.getWestSidePorts())
+                if y + 1 >= len(self.tile_map) or self.tile_map[y + 1][x] is None:
+                    ports[f"{x},{y}"].append(tile.get_port_on_side(Side.NORTH))
+                if x + 1 >= len(self.tile_map[y]) or self.tile_map[y][x + 1] is None:
+                    ports[f"{x},{y}"].append(tile.get_port_on_side(Side.EAST))
+                if y - 1 < 0 or self.tile_map[y - 1][x] is None:
+                    ports[f"{x},{y}"].append(tile.get_port_on_side(Side.SOUTH))
+                if x - 1 < 0 or self.tile_map[y][x - 1] is None:
+                    ports[f"{x},{y}"].append(tile.get_port_on_side(Side.WEST))
         return ports
 
     def __iter__(self) -> Generator[tuple[tuple[int, int], Tile], None, None]:
         """Iterate over all sub-tiles in the supertile."""
-        for x, row in enumerate(self.tileMap):
+        for x, row in enumerate(self.tile_map):
             for y, tile in enumerate(row):
                 if tile is not None:
                     yield (x, y), tile
@@ -101,33 +102,41 @@ class SuperTile:
             A list of tuples which contains the internal connected port
             and the x and y coordinate of the tile.
         """
-        internalConnections = []
-        for y, row in enumerate(self.tileMap):
+        internal_connections = []
+        for y, row in enumerate(self.tile_map):
             for x, tile in enumerate(row):
                 if tile is None:
                     continue
                 # Bottom-left origin: y+1 is north (above), y-1 is south (below)
                 if (
-                    0 <= y + 1 < len(self.tileMap)
-                    and self.tileMap[y + 1][x] is not None
+                    0 <= y + 1 < len(self.tile_map)
+                    and self.tile_map[y + 1][x] is not None
                 ):
-                    internalConnections.append((tile.getNorthSidePorts(), x, y))
+                    internal_connections.append(
+                        (tile.get_port_on_side(Side.NORTH), x, y)
+                    )
                 if (
-                    0 <= x + 1 < len(self.tileMap[0])
-                    and self.tileMap[y][x + 1] is not None
+                    0 <= x + 1 < len(self.tile_map[0])
+                    and self.tile_map[y][x + 1] is not None
                 ):
-                    internalConnections.append((tile.getEastSidePorts(), x, y))
+                    internal_connections.append(
+                        (tile.get_port_on_side(Side.EAST), x, y)
+                    )
                 if (
-                    0 <= y - 1 < len(self.tileMap)
-                    and self.tileMap[y - 1][x] is not None
+                    0 <= y - 1 < len(self.tile_map)
+                    and self.tile_map[y - 1][x] is not None
                 ):
-                    internalConnections.append((tile.getSouthSidePorts(), x, y))
+                    internal_connections.append(
+                        (tile.get_port_on_side(Side.SOUTH), x, y)
+                    )
                 if (
-                    0 <= x - 1 < len(self.tileMap[0])
-                    and self.tileMap[y][x - 1] is not None
+                    0 <= x - 1 < len(self.tile_map[0])
+                    and self.tile_map[y][x - 1] is not None
                 ):
-                    internalConnections.append((tile.getWestSidePorts(), x, y))
-        return internalConnections
+                    internal_connections.append(
+                        (tile.get_port_on_side(Side.WEST), x, y)
+                    )
+        return internal_connections
 
     def get_master_tile_coords(self) -> tuple[int, int]:
         """Return the (x, y) coordinates of the master tile in local space.
@@ -158,7 +167,7 @@ class SuperTile:
             return self.master_tile_coords
         mx, my = 0, 0
         found = False
-        for y, row in enumerate(self.tileMap):
+        for y, row in enumerate(self.tile_map):
             for x, tile in enumerate(row):
                 if tile is not None:
                     mx, my = x, y
@@ -179,7 +188,7 @@ class SuperTile:
             with `wire_direction == Direction.SJUMP` in any child tile.
         """
         result = []
-        for y, row in enumerate(self.tileMap):
+        for y, row in enumerate(self.tile_map):
             for x, tile in enumerate(row):
                 if tile is None:
                     continue
@@ -198,7 +207,7 @@ class SuperTile:
             with `wire_direction == Direction.SJUMP` in any child tile.
         """
         result = []
-        for y, row in enumerate(self.tileMap):
+        for y, row in enumerate(self.tile_map):
             for x, tile in enumerate(row):
                 if tile is None:
                     continue
@@ -225,7 +234,7 @@ class SuperTile:
         valid_sources: set[str] = set()
         valid_sinks: set[str] = set()
 
-        for row in self.tileMap:
+        for row in self.tile_map:
             for tile in row:
                 if tile is None:
                     continue
@@ -260,12 +269,12 @@ class SuperTile:
     @property
     def max_width(self) -> int:
         """Return the maximum width of the supertile."""
-        return max(len(i) for i in self.tileMap)
+        return max(len(i) for i in self.tile_map)
 
     @property
     def max_height(self) -> int:
         """Return the maximum height of the supertile."""
-        return len(self.tileMap)
+        return len(self.tile_map)
 
     def get_min_die_area(
         self,

--- a/fabulous/fabric_definition/tile.py
+++ b/fabulous/fabric_definition/tile.py
@@ -1,9 +1,12 @@
 """Tile class definition for FPGA fabric representation."""
 
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from decimal import Decimal
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from loguru import logger
 
 from fabulous.fabric_definition.bel import Bel
 from fabulous.fabric_definition.define import IO, Direction, PinSortMode, Side
@@ -27,6 +30,15 @@ if TYPE_CHECKING:
 class Tile:
     """Store information about a tile.
 
+    A tile is composite-capable: a leaf tile is a 1x1 composite of itself, while
+    a former supertile is a ``Tile`` whose ``tile_map`` holds a grid of sub-tile
+    objects. The grid is stored top row first, so ``tile_map[0]`` is the TOP row
+    (physically north) and ``tile_map[-1]`` is the bottom row (physically south).
+    All ``(x, y)`` cell coordinates produced by :meth:`__iter__`,
+    :meth:`get_ports_around_tile`, :meth:`get_sub_tile_offset`,
+    :meth:`get_anchor_offset` and :meth:`get_master_offset` use ``x`` as the
+    column index and ``y`` as the row index in this top-first space.
+
     Parameters
     ----------
     name : str
@@ -42,7 +54,7 @@ class Tile:
         when the tile has no wrapper switch matrix.
     gen_ios : list[Gen_IO]
         List of general I/O components
-    userCLK : bool
+    user_clk : bool
         True if the tile uses a clk signal
     switch_matrix : SwitchMatrix
         Switch matrix of the tile, holding its source file, connectivity, and
@@ -50,8 +62,16 @@ class Tile:
     pin_order_config : dict[Side, PinOrderConfig] | None, optional
         Configuration for pin ordering on each side of the tile. If None, defaults to
         BUS_MAJOR sorting on all sides.
-    tileMap : list[list[str | None]] | None, optional
-        2D sub-tile layout for composite tiles, or None for simple tiles.
+    tile_map : list[list[Tile | None]] | None, optional
+        The 2D grid of sub-tile objects for a composite tile, stored top row
+        first. ``None`` for a leaf tile. Default is None.
+    sub_tiles : list[Tile] | None, optional
+        The flat list of constituent sub-tiles of a composite tile. Defaults to
+        an empty list for a leaf tile.
+    master_offset : tuple[int, int] | None, optional
+        Explicit ``(x, y)`` cell of the master sub-tile (where the wrapper BELs
+        and config bits live). When None, the master defaults to the last
+        non-None cell in row-major order. Default is None.
 
     Attributes
     ----------
@@ -65,18 +85,25 @@ class Tile:
         The switch matrix of the tile
     gen_ios : list[Gen_IO]
         The list of GEN_IOs of the tile
-    withUserCLK : bool
-        Whether the tile has a userCLK port. Default is False.
+    with_user_clk : bool
+        Whether the tile has a user_clk port. Default is False.
     wire_list : list[Wire]
         The list of wires of the tile
     tile_dir : Path
         The path to the tile folder
-    partOfSuperTile : bool, optional
+    part_of_super_tile : bool, optional
         Whether the tile is part of a super tile. Default is False.
     pin_order_config : dict, optional
         Configuration for pin ordering on each side of the tile.
-    tileMap : list[list[str | None]] | None, optional
-        2D sub-tile layout for composite tiles, or None for simple tiles.
+    tile_map : list[list[Tile | None]] | None, optional
+        The 2D grid of sub-tile objects for a composite tile, stored top row
+        first. ``None`` for a leaf tile. Default is None.
+    sub_tiles : list[Tile], optional
+        The flat list of constituent sub-tiles of a composite tile. Empty for a
+        leaf tile.
+    master_offset : tuple[int, int] | None, optional
+        Explicit ``(x, y)`` cell of the master sub-tile, or None to use the
+        row-major default.
     """
 
     name: str
@@ -84,12 +111,14 @@ class Tile:
     bels: list[Bel]
     switch_matrix: SwitchMatrix
     gen_ios: list[Gen_IO]
-    withUserCLK: bool = False
+    with_user_clk: bool = False
     wire_list: list[Wire] = field(default_factory=list)
     tile_dir: Path = Path()
-    partOfSuperTile: bool = False
+    part_of_super_tile: bool = False
     pin_order_config: dict = field(default_factory=dict)
-    tileMap: list[list[str | None]] | None = None  # 2D sub-tile layout
+    tile_map: list[list["Tile | None"]] | None = None  # 2D sub-tile layout
+    sub_tiles: list["Tile"] = field(default_factory=list)  # flat list of sub-tiles
+    master_offset: tuple[int, int] | None = None  # explicit master cell (x, y)
 
     def __init__(
         self,
@@ -99,21 +128,25 @@ class Tile:
         tile_dir: Path,
         matrix_dir: Path,
         gen_ios: list[Gen_IO],
-        userCLK: bool,
+        user_clk: bool,
         switch_matrix: SwitchMatrix,
         pin_order_config: dict[Side, "PinOrderConfig"] | None = None,
-        tileMap: list[list[str | None]] | None = None,
+        tile_map: list[list["Tile | None"]] | None = None,
+        sub_tiles: list["Tile"] | None = None,
+        master_offset: tuple[int, int] | None = None,
     ) -> None:
         self.name = name
         self.ports_info = ports
         self.bels = bels
         self.gen_ios = gen_ios
         self.matrix_dir = matrix_dir
-        self.withUserCLK = userCLK
+        self.with_user_clk = user_clk
         self.switch_matrix = switch_matrix
         self.wire_list = []
         self.tile_dir = tile_dir
-        self.tileMap = tileMap
+        self.tile_map = tile_map
+        self.sub_tiles = sub_tiles if sub_tiles is not None else []
+        self.master_offset = master_offset
 
         if pin_order_config is None:
             from fabulous.fabric_generator.gds_generator.gen_io_pin_config_yaml import (
@@ -145,62 +178,6 @@ class Tile:
         if __o is None or not isinstance(__o, Tile):
             return False
         return self.name == __o.name
-
-    def getWestSidePorts(self) -> list[TilePort]:
-        """Get all ports physically located on the west side of the tile.
-
-        Returns
-        -------
-        list[TilePort]
-            List of ports on the west side, excluding NULL ports.
-        """
-        return [
-            p
-            for p in self.ports_info
-            if p.side_of_tile == Side.WEST and not p.name_is_null
-        ]
-
-    def getEastSidePorts(self) -> list[TilePort]:
-        """Get all ports physically located on the east side of the tile.
-
-        Returns
-        -------
-        list[TilePort]
-            List of ports on the east side, excluding NULL ports.
-        """
-        return [
-            p
-            for p in self.ports_info
-            if p.side_of_tile == Side.EAST and not p.name_is_null
-        ]
-
-    def getNorthSidePorts(self) -> list[TilePort]:
-        """Get all ports physically located on the north side of the tile.
-
-        Returns
-        -------
-        list[TilePort]
-            List of ports on the north side, excluding NULL ports.
-        """
-        return [
-            p
-            for p in self.ports_info
-            if p.side_of_tile == Side.NORTH and not p.name_is_null
-        ]
-
-    def getSouthSidePorts(self) -> list[TilePort]:
-        """Get all ports physically located on the south side of the tile.
-
-        Returns
-        -------
-        list[TilePort]
-            List of ports on the south side, excluding NULL ports.
-        """
-        return [
-            p
-            for p in self.ports_info
-            if p.side_of_tile == Side.SOUTH and not p.name_is_null
-        ]
 
     def get_port_on_side(self, side: Side, io: IO | None = None) -> list[TilePort]:
         """Get the ports physically located on a given side of the tile.
@@ -262,7 +239,21 @@ class Tile:
         ]
 
     @property
-    def globalConfigBits(self) -> int:
+    def switch_matrix_config_bits(self) -> int:
+        """Get the number of config bits for the switch matrix.
+
+        This is a backward-compatibility property that returns
+        the config_bits from the switch_matrix.
+
+        Returns
+        -------
+        int
+            Number of configuration bits for the switch matrix.
+        """
+        return self.switch_matrix.total_config_bits
+
+    @property
+    def total_config_bits(self) -> int:
         """Get the total number of global configuration bits.
 
         Calculates the sum of switch matrix configuration bits
@@ -330,6 +321,11 @@ class Tile:
 
             min_dim = required_tracks * pitch
 
+        For a composite tile the per-side pin count is the maximum across all
+        constituent sub-tiles (a conservative upper bound). A leaf tile's
+        :meth:`get_sub_tiles` returns ``[self]``, so the same code path naturally
+        uses the leaf's own per-side pin counts.
+
         Parameters
         ----------
         x_pitch : Decimal
@@ -352,10 +348,11 @@ class Tile:
         tuple[Decimal, Decimal]
             (min_width, min_height)
         """
-        north_ports = self.get_port_count(Side.NORTH)
-        south_ports = self.get_port_count(Side.SOUTH)
-        west_ports = self.get_port_count(Side.WEST)
-        east_ports = self.get_port_count(Side.EAST)
+        sub_tiles = self.get_sub_tiles()
+        north_ports = max(sub.get_port_count(Side.NORTH) for sub in sub_tiles)
+        south_ports = max(sub.get_port_count(Side.SOUTH) for sub in sub_tiles)
+        west_ports = max(sub.get_port_count(Side.WEST) for sub in sub_tiles)
+        east_ports = max(sub.get_port_count(Side.EAST) for sub in sub_tiles)
 
         x_io_count = Decimal(max(north_ports, south_ports) + frame_strobe_width)
         min_width_io = (x_io_count * x_pin_thickness_mult + edge_offset) * x_pitch
@@ -367,137 +364,363 @@ class Tile:
 
     @property
     def ports(self) -> dict[str, list[TilePort]]:
-        """Provide hierarchical view of ports grouped by sub-tile name.
+        """Provide a hierarchical view of ports grouped by sub-tile name.
 
-        For simple tiles (no tileMap), all ports are grouped under the tile name.
-        For composite tiles, ports are grouped by their sub-tile attribute if
-        available, otherwise by the tile name.
+        Sub-tile ownership is structural: each sub-tile object owns its own
+        ``ports_info``. A leaf tile's :meth:`get_sub_tiles` returns ``[self]``, so
+        its ports are grouped under the tile's own name. A composite tile groups
+        each sub-tile's ports under that sub-tile's name; sub-tiles that share a
+        name have their ports merged.
 
         Returns
         -------
         dict[str, list[TilePort]]
             Dictionary mapping sub-tile names to their associated ports.
         """
-        if self.tileMap is None:
-            return {self.name: self.ports_info}
-
         result: dict[str, list[TilePort]] = {}
-        for port in self.ports_info:
-            subtile = getattr(port, "subTile", self.name)
-            if subtile not in result:
-                result[subtile] = []
-            result[subtile].append(port)
+        for sub_tile in self.get_sub_tiles():
+            result.setdefault(sub_tile.name, []).extend(sub_tile.ports_info)
         return result
 
     @property
     def bel_groups(self) -> dict[str, list[Bel]]:
-        """Provide hierarchical view of BELs grouped by sub-tile name.
+        """Provide a hierarchical view of BELs grouped by sub-tile name.
 
-        For simple tiles (no tileMap), all BELs are grouped under the tile name.
-        For composite tiles, BELs are grouped by their sub-tile attribute if
-        available, otherwise by the tile name.
+        Sub-tile ownership is structural: each sub-tile object owns its own
+        ``bels``. A leaf tile's :meth:`get_sub_tiles` returns ``[self]``, so its
+        BELs are grouped under the tile's own name. A composite tile groups each
+        sub-tile's BELs under that sub-tile's name; sub-tiles that share a name
+        have their BELs merged. A composite's own wrapper BELs (``self.bels``)
+        are not sub-tile BELs and are surfaced separately via :attr:`bels`.
 
         Returns
         -------
         dict[str, list[Bel]]
             Dictionary mapping sub-tile names to their associated BELs.
         """
-        if self.tileMap is None:
-            return {self.name: self.bels}
-
         result: dict[str, list[Bel]] = {}
-        for bel in self.bels:
-            subtile = getattr(bel, "subTile", self.name)
-            if subtile not in result:
-                result[subtile] = []
-            result[subtile].append(bel)
+        for sub_tile in self.get_sub_tiles():
+            result.setdefault(sub_tile.name, []).extend(sub_tile.bels)
         return result
 
     @property
     def config_bits(self) -> int:
         """Get the total number of configuration bits.
 
-        This is an alias for globalConfigBits for API compatibility.
+        This is an alias for total_config_bits for API compatibility.
 
         Returns
         -------
         int
             Total number of configuration bits for the tile.
         """
-        return self.globalConfigBits
+        return self.total_config_bits
 
-    def get_sub_tiles(self) -> list[str]:
-        """Get list of all sub-tile names.
+    @property
+    def is_composite(self) -> bool:
+        """Whether this tile is a composite tile holding sub-tiles.
 
         Returns
         -------
-        list[str]
-            List of sub-tile names. For simple tiles, returns [tile.name].
+        bool
+            ``True`` if the tile carries a ``tile_map`` (and therefore contains
+            sub-tiles), ``False`` for a leaf tile.
         """
-        if self.tileMap is None:
-            return [self.name]
-        return [name for row in self.tileMap for name in row if name is not None]
+        return self.tile_map is not None
 
-    def get_sub_tile_offset(self, subTile: str) -> tuple[int, int]:
-        """Get (x, y) offset for a sub-tile in the tile map.
+    @property
+    def max_width(self) -> int:
+        """Maximum number of columns across the tile map.
 
-        Parameters
-        ----------
-        subTile : str
-            Name of the sub-tile to find.
+        Returns
+        -------
+        int
+            The widest row in ``tile_map`` for a composite tile, or ``1`` for a
+            leaf tile.
+        """
+        if self.tile_map is None:
+            return 1
+        return max(len(row) for row in self.tile_map)
+
+    @property
+    def max_height(self) -> int:
+        """Number of rows in the tile map.
+
+        Returns
+        -------
+        int
+            The number of rows in ``tile_map`` for a composite tile, or ``1`` for
+            a leaf tile.
+        """
+        if self.tile_map is None:
+            return 1
+        return len(self.tile_map)
+
+    def __iter__(self) -> Iterator[tuple[tuple[int, int], "Tile"]]:
+        """Iterate over the sub-tiles and their grid coordinates.
+
+        For a leaf tile a single ``((0, 0), self)`` pair is yielded. For a
+        composite tile each non-``None`` cell is yielded as ``((x, y), tile)``
+        where ``x`` is the column index and ``y`` is the row index.
+
+        Yields
+        ------
+        tuple[tuple[int, int], Tile]
+            The ``(x, y)`` grid coordinate and the sub-tile at that cell.
+        """
+        if self.tile_map is None:
+            yield (0, 0), self
+            return
+        for y, row in enumerate(self.tile_map):
+            for x, tile in enumerate(row):
+                if tile is not None:
+                    yield (x, y), tile
+
+    def get_ports_around_tile(self) -> dict[str, list[list[TilePort]]]:
+        """Return the perimeter side ports of each composite sub-tile cell.
+
+        The dictionary key is the sub-tile cell location in ``"x,y"`` format,
+        matching the ``(x, y)`` grid indexing of :meth:`__iter__` (``x`` is the
+        column, ``y`` is the row). For each present cell, the side-port list of a
+        given side is appended only when that side faces the composite boundary
+        (its neighbour in the grid is missing or ``None``). ``tile_map`` is stored
+        top row first, so a smaller row index is physically north.
+
+        Returns
+        -------
+        dict[str, list[list[TilePort]]]
+            Mapping from cell coordinate to the perimeter side-port lists. An
+            empty dict for a leaf tile.
+        """
+        if self.tile_map is None:
+            return {}
+
+        ports: dict[str, list[list[TilePort]]] = {}
+        for y, row in enumerate(self.tile_map):
+            for x, tile in enumerate(row):
+                if tile is None:
+                    continue
+                key = f"{x},{y}"
+                ports[key] = []
+                # Top-first storage: y-1 is physically north, y+1 is south.
+                if y - 1 < 0 or self.tile_map[y - 1][x] is None:
+                    ports[key].append(tile.get_port_on_side(Side.NORTH))
+                if y + 1 >= len(self.tile_map) or self.tile_map[y + 1][x] is None:
+                    ports[key].append(tile.get_port_on_side(Side.SOUTH))
+                if x + 1 >= len(row) or row[x + 1] is None:
+                    ports[key].append(tile.get_port_on_side(Side.EAST))
+                if x - 1 < 0 or row[x - 1] is None:
+                    ports[key].append(tile.get_port_on_side(Side.WEST))
+        return ports
+
+    def get_internal_connections(self) -> list[tuple[list[TilePort], int, int]]:
+        """Return the internal edge side ports between adjacent sub-tile cells.
+
+        For each present cell, the side-port list of a given side is reported
+        when that side faces another present sub-tile (an internal edge). Each
+        entry carries the side ports and the ``(x, y)`` cell coordinate, using
+        the same grid indexing as :meth:`__iter__`. ``tile_map`` is stored top row
+        first, so a smaller row index is physically north.
+
+        Returns
+        -------
+        list[tuple[list[TilePort], int, int]]
+            One entry per internal edge as ``(side_ports, x, y)``. An empty list
+            for a leaf tile.
+        """
+        if self.tile_map is None:
+            return []
+
+        internal_connections: list[tuple[list[TilePort], int, int]] = []
+        for y, row in enumerate(self.tile_map):
+            for x, tile in enumerate(row):
+                if tile is None:
+                    continue
+                # Top-first storage: y-1 is physically north, y+1 is south.
+                if y - 1 >= 0 and self.tile_map[y - 1][x] is not None:
+                    internal_connections.append(
+                        (tile.get_port_on_side(Side.NORTH), x, y)
+                    )
+                if y + 1 < len(self.tile_map) and self.tile_map[y + 1][x] is not None:
+                    internal_connections.append(
+                        (tile.get_port_on_side(Side.SOUTH), x, y)
+                    )
+                if x + 1 < len(row) and row[x + 1] is not None:
+                    internal_connections.append(
+                        (tile.get_port_on_side(Side.EAST), x, y)
+                    )
+                if x - 1 >= 0 and row[x - 1] is not None:
+                    internal_connections.append(
+                        (tile.get_port_on_side(Side.WEST), x, y)
+                    )
+        return internal_connections
+
+    def get_anchor_offset(self) -> tuple[int, int]:
+        """Return the ``(x, y)`` cell of the composite anchor sub-tile.
+
+        The anchor is where the composite is structurally placed and where its
+        external ports are named: the first non-None cell in row-major order,
+        which under top-first storage is the top-left cell. A leaf tile anchors
+        at the origin.
 
         Returns
         -------
         tuple[int, int]
-            (x, y) position in the tile map, with y=0 at the top row.
+            The ``(x, y)`` anchor cell, ``(0, 0)`` for a leaf tile.
+
+        Raises
+        ------
+        ValueError
+            If a composite tile has an all-None ``tile_map``.
+        """
+        if self.tile_map is None:
+            return (0, 0)
+        for y, row in enumerate(self.tile_map):
+            for x, tile in enumerate(row):
+                if tile is not None:
+                    return (x, y)
+        message = (
+            f"Composite tile '{self.name}' has no sub-tiles; cannot determine anchor"
+        )
+        logger.error(message)
+        raise ValueError(message)
+
+    def get_master_offset(self) -> tuple[int, int]:
+        """Return the ``(x, y)`` cell of the composite master sub-tile.
+
+        The master is where the wrapper's BELs and config bits physically live.
+        When ``master_offset`` is set it is returned directly; otherwise the
+        master defaults to the last non-None cell in row-major order. A leaf tile
+        masters at the origin.
+
+        Returns
+        -------
+        tuple[int, int]
+            The ``(x, y)`` master cell, ``(0, 0)`` for a leaf tile.
+
+        Raises
+        ------
+        ValueError
+            If a composite tile has an all-None ``tile_map`` and no explicit
+            ``master_offset``.
+        """
+        if self.tile_map is None:
+            return (0, 0)
+        if self.master_offset is not None:
+            return self.master_offset
+
+        master: tuple[int, int] | None = None
+        for y, row in enumerate(self.tile_map):
+            for x, tile in enumerate(row):
+                if tile is not None:
+                    master = (x, y)
+        if master is None:
+            message = (
+                f"Composite tile '{self.name}' has no sub-tiles; "
+                "cannot determine master"
+            )
+            logger.error(message)
+            raise ValueError(message)
+        return master
+
+    def get_sub_tiles(self) -> list["Tile"]:
+        """Get the list of all sub-tiles.
+
+        Returns
+        -------
+        list[Tile]
+            The non-``None`` sub-tile objects of a composite tile, or ``[self]``
+            for a leaf tile.
+        """
+        if self.tile_map is None:
+            return [self]
+        return [tile for row in self.tile_map for tile in row if tile is not None]
+
+    def get_sub_tile_offset(self, sub_tile: "Tile | str") -> tuple[int, int]:
+        """Get the (x, y) offset for a sub-tile in the tile map.
+
+        Parameters
+        ----------
+        sub_tile : Tile | str
+            The sub-tile object or its name to locate.
+
+        Returns
+        -------
+        tuple[int, int]
+            The ``(x, y)`` position in the tile map, with ``y=0`` at the top row,
+            matching :meth:`get_anchor_offset` and :meth:`get_master_offset`.
 
         Raises
         ------
         ValueError
             If the sub-tile is not found.
         """
-        if self.tileMap is None:
-            if subTile == self.name:
+        if self.tile_map is None:
+            if self._matches_tile(self, sub_tile):
                 return (0, 0)
-            raise ValueError(f"Sub-tile '{subTile}' not found in tile '{self.name}'")
+            raise ValueError(f"Sub-tile '{sub_tile}' not found in tile '{self.name}'")
 
-        for y, row in enumerate(self.tileMap):
-            for x, name in enumerate(row):
-                if name == subTile:
+        for y, row in enumerate(self.tile_map):
+            for x, tile in enumerate(row):
+                if tile is not None and self._matches_tile(tile, sub_tile):
                     return (x, y)
-        raise ValueError(f"Sub-tile '{subTile}' not found in tileMap")
+        raise ValueError(f"Sub-tile '{sub_tile}' not found in tile_map")
 
-    def part_of_tile(self, name: str) -> bool:
-        """Check if name is part of this tile.
+    def part_of_tile(self, sub_tile: "Tile | str") -> bool:
+        """Check whether a sub-tile is part of this tile.
 
         Parameters
         ----------
-        name : str
-            Name to check.
+        sub_tile : Tile | str
+            The sub-tile object or its name to check.
 
         Returns
         -------
         bool
-            True if name is a sub-tile of this tile.
+            ``True`` if the given sub-tile is a sub-tile of this tile.
         """
-        return name in self.get_sub_tiles()
+        return any(self._matches_tile(tile, sub_tile) for tile in self.get_sub_tiles())
 
-    def is_root_tile(self, name: str) -> bool:
-        """Check if name is the root sub-tile (bottom-left).
+    def is_root_tile(self, sub_tile: "Tile | str") -> bool:
+        """Check whether a sub-tile is the root sub-tile (bottom-left).
 
         Parameters
         ----------
-        name : str
-            Name to check.
+        sub_tile : Tile | str
+            The sub-tile object or its name to check.
 
         Returns
         -------
         bool
-            True if name is the root sub-tile.
+            ``True`` if the given sub-tile is the bottom-left sub-tile.
         """
-        if self.tileMap is None:
-            return name == self.name
-        return self.tileMap[-1][0] == name
+        if self.tile_map is None:
+            return self._matches_tile(self, sub_tile)
+        root_tile = self.tile_map[-1][0]
+        if root_tile is None:
+            return False
+        return self._matches_tile(root_tile, sub_tile)
+
+    @staticmethod
+    def _matches_tile(tile: "Tile", reference: "Tile | str") -> bool:
+        """Check whether a tile matches a reference object or name.
+
+        Parameters
+        ----------
+        tile : Tile
+            The candidate sub-tile.
+        reference : Tile | str
+            The sub-tile object or name to match against.
+
+        Returns
+        -------
+        bool
+            ``True`` if ``tile`` matches ``reference`` by name (when a string is
+            given) or by equality (when a tile object is given).
+        """
+        if isinstance(reference, str):
+            return tile.name == reference
+        return tile == reference
 
     def find_port_by_name(self, port_name: str) -> GenericPort | None:
         """Find a port by name in tile ports or BEL ports.
@@ -562,12 +785,12 @@ class Tile:
 
         return False
 
-    def get_tile_input_ports(self, subTile: str = "") -> list[TilePort]:
+    def get_tile_input_ports(self, sub_tile: str = "") -> list[TilePort]:
         """Get all input ports, optionally filtered by sub-tile.
 
         Parameters
         ----------
-        subTile : str, optional
+        sub_tile : str, optional
             Sub-tile name to filter by. If empty, returns all input ports.
 
         Returns
@@ -575,15 +798,15 @@ class Tile:
         list[TilePort]
             List of input ports, sorted by name.
         """
-        ports = self.ports.get(subTile, []) if subTile else self.ports_info
+        ports = self.ports.get(sub_tile, []) if sub_tile else self.ports_info
         return sorted([p for p in ports if p.is_input], key=lambda p: p.name)
 
-    def get_tile_output_ports(self, subTile: str = "") -> list[TilePort]:
+    def get_tile_output_ports(self, sub_tile: str = "") -> list[TilePort]:
         """Get all output ports, optionally filtered by sub-tile.
 
         Parameters
         ----------
-        subTile : str, optional
+        sub_tile : str, optional
             Sub-tile name to filter by. If empty, returns all output ports.
 
         Returns
@@ -591,7 +814,7 @@ class Tile:
         list[TilePort]
             List of output ports, sorted by name.
         """
-        ports = self.ports.get(subTile, []) if subTile else self.ports_info
+        ports = self.ports.get(sub_tile, []) if sub_tile else self.ports_info
         return sorted([p for p in ports if p.is_output], key=lambda p: p.name)
 
     def get_tile_port_grouped(self, io: IO | None = None) -> dict[Side, list[TilePort]]:
@@ -608,10 +831,10 @@ class Tile:
             Dictionary mapping Side enum to list of ports on that side.
         """
         result = {
-            Side.NORTH: self.getNorthSidePorts(),
-            Side.EAST: self.getEastSidePorts(),
-            Side.SOUTH: self.getSouthSidePorts(),
-            Side.WEST: self.getWestSidePorts(),
+            Side.NORTH: self.get_port_on_side(Side.NORTH),
+            Side.EAST: self.get_port_on_side(Side.EAST),
+            Side.SOUTH: self.get_port_on_side(Side.SOUTH),
+            Side.WEST: self.get_port_on_side(Side.WEST),
         }
         if io is not None:
             for side in result:
@@ -685,15 +908,19 @@ class Tile:
             "name": self.name,
             "ports": {k: [p.serialize() for p in v] for k, v in self.ports.items()},
             "bels": [b.serialize() for b in self.bels],
-            "switch_matrix": (
-                self.switch_matrix.serialize()
-                if hasattr(self.switch_matrix, "serialize")
-                else {"config_bits": self.switch_matrix.total_config_bits}
+            "switch_matrix": self.switch_matrix.serialize(),
+            "config_bits": self.total_config_bits,
+            "with_user_clk": self.with_user_clk,
+            "tile_map": (
+                [
+                    [tile.name if tile is not None else None for tile in row]
+                    for row in self.tile_map
+                ]
+                if self.tile_map is not None
+                else None
             ),
-            "config_bits": self.globalConfigBits,
-            "withUserCLK": self.withUserCLK,
-            "tileMap": self.tileMap,
-            "partOfSuperTile": self.partOfSuperTile,
+            "part_of_super_tile": self.part_of_super_tile,
+            "is_composite": self.is_composite,
         }
 
     def __str__(self) -> str:
@@ -705,13 +932,13 @@ class Tile:
             Multi-line string describing the tile.
         """
         lines = [f"Tile: {self.name}"]
-        lines.append(f"  Config bits: {self.globalConfigBits}")
+        lines.append(f"  Config bits: {self.total_config_bits}")
         lines.append(f"  Switch matrix bits: {self.switch_matrix_config_bits}")
         lines.append(f"  BELs: {len(self.bels)}")
         lines.append(f"  Ports: {len(self.ports_info)}")
-        lines.append(f"  User CLK: {self.withUserCLK}")
+        lines.append(f"  User CLK: {self.with_user_clk}")
 
-        if self.tileMap:
+        if self.tile_map:
             lines.append(f"  Sub-tiles: {self.get_sub_tiles()}")
 
         # Port summary by side

--- a/fabulous/fabric_generator/gds_generator/flows/fabric_macro_flow.py
+++ b/fabulous/fabric_generator/gds_generator/flows/fabric_macro_flow.py
@@ -201,7 +201,7 @@ class FABulousFabricMacroFlow(Classic):
         supertile_anchors: dict[str, str] = {}
         subtile_to_anchor: dict[str, str] = {}
         for supertile_name, supertile in fabric.superTileDic.items():
-            anchor = supertile.tileMap[-1][0]
+            anchor = supertile.tile_map[-1][0]
             supertile_anchors[anchor.name] = supertile_name
             # Create back-references from all subtiles to their anchor
             for tile in supertile.tiles:
@@ -218,8 +218,10 @@ class FABulousFabricMacroFlow(Classic):
                 supertile_name = supertile_anchors[tile_key]
                 supertile = fabric.superTileDic[supertile_name]
                 width, height = tile_sizes[supertile_name]
-                num_rows_spanned = len(supertile.tileMap)
-                num_cols_spanned = len(supertile.tileMap[0]) if supertile.tileMap else 1
+                num_rows_spanned = len(supertile.tile_map)
+                num_cols_spanned = (
+                    len(supertile.tile_map[0]) if supertile.tile_map else 1
+                )
             elif tile_key in subtile_to_anchor:
                 # This is a non-anchor subtile, skip it but process only
                 # when we hit the anchor
@@ -593,7 +595,7 @@ class FABulousFabricMacroFlow(Classic):
                     subtiles = [tile.name for tile in supertile.tiles]
 
                     # Get the anchor of the supertile (bottom left)
-                    anchor = supertile.tileMap[-1][0]
+                    anchor = supertile.tile_map[-1][0]
 
                     if tile_name in subtiles:
                         if tile_name == anchor.name:

--- a/fabulous/fabric_generator/gds_generator/gen_io_pin_config_yaml.py
+++ b/fabulous/fabric_generator/gds_generator/gen_io_pin_config_yaml.py
@@ -50,7 +50,7 @@ def _serialize_tile_ports(
         Side.WEST.name: [],
     }
 
-    for port in tile.getNorthSidePorts():
+    for port in tile.get_port_on_side(Side.NORTH):
         if regex := port.get_port_regex(indexed=True, prefix=prefix):
             port_dict[Side.NORTH.name].append(
                 tile.pin_order_config[Side.NORTH]([regex]).to_dict()
@@ -60,7 +60,7 @@ def _serialize_tile_ports(
         PinOrderConfig()([rf"{prefix}FrameStrobe_O\[\d+\]"]).to_dict()
     )
 
-    for port in tile.getEastSidePorts():
+    for port in tile.get_port_on_side(Side.EAST):
         if regex := port.get_port_regex(indexed=True, prefix=prefix):
             port_dict[Side.EAST.name].append(
                 tile.pin_order_config[Side.EAST]([regex]).to_dict()
@@ -69,7 +69,7 @@ def _serialize_tile_ports(
         PinOrderConfig()([rf"{prefix}FrameData_O\[\d+\]"]).to_dict()
     )
 
-    for port in tile.getSouthSidePorts():
+    for port in tile.get_port_on_side(Side.SOUTH):
         if regex := port.get_port_regex(indexed=True, prefix=prefix):
             port_dict[Side.SOUTH.name].append(
                 tile.pin_order_config[Side.SOUTH]([regex]).to_dict()
@@ -79,7 +79,7 @@ def _serialize_tile_ports(
         PinOrderConfig()([rf"{prefix}FrameStrobe\[\d+\]"]).to_dict()
     )
 
-    for port in tile.getWestSidePorts():
+    for port in tile.get_port_on_side(Side.WEST):
         if regex := port.get_port_regex(indexed=True, prefix=prefix):
             port_dict[Side.WEST.name].append(
                 tile.pin_order_config[Side.WEST]([regex]).to_dict()
@@ -124,7 +124,7 @@ def _serialize_supertile_ports(
         }
 
         x_int, y_int = int(x), int(y)
-        tile = super_tile.tileMap[y_int][x_int]
+        tile = super_tile.tile_map[y_int][x_int]
         if tile is None:
             continue
 
@@ -148,7 +148,7 @@ def _serialize_supertile_ports(
         # carries FrameData on its WEST edge). Derive the full perimeter set from
         # the supertile layout instead of relying on the routing-port list.
         all_perimeter_sides: set[Side] = set()
-        tm = super_tile.tileMap
+        tm = super_tile.tile_map
         if y_int == 0 or tm[y_int - 1][x_int] is None:
             all_perimeter_sides.add(Side.NORTH)
         if x_int + 1 >= len(tm[y_int]) or tm[y_int][x_int + 1] is None:
@@ -213,7 +213,7 @@ def _serialize_supertile_ports(
         ]
         mx, my = super_tile.get_master_tile_coords()
         master_key = f"X{mx}Y{my}"
-        master_tile = super_tile.tileMap[my][mx]
+        master_tile = super_tile.tile_map[my][mx]
         if st_pin_regexes and master_tile is not None and master_key in config_payload:
             if external_port_sides and (mx, my) in external_port_sides:
                 master_side = external_port_sides[(mx, my)]
@@ -265,7 +265,7 @@ def generate_IO_pin_order_config(
                 base_x = min(pos[0] for pos in positions)
                 base_y = min(pos[1] for pos in positions)
 
-            for st_y, row in enumerate(tile_or_super_tile.tileMap):
+            for st_y, row in enumerate(tile_or_super_tile.tile_map):
                 for st_x, st_tile in enumerate(row):
                     if st_tile is None:
                         continue
@@ -276,7 +276,7 @@ def generate_IO_pin_order_config(
         else:
             sides = {
                 (x, y): external_port_side
-                for y, row in enumerate(tile_or_super_tile.tileMap)
+                for y, row in enumerate(tile_or_super_tile.tile_map)
                 for x, subtile in enumerate(row)
                 if subtile is not None
             }

--- a/fabulous/fabric_generator/gds_generator/steps/fabric_area_opt.py
+++ b/fabulous/fabric_generator/gds_generator/steps/fabric_area_opt.py
@@ -113,7 +113,7 @@ class NLPTileProblem(ElementwiseProblem):
 
         tile_min: dict[str, tuple[float, float]] = {}
         for tile in fabric.tileDic.values():
-            if tile.partOfSuperTile:
+            if tile.part_of_super_tile:
                 continue
             tile_min[tile.name] = _combined_min(tile.name)
 
@@ -121,24 +121,24 @@ class NLPTileProblem(ElementwiseProblem):
         # and from row/column neighbors
         for supertile in fabric.superTileDic.values():
             st_min_w, st_min_h = _combined_min(supertile.name)
-            first_row = supertile.tileMap[0] if supertile.tileMap else []
+            first_row = supertile.tile_map[0] if supertile.tile_map else []
             n_cols = sum(1 for t in first_row if t is not None)
             n_rows = sum(
                 1
-                for row in supertile.tileMap
+                for row in supertile.tile_map
                 if row and any(t is not None for t in row)
             )
             if n_cols == 0 or n_rows == 0:
                 continue
 
             # Ensure all component tiles have an entry before updating
-            for row in supertile.tileMap:
+            for row in supertile.tile_map:
                 for component_tile in row:
                     if component_tile is not None:
                         tile_min.setdefault(component_tile.name, (1.0, 1.0))
 
             # Update height bounds from row neighbors
-            for row in supertile.tileMap:
+            for row in supertile.tile_map:
                 for component_tile in row:
                     if component_tile is None:
                         continue
@@ -153,7 +153,7 @@ class NLPTileProblem(ElementwiseProblem):
 
             # Update width bounds from column neighbors
             for col_idx in range(supertile.max_width):
-                for row in supertile.tileMap:
+                for row in supertile.tile_map:
                     if col_idx >= len(row) or row[col_idx] is None:
                         continue
                     name = row[col_idx].name
@@ -218,11 +218,11 @@ class NLPTileProblem(ElementwiseProblem):
             is_supertile = tile.name in self.fabric.superTileDic
             if is_supertile:
                 supertile = self.fabric.superTileDic[tile.name]
-                first_row = supertile.tileMap[0] if supertile.tileMap else []
+                first_row = supertile.tile_map[0] if supertile.tile_map else []
                 n_cols = sum(1 for t in first_row if t is not None)
                 n_rows = sum(
                     1
-                    for row in supertile.tileMap
+                    for row in supertile.tile_map
                     if row and any(t is not None for t in row)
                 )
                 if n_cols == 0 or n_rows == 0:
@@ -242,7 +242,7 @@ class NLPTileProblem(ElementwiseProblem):
             if is_supertile:
                 per_row_h = sample_h / n_rows
                 per_col_w = sample_w / n_cols
-                for row in supertile.tileMap:
+                for row in supertile.tile_map:
                     for component in row:
                         if component is None:
                             continue
@@ -278,7 +278,7 @@ class NLPTileProblem(ElementwiseProblem):
 
         xu = xl * 3.0  # upper bound safety floor
         for tile in fabric.tileDic.values():
-            if tile.partOfSuperTile:
+            if tile.part_of_super_tile:
                 continue
             required = self.min_areas.get(tile.name, 0.0) * (1.0 + self.area_margin)
             if required <= 0:
@@ -322,7 +322,7 @@ class NLPTileProblem(ElementwiseProblem):
         # same row/col group share identical dimensions.
         tile_constraints: list[tuple[str, int, int]] = []
         for tile in fabric.tileDic.values():
-            if tile.partOfSuperTile:
+            if tile.part_of_super_tile:
                 continue
             rows = self.tile_row_set[tile.name]
             cols = self.tile_column_set[tile.name]
@@ -333,11 +333,11 @@ class NLPTileProblem(ElementwiseProblem):
         for supertile in fabric.superTileDic.values():
             st_cols = [
                 min(self.tile_column_set[tile.name])
-                for tile in (supertile.tileMap[0] if supertile.tileMap else [])
+                for tile in (supertile.tile_map[0] if supertile.tile_map else [])
                 if tile is not None
             ]
             st_rows: list[int] = []
-            for row in supertile.tileMap:
+            for row in supertile.tile_map:
                 first_tile = (
                     next((t for t in row if t is not None), None) if row else None
                 )
@@ -806,7 +806,7 @@ class FabricAreaOptimisation(Step):
             return Decimal(problem.get_row_height(res.X, row)).quantize(quant)
 
         for tile in fabric.tileDic.values():
-            if tile.partOfSuperTile:
+            if tile.part_of_super_tile:
                 continue
             result_dict[tile.name] = (
                 zero,
@@ -817,13 +817,13 @@ class FabricAreaOptimisation(Step):
 
         for supertile in fabric.superTileDic.values():
             total_w = zero
-            if supertile.tileMap:
-                for tile in supertile.tileMap[0]:
+            if supertile.tile_map:
+                for tile in supertile.tile_map[0]:
                     if tile is not None:
                         total_w += quantized_width(tile.name)
 
             total_h = zero
-            for row_tiles in supertile.tileMap:
+            for row_tiles in supertile.tile_map:
                 first_tile = (
                     next((t for t in row_tiles if t is not None), None)
                     if row_tiles

--- a/fabulous/fabric_generator/gen_fabric/gen_fabric.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_fabric.py
@@ -56,7 +56,7 @@ def iter_super_tile_anchors(
         The anchor `(x, y)` and the `SuperTile` placed there.
     """
     for base_fx, base_fy, superTile in fabric.iter_super_tile_placements():
-        for ly, row in enumerate(superTile.tileMap):
+        for ly, row in enumerate(superTile.tile_map):
             for lx, tile in enumerate(row):
                 if tile is not None:
                     yield base_fx + lx, base_fy + ly, superTile
@@ -268,7 +268,7 @@ def generateFabric(writer: CodeGenerator, fabric: Fabric) -> None:
             # get all the ports of the tile. If is a super tile, we loop over the
             # tile map and find all the offset of the subtile, and all their related
             # ports.
-            if tile.partOfSuperTile:
+            if tile.part_of_super_tile:
                 for k, v in fabric.superTileDic.items():
                     if tile.name in [i.name for i in v.tiles]:
                         superTile = fabric.superTileDic[k]
@@ -292,7 +292,7 @@ def generateFabric(writer: CodeGenerator, fabric: Fabric) -> None:
             # if is a normal tile then the offset is (0, 0)
             for i, j in tileLocationOffset:
                 here = fabric.tile[y + j][x + i]
-                in_super = here.partOfSuperTile
+                in_super = here.part_of_super_tile
 
                 def _local_names(
                     ports: list, _i: int = i, _j: int = j, in_super: bool = in_super
@@ -380,7 +380,7 @@ def generateFabric(writer: CodeGenerator, fabric: Fabric) -> None:
 
             if not fabric.disableUserCLK:
                 if not superTile:
-                    # for userCLK
+                    # for user_clk
                     if (
                         y + 1 < fabric.numberOfRows
                         and fabric.tile[y + 1][x] is not None

--- a/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
@@ -35,7 +35,7 @@ from fabulous.fabric_generator.code_generator.code_generator_VHDL import (
 def _unconnected_port_diagnostic(ports: list[Port], port_name: str) -> str:
     """Explain an unconnected switch matrix port caused by NULL-wire expansion.
 
-    A NULL-terminated spanning wire expands to `wires x distance` nested
+    A NULL-terminated spanning wire expands to ``wires x distance`` nested
     wires (see `Port.expand_port_info_by_name`). When the switch matrix leaves some
     of those nested wires unconnected, the bare wire name is unhelpful, so this
     traces the wire back to its originating port and explains the expansion.
@@ -472,7 +472,7 @@ def gen_super_tile_switch_matrix(
     if all_sjump_ports:
         writer.addComment("SJUMP inputs from child tiles", onNewLine=True)
         for lx, ly, p in all_sjump_ports:
-            tileName = superTile.tileMap[ly][lx].name
+            tileName = superTile.tile_map[ly][lx].name
             for k in range(p.wire_count):
                 writer.addPortScalar(f"{tileName}_{p.name}{k}", IO.INPUT, indentLevel=2)
 
@@ -495,7 +495,7 @@ def gen_super_tile_switch_matrix(
     if all_input_sjump:
         writer.addComment("Reverse SJUMP outputs (SM -> child tile)", onNewLine=True)
         for lx, ly, p in all_input_sjump:
-            tileName = superTile.tileMap[ly][lx].name
+            tileName = superTile.tile_map[ly][lx].name
             for k in range(p.wire_count):
                 writer.addPortScalar(
                     f"{tileName}_{p.name}{k}", IO.OUTPUT, indentLevel=2

--- a/fabulous/fabric_generator/gen_fabric/gen_tile.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_tile.py
@@ -105,9 +105,9 @@ def generateTile(
         writer.addPreprocEndif()
     writer.addParameter("MaxFramesPerCol", "integer", max_frame_per_col, indentLevel=2)
     writer.addParameter("FrameBitsPerRow", "integer", frame_bits_per_row, indentLevel=2)
-    if tile.globalConfigBits > 0:
+    if tile.total_config_bits > 0:
         writer.addParameter(
-            "NoConfigBits", "integer", tile.globalConfigBits, indentLevel=2
+            "NoConfigBits", "integer", tile.total_config_bits, indentLevel=2
         )
 
     writer.addParameterEnd(indentLevel=1)
@@ -115,10 +115,10 @@ def generateTile(
 
     # holder for each direction of port string
     portList = (
-        tile.getNorthSidePorts()
-        + tile.getEastSidePorts()
-        + tile.getWestSidePorts()
-        + tile.getSouthSidePorts()
+        tile.get_port_on_side(Side.NORTH)
+        + tile.get_port_on_side(Side.EAST)
+        + tile.get_port_on_side(Side.WEST)
+        + tile.get_port_on_side(Side.SOUTH)
     )
 
     side_of_port = None
@@ -215,7 +215,7 @@ def generateTile(
                 "Need to run matrix generation first"
             )
 
-        if tile.globalConfigBits > 0:
+        if tile.total_config_bits > 0:
             if (basePath / f"{tile.name}_ConfigMem.vhdl").exists():
                 writer.addComponentDeclarationForFile(
                     f"{basePath}/{tile.name}_ConfigMem.vhdl"
@@ -273,7 +273,7 @@ def generateTile(
     # maybe even useful if we want to add a buffer here
 
     # all the signal wire need to declare first for compatibility with VHDL
-    if tile.globalConfigBits > 0:
+    if tile.total_config_bits > 0:
         writer.addConnectionVector("ConfigBits", "NoConfigBits-1", 0)
         writer.addConnectionVector("ConfigBits_N", "NoConfigBits-1", 0)
 
@@ -391,7 +391,7 @@ def generateTile(
         writer.addAssignScalar("conf_data(conf_data'high)", "CONFout")
         writer.addComment("CONFout is from tile entity")
 
-    if config_bit_mode == ConfigBitMode.FRAME_BASED and tile.globalConfigBits > 0:
+    if config_bit_mode == ConfigBitMode.FRAME_BASED and tile.total_config_bits > 0:
         writer.addComment("configuration storage latches", onNewLine=True)
         writer.addInstantiation(
             compName=f"{tile.name}_ConfigMem",
@@ -566,17 +566,17 @@ def generateTile(
         ports_pairs.append(("CONFout", f"conf_data({belCounter + 1})"))
         ports_pairs.append(("CLK", "CLK"))
 
-    if config_bit_mode == ConfigBitMode.FRAME_BASED and tile.globalConfigBits > 0:
+    if config_bit_mode == ConfigBitMode.FRAME_BASED and tile.total_config_bits > 0:
         ports_pairs.append(
             (
                 "ConfigBits",
-                f"ConfigBits[{tile.globalConfigBits}-1:{belConfigBitsCounter}]",
+                f"ConfigBits[{tile.total_config_bits}-1:{belConfigBitsCounter}]",
             )
         )
         ports_pairs.append(
             (
                 "ConfigBits_N",
-                f"ConfigBits_N[{tile.globalConfigBits}-1:{belConfigBitsCounter}]",
+                f"ConfigBits_N[{tile.total_config_bits}-1:{belConfigBitsCounter}]",
             )
         )
 
@@ -635,7 +635,7 @@ def generateSuperTile(
     if isinstance(writer, VerilogCodeGenerator):
         writer.addPreprocIfDef("EMULATION")
         maxBits = frame_bits_per_row * max_frame_per_col
-        for y, row in enumerate(superTile.tileMap):
+        for y, row in enumerate(superTile.tile_map):
             for x, tile in enumerate(row):
                 if not tile:
                     continue
@@ -701,14 +701,12 @@ def generateSuperTile(
 
     # add config port
     if config_bit_mode == ConfigBitMode.FRAME_BASED:
-        for y, row in enumerate(superTile.tileMap):
-            for x, tile in enumerate(row):
-                if tile is None:
-                    continue
+        for y, row in enumerate(superTile.tile_map):
+            for x, _tile in enumerate(row):
                 # Bottom-left origin: expose FrameStrobe_O if no tile above (y+1)
                 if (
-                    y + 1 >= len(superTile.tileMap)
-                    or superTile.tileMap[y + 1][x] is None
+                    y + 1 >= len(superTile.tile_map)
+                    or superTile.tile_map[y + 1][x] is None
                 ):
                     writer.addPortVector(
                         f"Tile_X{x}Y{y}_FrameStrobe_O",
@@ -717,7 +715,7 @@ def generateSuperTile(
                         indentLevel=2,
                     )
                     writer.addComment("CONFIG_PORT", onNewLine=False)
-                if x - 1 < 0 or superTile.tileMap[y][x - 1] is None:
+                if x - 1 < 0 or superTile.tile_map[y][x - 1] is None:
                     writer.addPortVector(
                         f"Tile_X{x}Y{y}_FrameData",
                         IO.INPUT,
@@ -726,7 +724,7 @@ def generateSuperTile(
                     )
                     writer.addComment("CONFIG_PORT", onNewLine=False)
                 # Bottom-left origin: expose FrameStrobe if no tile below (y-1)
-                if y - 1 < 0 or superTile.tileMap[y - 1][x] is None:
+                if y - 1 < 0 or superTile.tile_map[y - 1][x] is None:
                     writer.addPortVector(
                         f"Tile_X{x}Y{y}_FrameStrobe",
                         IO.INPUT,
@@ -735,8 +733,8 @@ def generateSuperTile(
                     )
                     writer.addComment("CONFIG_PORT", onNewLine=False)
                 if (
-                    x + 1 >= len(superTile.tileMap[y])
-                    or superTile.tileMap[y][x + 1] is None
+                    x + 1 >= len(superTile.tile_map[y])
+                    or superTile.tile_map[y][x + 1] is None
                 ):
                     writer.addPortVector(
                         f"Tile_X{x}Y{y}_FrameData_O",
@@ -746,17 +744,15 @@ def generateSuperTile(
                     )
                     writer.addComment("CONFIG_PORT", onNewLine=False)
     if not disable_user_clk:
-        for y, row in enumerate(superTile.tileMap):
-            for x, tile in enumerate(row):
-                if tile is None:
-                    continue
-                if y - 1 < 0 or superTile.tileMap[y - 1][x] is None:
+        for y, row in enumerate(superTile.tile_map):
+            for x, _tile in enumerate(row):
+                if y - 1 < 0 or superTile.tile_map[y - 1][x] is None:
                     writer.addPortScalar(
                         f"Tile_X{x}Y{y}_UserCLKo", IO.OUTPUT, indentLevel=2
                     )
                 if (
-                    y + 1 >= len(superTile.tileMap)
-                    or superTile.tileMap[y + 1][x] is None
+                    y + 1 >= len(superTile.tile_map)
+                    or superTile.tile_map[y + 1][x] is None
                 ):
                     writer.addPortScalar(
                         f"Tile_X{x}Y{y}_UserCLK", IO.INPUT, indentLevel=2
@@ -811,7 +807,7 @@ def generateSuperTile(
         writer.addComment("SJUMP signals (child tile -> supertile SM)", onNewLine=True)
         for lx, ly, p in sjump_ports:
             writer.addConnectionVector(
-                f"{superTile.tileMap[ly][lx].name}_{p.name}",
+                f"{superTile.tile_map[ly][lx].name}_{p.name}",
                 f"{p.wire_count}-1",
                 indentLevel=1,
             )
@@ -822,7 +818,7 @@ def generateSuperTile(
         writer.addComment("SJUMP signals (supertile SM -> child tile)", onNewLine=True)
         for lx, ly, p in all_input_sjump:
             writer.addConnectionVector(
-                f"{superTile.tileMap[ly][lx].name}_{p.name}",
+                f"{superTile.tile_map[ly][lx].name}_{p.name}",
                 f"{p.wire_count}-1",
                 indentLevel=1,
             )
@@ -848,14 +844,12 @@ def generateSuperTile(
                     writer.addComment(str(p), onNewLine=False)
 
     # declare internal connections for frameData, frameStrobe, and UserCLK
-    for y, row in enumerate(superTile.tileMap):
-        for x, tile in enumerate(row):
-            if tile is None:
-                continue
+    for y, row in enumerate(superTile.tile_map):
+        for x, _tile in enumerate(row):
             # Bottom-left origin: internal FrameStrobe_O wire if a tile is above (y+1)
             if (
-                0 <= y + 1 < len(superTile.tileMap)
-                and superTile.tileMap[y + 1][x] is not None
+                0 <= y + 1 < len(superTile.tile_map)
+                and superTile.tile_map[y + 1][x] is not None
             ):
                 writer.addConnectionVector(
                     f"Tile_X{x}Y{y}_FrameStrobe_O",
@@ -866,13 +860,13 @@ def generateSuperTile(
             # below (y-1) to receive it, and the user clock is enabled.
             if (
                 not disable_user_clk
-                and 0 <= y - 1 < len(superTile.tileMap)
-                and superTile.tileMap[y - 1][x] is not None
+                and 0 <= y - 1 < len(superTile.tile_map)
+                and superTile.tile_map[y - 1][x] is not None
             ):
                 writer.addConnectionScalar(f"Tile_X{x}Y{y}_UserCLKo", indentLevel=1)
             if (
-                0 <= x + 1 < len(superTile.tileMap[y])
-                and superTile.tileMap[y][x + 1] is not None
+                0 <= x - 1 < len(superTile.tile_map[y])
+                and superTile.tile_map[y][x - 1] is not None
             ):
                 writer.addConnectionVector(
                     f"Tile_X{x}Y{y}_FrameData_O", "FrameBitsPerRow-1", indentLevel=1
@@ -891,7 +885,7 @@ def generateSuperTile(
     writer.addLogicStart()
 
     # pair up the connection for tile instantiation
-    for y, row in enumerate(superTile.tileMap):
+    for y, row in enumerate(superTile.tile_map):
         for x, tile in enumerate(row):
             north_input, south_input, east_input, west_input = [], [], [], []
             ports_pairs = []
@@ -902,10 +896,10 @@ def generateSuperTile(
             north_port = [i.name for i in tile.get_port_on_side(Side.SOUTH, IO.INPUT)]
             # Bottom-left origin: north input comes from south tile (y-1)
             if (
-                0 <= y - 1 < len(superTile.tileMap)
-                and superTile.tileMap[y - 1][x] is not None
+                0 <= y - 1 < len(superTile.tile_map)
+                and superTile.tile_map[y - 1][x] is not None
             ):
-                for p in superTile.tileMap[y - 1][x].get_port_on_side(
+                for p in superTile.tile_map[y - 1][x].get_port_on_side(
                     Side.NORTH, IO.OUTPUT
                 ):
                     north_input.append(f"Tile_X{x}Y{y - 1}_{p.name}")
@@ -917,10 +911,10 @@ def generateSuperTile(
             # east direction input connection
             east_port = [i.name for i in tile.get_port_on_side(Side.WEST, IO.INPUT)]
             if (
-                0 <= x - 1 < len(superTile.tileMap[0])
-                and superTile.tileMap[y][x - 1] is not None
+                0 <= x - 1 < len(superTile.tile_map[0])
+                and superTile.tile_map[y][x - 1] is not None
             ):
-                for p in superTile.tileMap[y][x - 1].get_port_on_side(
+                for p in superTile.tile_map[y][x - 1].get_port_on_side(
                     Side.EAST, IO.OUTPUT
                 ):
                     east_input.append(f"Tile_X{x - 1}Y{y}_{p.name}")
@@ -934,10 +928,10 @@ def generateSuperTile(
             south_port = [i.name for i in tile.get_port_on_side(Side.NORTH, IO.INPUT)]
             # Bottom-left origin: south input comes from north tile (y+1)
             if (
-                0 <= y + 1 < len(superTile.tileMap)
-                and superTile.tileMap[y + 1][x] is not None
+                0 <= y + 1 < len(superTile.tile_map)
+                and superTile.tile_map[y + 1][x] is not None
             ):
-                for p in superTile.tileMap[y + 1][x].get_port_on_side(
+                for p in superTile.tile_map[y + 1][x].get_port_on_side(
                     Side.SOUTH, IO.OUTPUT
                 ):
                     south_input.append(f"Tile_X{x}Y{y + 1}_{p.name}")
@@ -950,10 +944,10 @@ def generateSuperTile(
             # west direction input connection
             west_port = [i.name for i in tile.get_port_on_side(Side.EAST, IO.INPUT)]
             if (
-                0 <= x + 1 < len(superTile.tileMap[0])
-                and superTile.tileMap[y][x + 1] is not None
+                0 <= x + 1 < len(superTile.tile_map[0])
+                and superTile.tile_map[y][x + 1] is not None
             ):
-                for p in superTile.tileMap[y][x + 1].get_port_on_side(
+                for p in superTile.tile_map[y][x + 1].get_port_on_side(
                     Side.WEST, IO.OUTPUT
                 ):
                     west_input.append(f"Tile_X{x + 1}Y{y}_{p.name}")
@@ -990,8 +984,8 @@ def generateSuperTile(
             # add clock to tile
             if not disable_user_clk:
                 if (
-                    0 <= y + 1 < len(superTile.tileMap)
-                    and superTile.tileMap[y + 1][x] is not None
+                    0 <= y + 1 < len(superTile.tile_map)
+                    and superTile.tile_map[y + 1][x] is not None
                 ):
                     ports_pairs.append(("UserCLK", f"Tile_X{x}Y{y + 1}_UserCLKo"))
                 else:
@@ -1000,8 +994,8 @@ def generateSuperTile(
             if config_bit_mode == ConfigBitMode.FRAME_BASED:
                 # add connection for frameData, frameStrobe
                 if (
-                    0 <= x - 1 < len(superTile.tileMap[0])
-                    and superTile.tileMap[y][x - 1] is not None
+                    0 <= x - 1 < len(superTile.tile_map[0])
+                    and superTile.tile_map[y][x - 1] is not None
                 ):
                     ports_pairs.append(("FrameData", f"Tile_X{x - 1}Y{y}_FrameData_O"))
                 else:
@@ -1011,8 +1005,8 @@ def generateSuperTile(
 
                 # Bottom-left origin: FrameStrobe comes from tile below (y-1)
                 if (
-                    0 <= y - 1 < len(superTile.tileMap)
-                    and superTile.tileMap[y - 1][x] is not None
+                    0 <= y - 1 < len(superTile.tile_map)
+                    and superTile.tile_map[y - 1][x] is not None
                 ):
                     ports_pairs.append(
                         ("FrameStrobe", f"Tile_X{x}Y{y - 1}_FrameStrobe_O")
@@ -1037,15 +1031,15 @@ def generateSuperTile(
     if st_config_bits > 0 and config_bit_mode == ConfigBitMode.FRAME_BASED:
         mx, my = superTile.get_master_tile_coords()
         if (
-            0 <= mx - 1 < len(superTile.tileMap[0])
-            and superTile.tileMap[my][mx - 1] is not None
+            0 <= mx - 1 < len(superTile.tile_map[0])
+            and superTile.tile_map[my][mx - 1] is not None
         ):
             cm_frame_data = f"Tile_X{mx - 1}Y{my}_FrameData_O"
         else:
             cm_frame_data = f"Tile_X{mx}Y{my}_FrameData"
         if (
-            0 <= my + 1 < len(superTile.tileMap)
-            and superTile.tileMap[my + 1][mx] is not None
+            0 <= my + 1 < len(superTile.tile_map)
+            and superTile.tile_map[my + 1][mx] is not None
         ):
             cm_frame_strobe = f"Tile_X{mx}Y{my + 1}_FrameStrobe_O"
         else:
@@ -1072,7 +1066,7 @@ def generateSuperTile(
         sm_ports_pairs = []
         # Connect SJUMP vector signals to SM scalar input ports
         for lx, ly, p in superTile.get_all_sjump_ports():
-            tileName = superTile.tileMap[ly][lx].name
+            tileName = superTile.tile_map[ly][lx].name
             for k in range(p.wire_count):
                 sm_ports_pairs.append(
                     (f"{tileName}_{p.name}{k}", f"{tileName}_{p.name}[{k}]")
@@ -1086,7 +1080,7 @@ def generateSuperTile(
             for op in bel.outputs:
                 sm_ports_pairs.append((op.name, op.name))
         # SM outputs also drive reverse SJUMP signals into child tiles
-        for _ly, row in enumerate(superTile.tileMap):
+        for _ly, row in enumerate(superTile.tile_map):
             for _lx, st_tile in enumerate(row):
                 if st_tile is None:
                     continue
@@ -1153,8 +1147,8 @@ def generateSuperTile(
             # chained UserCLKo from the tile below, or its own UserCLK input).
             mx, my = superTile.get_master_tile_coords()
             if (
-                0 <= my + 1 < len(superTile.tileMap)
-                and superTile.tileMap[my + 1][mx] is not None
+                0 <= my + 1 < len(superTile.tile_map)
+                and superTile.tile_map[my + 1][mx] is not None
             ):
                 bel_user_clk = f"Tile_X{mx}Y{my + 1}_UserCLKo"
             else:

--- a/fabulous/fabric_generator/parser/parse_configmem.py
+++ b/fabulous/fabric_generator/parser/parse_configmem.py
@@ -23,7 +23,7 @@ def parseConfigMem(
     fileName: Path,
     maxFramePerCol: int,
     frameBitPerRow: int,
-    globalConfigBits: int,
+    total_config_bits: int,
 ) -> list[ConfigMem]:
     """Parse the config memory CSV file into a list of ConfigMem objects.
 
@@ -35,7 +35,7 @@ def parseConfigMem(
         Maximum number of frames per column
     frameBitPerRow : int
         Number of bits per row
-    globalConfigBits : int
+    total_config_bits : int
         Number of configuration bits the config memory must cover
 
     Raises
@@ -87,11 +87,11 @@ def parseConfigMem(
                 )
             usedBitsCounter += entry["used_bits_mask"].count("1")
 
-        if usedBitsCounter != globalConfigBits:
+        if usedBitsCounter != total_config_bits:
             raise ValueError(
                 f"bitstream mapping file {fileName} has a bitmask mismatch; "
                 f"bitmask has in total {usedBitsCounter} 1-values for "
-                f"{globalConfigBits} bits."
+                f"{total_config_bits} bits."
             )
 
         allConfigBitsOrder = []

--- a/fabulous/fabric_generator/parser/parse_csv.py
+++ b/fabulous/fabric_generator/parser/parse_csv.py
@@ -105,7 +105,7 @@ def parseTilesCSV(
         bels: list[Bel] = []
         matrixDir: Path | None = None
         gen_ios: list[Gen_IO] = []
-        withUserCLK = False
+        with_user_clk = False
         genMatrixList = False
         tileCarry: dict[str, dict[IO, str]] = {}
         localSharedPorts: dict[str, list[TilePort]] = {}
@@ -325,7 +325,7 @@ def parseTilesCSV(
                     "BEL, GEN_IO, MATRIX, and INCLUDE."
                 )
 
-        withUserCLK = any(bel.with_user_clock for bel in bels)
+        with_user_clk = any(bel.with_user_clock for bel in bels)
 
         if matrixDir is None:
             raise InvalidTileDefinition(
@@ -353,7 +353,7 @@ def parseTilesCSV(
                     preserve_list_order=preserve_list_order,
                 ),
                 gen_ios=gen_ios,
-                userCLK=withUserCLK,
+                user_clk=with_user_clk,
             )
         )
 
@@ -453,10 +453,10 @@ def parseSupertilesCSV(fileName: Path, tileDic: dict[str, Tile]) -> list[SuperTi
     for t in superTilesData:
         description = t.split("\n")
         name = description[0].split(",")[1]
-        tileMap = []
+        tile_map = []
         tiles = []
         bels = []
-        withUserCLK = False
+        with_user_clk = False
         master_set = False
         master_coords: tuple[int, int] | None = None
         matrix_line_path: Path | None = None
@@ -486,7 +486,7 @@ def parseSupertilesCSV(fileName: Path, tileDic: dict[str, Tile]) -> list[SuperTi
                     row_master = True
                     continue
                 if j in tileDic:
-                    tileDic[j].partOfSuperTile = True
+                    tileDic[j].part_of_super_tile = True
                     t = deepcopy(tileDic[j])
                     row.append(t)
                     if t not in tiles:
@@ -504,7 +504,7 @@ def parseSupertilesCSV(fileName: Path, tileDic: dict[str, Tile]) -> list[SuperTi
                         f"Supertile '{name}': MASTER cannot be used on a row "
                         "with multiple tiles."
                     )
-                row_index = len(tileMap)
+                row_index = len(tile_map)
                 col_index = len(row) - 1
                 if master_set:
                     raise InvalidSupertileDefinition(
@@ -512,17 +512,17 @@ def parseSupertilesCSV(fileName: Path, tileDic: dict[str, Tile]) -> list[SuperTi
                     )
                 master_coords = (col_index, row_index)
                 master_set = True
-            tileMap.append(row)
+            tile_map.append(row)
 
-        # Reverse tileMap to use bottom-left origin coordinate system
-        # After this: tileMap[0] = bottom row, tileMap[-1] = top row
-        tileMap.reverse()
+        # Reverse tile_map to use bottom-left origin coordinate system
+        # After this: tile_map[0] = bottom row, tile_map[-1] = top row
+        tile_map.reverse()
 
-        withUserCLK = any(bel.with_user_clock for bel in bels)
+        with_user_clk = any(bel.with_user_clock for bel in bels)
         # tile_dir is the supertile CSV file path (matching Tile.tile_dir), so
         # consumers use `tile_dir.parent` for the supertile's directory.
         super_tile = SuperTile(
-            name, fileName.absolute(), tiles, tileMap, bels, withUserCLK
+            name, fileName.absolute(), tiles, tile_map, bels, with_user_clk
         )
         super_tile.master_tile_coords = master_coords
 

--- a/fabulous/fabulous_api.py
+++ b/fabulous/fabulous_api.py
@@ -201,7 +201,7 @@ class FABulous_API:
             generateConfigMem(
                 self.writer,
                 tile.name,
-                tile.globalConfigBits,
+                tile.total_config_bits,
                 configMem,
                 frame_bits_per_row=self.fabric.frameBitsPerRow,
                 max_frame_per_col=self.fabric.maxFramesPerCol,
@@ -379,7 +379,7 @@ class FABulous_API:
         """
         if tile := self.fabric.getSuperTileByName(tileName):
             mx, my = tile.get_master_tile_coords()
-            master_tile = tile.tileMap[my][mx]
+            master_tile = tile.tile_map[my][mx]
             master_config_mem_csv = (
                 master_tile.tile_dir.parent / f"{master_tile.name}_ConfigMem.csv"
             )

--- a/fabulous/geometry_generator/fabric_geometry.py
+++ b/fabulous/geometry_generator/fabric_geometry.py
@@ -172,7 +172,7 @@ class FabricGeometry:
         master_bels: dict[str, list] = {}
         for superTile in self.fabric.superTileDic.values():
             mx, my = superTile.get_master_tile_coords()
-            master_tile = superTile.tileMap[my][mx]
+            master_tile = superTile.tile_map[my][mx]
             if master_tile is not None:
                 master_bels.setdefault(master_tile.name, []).extend(superTile.bels)
 

--- a/fabulous/geometry_generator/sm_geometry.py
+++ b/fabulous/geometry_generator/sm_geometry.py
@@ -275,10 +275,10 @@ class SmGeometry:
         self.jumpPorts = [
             port for port in tile.ports_info if port.wire_direction == Direction.JUMP
         ]
-        self.northPorts = tile.getNorthSidePorts()
-        self.southPorts = tile.getSouthSidePorts()
-        self.eastPorts = tile.getEastSidePorts()
-        self.westPorts = tile.getWestSidePorts()
+        self.northPorts = tile.get_port_on_side(Side.NORTH)
+        self.southPorts = tile.get_port_on_side(Side.SOUTH)
+        self.eastPorts = tile.get_port_on_side(Side.EAST)
+        self.westPorts = tile.get_port_on_side(Side.WEST)
         self.preprocessPorts(tileBorder)
 
         # Counting the total number of wires for each direction

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def make_empty_tile(
     pin_order_config: dict | None = None,
     config_bits: int = 0,
 ) -> Tile:
-    """Build a minimal Tile usable inside a SuperTile.tileMap.
+    """Build a minimal Tile usable inside a SuperTile.tile_map.
 
     Passing ``pin_order_config={}`` skips the GDS pin-order import; the ``None``
     default preserves the original behaviour for callers that don't care.
@@ -72,7 +72,7 @@ def make_empty_tile(
         tile_dir=tile_dir,
         matrix_dir=matrix_dir,
         gen_ios=[],
-        userCLK=False,
+        user_clk=False,
         switch_matrix=SwitchMatrix.from_connections(
             matrix_file=matrix_dir, connections={}, hdl_config_bits=config_bits or None
         ),

--- a/tests/fabric_cad_test/test_gen_bitstream_spec.py
+++ b/tests/fabric_cad_test/test_gen_bitstream_spec.py
@@ -316,7 +316,7 @@ def _build_fabric(
         matrix_dir=matrix_path,
         switch_matrix=SwitchMatrix.from_file(matrix_path, _TILE_NAME),
         gen_ios=[],
-        userCLK=False,
+        user_clk=False,
     )
     tile.wire_list = wires
 

--- a/tests/fabric_definition/test_composite_tile.py
+++ b/tests/fabric_definition/test_composite_tile.py
@@ -1,0 +1,406 @@
+"""Tests for the composite-capable Tile model.
+
+A leaf tile is a 1x1 composite; a former supertile is a Tile whose ``tile_map``
+holds a grid of sub-Tile objects. These tests cover the composite-shape queries
+(``is_composite``, ``max_width``, ``max_height``, ``__iter__``) and the sub-tile
+helpers that now accept either a Tile object or a name string.
+
+Storage convention (matching the existing tile helpers): ``tile_map`` is stored
+top row first, so ``tile_map[-1]`` is the bottom row. ``get_sub_tile_offset``
+uses a top-left origin (the top-left cell is ``(0, 0)``), matching
+``get_anchor_offset`` and ``get_master_offset``. ``is_root_tile`` applies a
+bottom-left origin (the bottom-left cell is the root). ``__iter__`` yields the raw
+grid index as ``(x=column, y=row)`` with no x/y swap.
+"""
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from fabulous.fabric_definition.bel import Bel
+from fabulous.fabric_definition.define import IO, Side
+from fabulous.fabric_definition.port import TilePort
+from fabulous.fabric_definition.switch_matrix import SwitchMatrix
+from fabulous.fabric_definition.tile import Tile
+from tests.conftest import make_yosys_module
+
+
+def _tport(name: str, side: Side) -> TilePort:
+    """Build a minimal TilePort located on a given side of the tile."""
+    return TilePort(
+        name=name,
+        io_direction=IO.OUTPUT,
+        width=1,
+        side_of_tile=side,
+        source_name=name,
+        destination_name=name,
+        wire_count=1,
+    )
+
+
+def _bel(config_bits: int) -> Bel:
+    """Build a minimal Bel carrying ``config_bits`` configuration bits."""
+    return Bel(
+        src=Path("mod.v"),
+        prefix="",
+        module=make_yosys_module({"A": (IO.INPUT, 1)}, config_bits=config_bits),
+        module_name="mod",
+    )
+
+
+def _leaf(
+    name: str,
+    ports: list[TilePort] | None = None,
+    bels: list[Bel] | None = None,
+    switch_matrix: SwitchMatrix | None = None,
+) -> Tile:
+    """Build a minimal leaf (non-composite) Tile."""
+    return Tile(
+        name=name,
+        ports=ports if ports is not None else [],
+        bels=bels if bels is not None else [],
+        tile_dir=Path(),
+        matrix_dir=Path(),
+        gen_ios=[],
+        user_clk=False,
+        switch_matrix=switch_matrix
+        if switch_matrix is not None
+        else SwitchMatrix.from_connections(matrix_file=Path(), connections={}),
+    )
+
+
+def _composite(
+    name: str,
+    tile_map: list[list[Tile | None]],
+    master_offset: tuple[int, int] | None = None,
+    bels: list[Bel] | None = None,
+    switch_matrix: SwitchMatrix | None = None,
+) -> Tile:
+    """Build a composite Tile carrying an object tile_map and flat sub_tiles."""
+    sub_tiles = [t for row in tile_map for t in row if t is not None]
+    return Tile(
+        name=name,
+        ports=[],
+        bels=bels if bels is not None else [],
+        tile_dir=Path(),
+        matrix_dir=Path(),
+        gen_ios=[],
+        user_clk=False,
+        switch_matrix=switch_matrix
+        if switch_matrix is not None
+        else SwitchMatrix.from_connections(matrix_file=Path(), connections={}),
+        tile_map=tile_map,
+        sub_tiles=sub_tiles,
+        master_offset=master_offset,
+    )
+
+
+class TestLeafTile:
+    """A leaf tile behaves as a 1x1 composite of itself."""
+
+    def test_is_not_composite(self) -> None:
+        """A leaf (tile_map=None) is not composite."""
+        assert _leaf("T").is_composite is False
+
+    def test_dimensions(self) -> None:
+        """A leaf has width and height of one."""
+        leaf = _leaf("T")
+        assert leaf.max_width == 1
+        assert leaf.max_height == 1
+
+    def test_sub_tiles_returns_self(self) -> None:
+        """A leaf reports itself as its only sub-tile."""
+        leaf = _leaf("T")
+        assert leaf.get_sub_tiles() == [leaf]
+
+    def test_iter_yields_self_at_origin(self) -> None:
+        """Iterating a leaf yields a single ((0, 0), self)."""
+        leaf = _leaf("T")
+        assert list(leaf) == [((0, 0), leaf)]
+
+    def test_subtiles_field_defaults_empty(self) -> None:
+        """A leaf has an empty flat sub_tiles list by default."""
+        assert _leaf("T").sub_tiles == []
+
+
+class TestCompositeTile:
+    """A composite tile exposes its grid of sub-Tile objects."""
+
+    def test_is_composite(self) -> None:
+        """A tile with a tile_map is composite."""
+        # tile_map stored top first: [top row], [bottom row].
+        top, bot = _leaf("top"), _leaf("bot")
+        comp = _composite("C", [[top], [bot]])
+        assert comp.is_composite is True
+
+    def test_dimensions(self) -> None:
+        """A two-row, one-column composite is 1 wide and 2 tall."""
+        top, bot = _leaf("top"), _leaf("bot")
+        comp = _composite("C", [[top], [bot]])
+        assert comp.max_width == 1
+        assert comp.max_height == 2
+
+    def test_get_sub_tiles_returns_objects(self) -> None:
+        """get_sub_tiles returns the non-None cell objects."""
+        top, bot = _leaf("top"), _leaf("bot")
+        comp = _composite("C", [[top], [bot]])
+        assert comp.get_sub_tiles() == [top, bot]
+
+    def test_subtiles_field_holds_objects(self) -> None:
+        """The flat sub_tiles field holds the constituent tiles."""
+        top, bot = _leaf("top"), _leaf("bot")
+        comp = _composite("C", [[top], [bot]])
+        assert comp.sub_tiles == [top, bot]
+
+    def test_iter_yields_each_cell_with_raw_row_index(self) -> None:
+        """__iter__ yields ((x, y), tile) using the raw grid row index."""
+        top, bot = _leaf("top"), _leaf("bot")
+        comp = _composite("C", [[top], [bot]])
+        # Raw enumeration: row 0 is top, row 1 is bottom.
+        assert list(comp) == [((0, 0), top), ((0, 1), bot)]
+
+    def test_iter_xy_ordering_is_column_row(self) -> None:
+        """For a wider grid, x is the column and y is the row (no swap)."""
+        a, b, c, d = _leaf("a"), _leaf("b"), _leaf("c"), _leaf("d")
+        comp = _composite("C", [[a, b], [c, d]])
+        assert list(comp) == [
+            ((0, 0), a),
+            ((1, 0), b),
+            ((0, 1), c),
+            ((1, 1), d),
+        ]
+
+    def test_iter_skips_none_cells(self) -> None:
+        """None cells in the grid are not yielded."""
+        a, d = _leaf("a"), _leaf("d")
+        comp = _composite("C", [[a, None], [None, d]])
+        assert list(comp) == [((0, 0), a), ((1, 1), d)]
+
+
+class TestSubTileHelpersAcceptObjectOrName:
+    """get_sub_tile_offset / part_of_tile / is_root_tile accept an object or a name."""
+
+    def test_offset_simple_self_by_object_and_name(self) -> None:
+        """A leaf is at offset (0, 0) whether queried by object or name."""
+        leaf = _leaf("M")
+        assert leaf.get_sub_tile_offset(leaf) == (0, 0)
+        assert leaf.get_sub_tile_offset("M") == (0, 0)
+
+    def test_offset_simple_missing_raises(self) -> None:
+        """Requesting an unknown sub-tile from a leaf raises."""
+        with pytest.raises(ValueError, match="not found in tile"):
+            _leaf("M").get_sub_tile_offset("Other")
+
+    def test_offset_composite_top_left_origin(self) -> None:
+        """Composite offsets use y=0 at the top row, by object or name."""
+        tl, tr = _leaf("tl"), _leaf("tr")
+        bl, br = _leaf("bl"), _leaf("br")
+        # Stored top first: top row then bottom row.
+        comp = _composite("C", [[tl, tr], [bl, br]])
+        assert comp.get_sub_tile_offset("tl") == (0, 0)
+        assert comp.get_sub_tile_offset(tl) == (0, 0)
+        assert comp.get_sub_tile_offset("tr") == (1, 0)
+        assert comp.get_sub_tile_offset(bl) == (0, 1)
+        assert comp.get_sub_tile_offset(br) == (1, 1)
+
+    def test_part_of_tile_by_object_and_name(self) -> None:
+        """part_of_tile reflects membership for both object and name."""
+        a, b = _leaf("a"), _leaf("b")
+        comp = _composite("C", [[a, b]])
+        assert comp.part_of_tile("a") is True
+        assert comp.part_of_tile(b) is True
+        assert comp.part_of_tile("X") is False
+        assert comp.part_of_tile(_leaf("X")) is False
+
+    def test_is_root_tile_by_object_and_name(self) -> None:
+        """The bottom-left sub-tile is the root, by object or name."""
+        leaf = _leaf("M")
+        assert leaf.is_root_tile(leaf) is True
+        assert leaf.is_root_tile("M") is True
+
+        tl, tr = _leaf("tl"), _leaf("tr")
+        bl, br = _leaf("bl"), _leaf("br")
+        comp = _composite("C", [[tl, tr], [bl, br]])
+        assert comp.is_root_tile("bl") is True
+        assert comp.is_root_tile(bl) is True
+        assert comp.is_root_tile("tl") is False
+        assert comp.is_root_tile(tr) is False
+
+
+def _leaf_all_sides(name: str) -> Tile:
+    """Build a leaf tile carrying one port on each of the four sides."""
+    return _leaf(
+        name,
+        ports=[
+            _tport(f"{name}_N", Side.NORTH),
+            _tport(f"{name}_S", Side.SOUTH),
+            _tport(f"{name}_E", Side.EAST),
+            _tport(f"{name}_W", Side.WEST),
+        ],
+    )
+
+
+class TestPerimeterAndInternalPorts:
+    """Tests for get_ports_around_tile / get_internal_connections on Tile."""
+
+    def test_leaf_has_no_perimeter_or_internal(self) -> None:
+        """A leaf tile exposes no composite-level perimeter or internal ports."""
+        leaf = _leaf_all_sides("L")
+        assert leaf.get_ports_around_tile() == {}
+        assert leaf.get_internal_connections() == []
+
+    def test_composite_perimeter_ports(self) -> None:
+        """Perimeter cells expose only the sides whose neighbor is absent.
+
+        For a 2-row, 1-column composite stored top first (``[[top], [bot]]``):
+        the top cell exposes NORTH, EAST and WEST; the bottom cell exposes
+        SOUTH, EAST and WEST. The shared edge (top SOUTH / bottom NORTH) is
+        internal and not in the perimeter result.
+        """
+        top, bot = _leaf_all_sides("top"), _leaf_all_sides("bot")
+        comp = _composite("C", [[top], [bot]])
+
+        ports = comp.get_ports_around_tile()
+
+        # Keys follow __iter__ raw (x, y) indexing: top is (0, 0), bot is (0, 1).
+        assert set(ports) == {"0,0", "0,1"}
+
+        # Top cell: NORTH exposed (no tile above), EAST and WEST exposed; the
+        # SOUTH side faces the bottom cell, so it is not a perimeter side.
+        assert top.get_port_on_side(Side.NORTH) in ports["0,0"]
+        assert top.get_port_on_side(Side.EAST) in ports["0,0"]
+        assert top.get_port_on_side(Side.WEST) in ports["0,0"]
+        assert top.get_port_on_side(Side.SOUTH) not in ports["0,0"]
+
+        # Bottom cell: SOUTH exposed (no tile below), EAST and WEST exposed; the
+        # NORTH side faces the top cell, so it is not a perimeter side.
+        assert bot.get_port_on_side(Side.SOUTH) in ports["0,1"]
+        assert bot.get_port_on_side(Side.EAST) in ports["0,1"]
+        assert bot.get_port_on_side(Side.WEST) in ports["0,1"]
+        assert bot.get_port_on_side(Side.NORTH) not in ports["0,1"]
+
+    def test_composite_internal_connections(self) -> None:
+        """The shared edge between stacked cells is reported as internal.
+
+        The top cell's SOUTH side and the bottom cell's NORTH side form the one
+        internal edge of the stack.
+        """
+        top, bot = _leaf_all_sides("top"), _leaf_all_sides("bot")
+        comp = _composite("C", [[top], [bot]])
+
+        internal = comp.get_internal_connections()
+
+        # Two directed entries: top->south (at 0,0) and bot->north (at 0,1).
+        assert (top.get_port_on_side(Side.SOUTH), 0, 0) in internal
+        assert (bot.get_port_on_side(Side.NORTH), 0, 1) in internal
+        assert len(internal) == 2
+
+
+class TestMasterAnchorOffsets:
+    """Tests for get_anchor_offset / get_master_offset on Tile."""
+
+    def test_leaf_offsets_are_origin(self) -> None:
+        """A leaf tile has anchor and master at the origin."""
+        leaf = _leaf("L")
+        assert leaf.get_anchor_offset() == (0, 0)
+        assert leaf.get_master_offset() == (0, 0)
+
+    def test_composite_anchor_is_first_cell(self) -> None:
+        """The anchor is the first non-None cell in row-major order (top-left)."""
+        top, bot = _leaf("top"), _leaf("bot")
+        # Top-first storage: tile_map[0] is the top row, so (0, 0) is the anchor.
+        comp = _composite("C", [[top], [bot]])
+        assert comp.get_anchor_offset() == (0, 0)
+
+    def test_composite_master_is_last_cell(self) -> None:
+        """The master defaults to the last non-None cell in row-major order."""
+        top, bot = _leaf("top"), _leaf("bot")
+        comp = _composite("C", [[top], [bot]])
+        assert comp.get_master_offset() == (0, 1)
+
+    def test_composite_master_override_honored(self) -> None:
+        """An explicit master_offset overrides the row-major default."""
+        top, bot = _leaf("top"), _leaf("bot")
+        comp = _composite("C", [[top], [bot]], master_offset=(0, 0))
+        assert comp.get_master_offset() == (0, 0)
+
+    def test_composite_all_none_master_raises(self) -> None:
+        """A composite with an all-None tile_map raises on get_master_offset."""
+        comp = _composite("C", [[None], [None]])
+        with pytest.raises(ValueError, match="no sub-tiles"):
+            comp.get_master_offset()
+
+
+class TestTotalConfigBits:
+    """``total_config_bits`` sums switch matrix bits and all BEL config bits."""
+
+    def test_leaf_sums_matrix_and_bels(self) -> None:
+        """A leaf reports switch matrix bits plus the sum of BEL config bits."""
+        leaf = _leaf(
+            "T",
+            bels=[_bel(2), _bel(3)],
+            switch_matrix=SwitchMatrix.from_config_bits(4),
+        )
+        assert leaf.total_config_bits == 4 + 2 + 3
+
+    def test_composite_sums_matrix_and_master_bels(self) -> None:
+        """A composite reports its own switch matrix bits plus its BEL bits."""
+        top, bot = _leaf("top"), _leaf("bot")
+        comp = _composite(
+            "C",
+            [[top], [bot]],
+            bels=[_bel(2)],
+            switch_matrix=SwitchMatrix.from_config_bits(4),
+        )
+        assert comp.total_config_bits == 6
+
+
+def _ports_on_side(side: Side, count: int, prefix: str) -> list[TilePort]:
+    """Build ``count`` single-wire OUTPUT ports on a given side of the tile."""
+    return [_tport(f"{prefix}_{side.name}_{i}", side) for i in range(count)]
+
+
+class TestGetMinDieAreaComposite:
+    """``get_min_die_area`` derives min dimensions from per-side pin counts.
+
+    For a composite tile it must take the maximum per-side pin count across all
+    constituent sub-tiles; a leaf tile uses its own per-side pin counts.
+    """
+
+    def test_leaf_uses_own_port_counts(self) -> None:
+        """A leaf derives its min dimensions from its own per-side ports."""
+        leaf = _leaf("L", ports=_ports_on_side(Side.NORTH, 4, "L"))
+        pitch = Decimal("0.5")
+        thickness = Decimal(2)
+        mw, _ = leaf.get_min_die_area(
+            x_pitch=pitch,
+            y_pitch=pitch,
+            x_pin_thickness_mult=thickness,
+            y_pin_thickness_mult=thickness,
+            frame_data_width=0,
+            frame_strobe_width=0,
+            edge_offset=2,
+        )
+        # 4 pins x 2 thickness + 2 offset = 10 tracks x 0.5 pitch = 5.0 um.
+        assert mw == Decimal("5.0")
+
+    def test_composite_uses_max_per_side_across_subtiles(self) -> None:
+        """A composite takes the max per-side pin count across its sub-tiles."""
+        # Two stacked sub-tiles: 3 north pins on top, 6 north pins on bottom.
+        top = _leaf("top", ports=_ports_on_side(Side.NORTH, 3, "top"))
+        bot = _leaf("bot", ports=_ports_on_side(Side.NORTH, 6, "bot"))
+        comp = _composite("C", [[top], [bot]])
+        pitch = Decimal("0.5")
+        thickness = Decimal(2)
+        mw, _ = comp.get_min_die_area(
+            x_pitch=pitch,
+            y_pitch=pitch,
+            x_pin_thickness_mult=thickness,
+            y_pin_thickness_mult=thickness,
+            frame_data_width=0,
+            frame_strobe_width=0,
+            edge_offset=2,
+        )
+        # max(3, 6) = 6 pins x 2 thickness + 2 offset = 14 tracks x 0.5 = 7.0 um.
+        assert mw == Decimal("7.0")

--- a/tests/fabric_definition/test_fabric.py
+++ b/tests/fabric_definition/test_fabric.py
@@ -135,7 +135,7 @@ class TestGetSuperTileContaining:
             name=name,
             tile_dir=Path(),
             tiles=tiles,
-            tileMap=[tiles],
+            tile_map=[tiles],
         )
 
     def test_returns_supertile_for_member_tile(

--- a/tests/fabric_definition/test_sjump_supertile.py
+++ b/tests/fabric_definition/test_sjump_supertile.py
@@ -115,13 +115,13 @@ class TestSuperTileHelpers:
             "name": "DSP",
             "tile_dir": Path(),
             "tiles": [top, bot],
-            "tileMap": [[top], [bot]],
+            "tile_map": [[top], [bot]],
         }
         defaults.update(overrides)
         return SuperTile(**defaults)
 
     def test_master_defaults_to_last_non_none_tile(self) -> None:
-        # tileMap [[DSP_top], [DSP_bot]] -> master is DSP_bot at local (0, 1).
+        # tile_map [[DSP_top], [DSP_bot]] -> master is DSP_bot at local (0, 1).
         assert self._supertile().get_master_tile_coords() == (0, 1)
 
     def test_master_explicit_override(self) -> None:
@@ -129,7 +129,7 @@ class TestSuperTileHelpers:
         assert st.get_master_tile_coords() == (0, 0)
 
     def test_master_raises_on_empty(self) -> None:
-        st = self._supertile(tiles=[], tileMap=[[None]])
+        st = self._supertile(tiles=[], tile_map=[[None]])
         with pytest.raises(ValueError, match="has no tiles"):
             st.get_master_tile_coords()
 
@@ -143,7 +143,7 @@ class TestSuperTileHelpers:
             name="DSP",
             tile_dir=Path(),
             tiles=[top, bot],
-            tileMap=[[top], [bot]],
+            tile_map=[[top], [bot]],
         )
         coords = [(x, y, p.name) for x, y, p in st.get_all_sjump_ports()]
         # Only OUTPUT SJUMP ports, with their (local_x, local_y).
@@ -172,10 +172,10 @@ class TestFabricSJumpWirePass:
             name="DSP",
             tile_dir=Path(),
             tiles=[top, bot],
-            tileMap=[[top], [bot]],
+            tile_map=[[top], [bot]],
         )
         for t in supertile.tiles:
-            t.partOfSuperTile = True
+            t.part_of_super_tile = True
         return make_fabric(
             tile=[[top], [bot]],
             superTileDic={"DSP": supertile},
@@ -220,12 +220,12 @@ class TestSJumpRequiresSupertile:
         self, make_fabric: Callable[..., Fabric]
     ) -> None:
         bot = _tile("DSP_bot", [sjump_port("A", IO.OUTPUT)])
-        bot.partOfSuperTile = True  # set by the parser for supertile members
+        bot.part_of_super_tile = True  # set by the parser for supertile members
         supertile = SuperTile(
             name="DSP",
             tile_dir=Path(),
             tiles=[bot],
-            tileMap=[[bot]],
+            tile_map=[[bot]],
         )
         # Must not raise.
         make_fabric(tile=[[bot]], superTileDic={"DSP": supertile})
@@ -274,11 +274,11 @@ class TestGenNpnrModelSupertile:
             name="DSP",
             tile_dir=tmp_path,
             tiles=[top, bot],
-            tileMap=[[top], [bot]],
+            tile_map=[[top], [bot]],
             switch_matrix=SwitchMatrix.from_file(st_mat, "DSP"),
         )
         for t in supertile.tiles:
-            t.partOfSuperTile = True
+            t.part_of_super_tile = True
         return make_fabric(tile=[[top], [bot]], superTileDic={"DSP": supertile})
 
     def test_forward_pip_has_bel_input_as_destination(self, fabric: Fabric) -> None:
@@ -321,7 +321,7 @@ class TestGenNpnrModelSupertile:
             name="DSP",
             tile_dir=tmp_path,
             tiles=[top, bot],
-            tileMap=[[top], [bot]],
+            tile_map=[[top], [bot]],
             bels=[bel],
         )
         for t in supertile.tiles:
@@ -385,11 +385,11 @@ class TestGenBitstreamSpecSupertileMux:
             # tile_dir.parent (here tmp_path, where the ConfigMem CSV is written).
             tile_dir=tmp_path / "DSP.csv",
             tiles=[top, bot],
-            tileMap=[[top], [bot]],
+            tile_map=[[top], [bot]],
             switch_matrix=SwitchMatrix.from_file(st_mat, "DSP"),
         )
         for t in supertile.tiles:
-            t.partOfSuperTile = True
+            t.part_of_super_tile = True
         fabric = make_fabric(tile=[[top], [bot]], superTileDic={"DSP": supertile})
         return generateBitstreamSpec(fabric)
 

--- a/tests/fabric_definition/test_supertile.py
+++ b/tests/fabric_definition/test_supertile.py
@@ -1,7 +1,7 @@
 """Tests for SuperTile methods.
 
 The supertile aggregates Tile objects into a 2D layout. The methods under test are
-pure functions of the ``tileMap`` shape and the constituent tiles' port counts:
+pure functions of the ``tile_map`` shape and the constituent tiles' port counts:
 
 - `get_ports_around_tile`: emits side-of-tile port lists for *outer* edges only.
 - `get_internal_connections`: emits side-of-tile port lists for *inner* edges only.
@@ -38,7 +38,7 @@ class TestSuperTileLayout:
             name="ST",
             tile_dir=Path(),
             tiles=[t00, t11],
-            tileMap=[[t00, None], [None, t11]],
+            tile_map=[[t00, None], [None, t11]],
         )
         assert list(st) == [((0, 0), t00), ((1, 1), t11)]
 
@@ -49,7 +49,7 @@ class TestSuperTileLayout:
             name="ST",
             tile_dir=Path(),
             tiles=[t],
-            tileMap=[[t, t, t], [t, None]],
+            tile_map=[[t, t, t], [t, None]],
         )
         assert st.max_width == 3
 
@@ -59,7 +59,7 @@ class TestSuperTileLayout:
             name="ST",
             tile_dir=Path(),
             tiles=[t],
-            tileMap=[[t], [t], [t]],
+            tile_map=[[t], [t], [t]],
         )
         assert st.max_height == 3
 
@@ -78,16 +78,18 @@ class TestSuperTilePortQueries:
     ) -> None:
         # A 1x1 supertile: every edge is outer, none are internal.
         tile = mocker.MagicMock(spec=Tile)
-        tile.getNorthSidePorts.return_value = ["N"]
-        tile.getEastSidePorts.return_value = ["E"]
-        tile.getSouthSidePorts.return_value = ["S"]
-        tile.getWestSidePorts.return_value = ["W"]
+        tile.get_port_on_side.side_effect = lambda side, _io=None: {
+            Side.NORTH: ["N"],
+            Side.EAST: ["E"],
+            Side.SOUTH: ["S"],
+            Side.WEST: ["W"],
+        }[side]
 
         st = SuperTile(
             name="ST",
             tile_dir=Path(),
             tiles=[tile],
-            tileMap=[[tile]],
+            tile_map=[[tile]],
         )
 
         ports = st.get_ports_around_tile()
@@ -106,22 +108,26 @@ class TestSuperTilePortQueries:
         # its east edge is internal (faces the right tile); mirror for the
         # right tile.
         left = mocker.MagicMock(spec=Tile)
-        left.getNorthSidePorts.return_value = ["LN"]
-        left.getEastSidePorts.return_value = ["LE"]
-        left.getSouthSidePorts.return_value = ["LS"]
-        left.getWestSidePorts.return_value = ["LW"]
+        left.get_port_on_side.side_effect = lambda side, _io=None: {
+            Side.NORTH: ["LN"],
+            Side.EAST: ["LE"],
+            Side.SOUTH: ["LS"],
+            Side.WEST: ["LW"],
+        }[side]
 
         right = mocker.MagicMock(spec=Tile)
-        right.getNorthSidePorts.return_value = ["RN"]
-        right.getEastSidePorts.return_value = ["RE"]
-        right.getSouthSidePorts.return_value = ["RS"]
-        right.getWestSidePorts.return_value = ["RW"]
+        right.get_port_on_side.side_effect = lambda side, _io=None: {
+            Side.NORTH: ["RN"],
+            Side.EAST: ["RE"],
+            Side.SOUTH: ["RS"],
+            Side.WEST: ["RW"],
+        }[side]
 
         st = SuperTile(
             name="ST",
             tile_dir=Path(),
             tiles=[left, right],
-            tileMap=[[left, right]],
+            tile_map=[[left, right]],
         )
 
         ports = st.get_ports_around_tile()
@@ -163,7 +169,7 @@ class TestSuperTileMinDieArea:
             name="ST",
             tile_dir=Path(),
             tiles=[a, b],
-            tileMap=[[a, b]],
+            tile_map=[[a, b]],
         )
 
         # pitch=1, thickness_mult=1, edge_offset=2.
@@ -189,7 +195,7 @@ class TestSuperTileMinDieArea:
             name="ST",
             tile_dir=Path(),
             tiles=[a],
-            tileMap=[[a]],
+            tile_map=[[a]],
         )
         # width = (2 * 3 + 2) * 0.5 = 4.0 ; height = (1 * 2 + 2) * 0.25 = 1.0
         w, h = st.get_min_die_area(

--- a/tests/fabric_definition/test_tile.py
+++ b/tests/fabric_definition/test_tile.py
@@ -23,7 +23,7 @@ def _mk_tile(ports: list[TilePort]) -> Tile:
         matrix_dir=Path(),
         switch_matrix=SwitchMatrix.from_connections(matrix_file=Path(), connections={}),
         gen_ios=[],
-        userCLK=False,
+        user_clk=False,
     )
 
 
@@ -160,13 +160,22 @@ def _simple_tile(
         tile_dir=Path(),
         matrix_dir=Path(),
         gen_ios=[],
-        userCLK=False,
+        user_clk=False,
         switch_matrix=SwitchMatrix.from_connections(matrix_file=Path(), connections={}),
     )
 
 
-def _composite_tile(name: str, tileMap: list[list[str | None]]) -> Tile:
-    """Build a composite Tile carrying a tileMap."""
+def _composite_tile(name: str, tile_map: list[list[str | None]]) -> Tile:
+    """Build a composite Tile from a grid of sub-tile names.
+
+    Name strings are turned into leaf ``Tile`` objects so the resulting
+    ``tile_map`` holds tile objects, matching the composite tile model.
+    """
+    objectMap: list[list[Tile | None]] = [
+        [_simple_tile(name=cell) if cell is not None else None for cell in row]
+        for row in tile_map
+    ]
+    sub_tiles = [tile for row in objectMap for tile in row if tile is not None]
     return Tile(
         name=name,
         ports=[],
@@ -174,9 +183,10 @@ def _composite_tile(name: str, tileMap: list[list[str | None]]) -> Tile:
         tile_dir=Path(),
         matrix_dir=Path(),
         gen_ios=[],
-        userCLK=False,
+        user_clk=False,
         switch_matrix=SwitchMatrix.from_connections(matrix_file=Path(), connections={}),
-        tileMap=tileMap,
+        tile_map=objectMap,
+        sub_tiles=sub_tiles,
     )
 
 
@@ -185,12 +195,13 @@ class TestSubTiles:
 
     def test_get_sub_tiles_simple(self) -> None:
         """A simple tile reports itself as its only sub-tile."""
-        assert _simple_tile(name="T1").get_sub_tiles() == ["T1"]
+        leaf = _simple_tile(name="T1")
+        assert leaf.get_sub_tiles() == [leaf]
 
     def test_get_sub_tiles_composite(self) -> None:
-        """A composite tile flattens non-None tileMap entries."""
+        """A composite tile flattens non-None tile_map entries."""
         tile = _composite_tile("C", [["T0", "T1"], ["T2", None]])
-        assert tile.get_sub_tiles() == ["T0", "T1", "T2"]
+        assert [t.name for t in tile.get_sub_tiles()] == ["T0", "T1", "T2"]
 
     def test_sub_tile_offset_simple_self(self) -> None:
         """A simple tile is at offset (0, 0)."""
@@ -288,9 +299,9 @@ class TestTileProperties:
         assert tile.bel_groups == {"T1": []}
 
     def test_config_bits_alias(self) -> None:
-        """config_bits mirrors globalConfigBits."""
+        """config_bits mirrors total_config_bits."""
         tile = _simple_tile()
-        assert tile.config_bits == tile.globalConfigBits
+        assert tile.config_bits == tile.total_config_bits
 
 
 class TestBelQueries:

--- a/tests/fabric_gen_test/configmem_test/test_configmem_rtl.py
+++ b/tests/fabric_gen_test/configmem_test/test_configmem_rtl.py
@@ -143,7 +143,7 @@ def test_configmem_rtl_with_generated_configmem_simulation(
     """Generate ConfigMem RTL and verify its behavior using cocotb simulation."""
     # Skip impossible configurations where fabric capacity < tile requirements
     fabric_capacity = fabric_config.frameBitsPerRow * fabric_config.maxFramesPerCol
-    tile_requirements = tile_config.globalConfigBits
+    tile_requirements = tile_config.total_config_bits
     if fabric_capacity < tile_requirements and tile_requirements > 0:
         pytest.skip(
             f"Impossible configuration: fabric capacity ({fabric_capacity}) < "
@@ -162,14 +162,14 @@ def test_configmem_rtl_with_generated_configmem_simulation(
     generateConfigMem(
         writer,
         tile_config.name,
-        tile_config.globalConfigBits,
+        tile_config.total_config_bits,
         csv_path,
         frame_bits_per_row=fabric_config.frameBitsPerRow,
         max_frame_per_col=fabric_config.maxFramesPerCol,
     )
 
     # Check if RTL file was created - skip if no config bits were generated
-    if tile_config.globalConfigBits != 0:
+    if tile_config.total_config_bits != 0:
         assert writer.outFileName.exists(), (
             f"ConfigMem RTL file {writer.outFileName} was not generated."
         )
@@ -181,7 +181,7 @@ def test_configmem_rtl_with_generated_configmem_simulation(
         csv_path,
         fabric_config.maxFramesPerCol,
         fabric_config.frameBitsPerRow,
-        tile_config.globalConfigBits,
+        tile_config.total_config_bits,
     )
 
     # Create direct mapping using the parsed ConfigMem objects
@@ -232,7 +232,7 @@ def test_configmem_rtl_with_custom_configmem_simulation(
     """Generate ConfigMem RTL and verify its behavior using cocotb simulation."""
     # Skip impossible configurations where fabric capacity < tile requirements
     fabric_capacity = default_fabric.frameBitsPerRow * default_fabric.maxFramesPerCol
-    tile_requirements = default_tile.globalConfigBits
+    tile_requirements = default_tile.total_config_bits
     if fabric_capacity < tile_requirements and tile_requirements > 0:
         pytest.skip(
             f"Impossible configuration: fabric capacity ({fabric_capacity}) < "
@@ -263,7 +263,7 @@ def test_configmem_rtl_with_custom_configmem_simulation(
     generateConfigMem(
         writer,
         default_tile.name,
-        default_tile.globalConfigBits,
+        default_tile.total_config_bits,
         csv_path,
         frame_bits_per_row=default_fabric.frameBitsPerRow,
         max_frame_per_col=default_fabric.maxFramesPerCol,

--- a/tests/fabric_gen_test/configmem_test/test_gen_configmem.py
+++ b/tests/fabric_gen_test/configmem_test/test_gen_configmem.py
@@ -59,7 +59,7 @@ class TestGenerateConfigMemInit:
     ) -> None:
         """Test that generateConfigMemInit creates CSV with correct structure."""
         output_file = tmp_path / f"test_{fabric_config.name}_{tile_config.name}.csv"
-        tile_config_bits = tile_config.globalConfigBits
+        tile_config_bits = tile_config.total_config_bits
         has_capacity, max_fabric_bits = _check_fabric_capacity(
             fabric_config, tile_config_bits
         )
@@ -95,7 +95,7 @@ class TestGenerateConfigMemInit:
         self, tmp_path: Path, fabric_config: Fabric, tile_config: Tile
     ) -> None:
         """Test that generated bitmasks are valid."""
-        tile_config_bits = tile_config.globalConfigBits
+        tile_config_bits = tile_config.total_config_bits
         has_capacity, max_fabric_bits = _check_fabric_capacity(
             fabric_config, tile_config_bits
         )
@@ -141,7 +141,7 @@ class TestGenerateConfigMemInit:
         self, tmp_path: Path, fabric_config: Fabric, tile_config: Tile
     ) -> None:
         """Test that bits are allocated across frames following priority order."""
-        tile_config_bits = tile_config.globalConfigBits
+        tile_config_bits = tile_config.total_config_bits
         has_capacity, max_fabric_bits = _check_fabric_capacity(
             fabric_config, tile_config_bits
         )
@@ -192,7 +192,7 @@ class TestGenerateConfigMemInit:
         self, tmp_path: Path, default_fabric: Fabric, default_tile: Tile
     ) -> None:
         """Test that ConfigBits_ranges are formatted correctly."""
-        tile_config_bits = default_tile.globalConfigBits
+        tile_config_bits = default_tile.total_config_bits
         has_capacity, max_fabric_bits = _check_fabric_capacity(
             default_fabric, tile_config_bits
         )
@@ -256,14 +256,14 @@ class TestGeneratedConfigMemRTL:
 
         # Call generateConfigMem
         has_capacity, _ = _check_fabric_capacity(
-            fabric_config, tile_config.globalConfigBits
+            fabric_config, tile_config.total_config_bits
         )
-        if not has_capacity and tile_config.globalConfigBits > 0:
+        if not has_capacity and tile_config.total_config_bits > 0:
             with pytest.raises(ValueError, match="adjust the configuration."):
                 generateConfigMem(
                     writer,
                     tile_config.name,
-                    tile_config.globalConfigBits,
+                    tile_config.total_config_bits,
                     config_csv,
                     frame_bits_per_row=fabric_config.frameBitsPerRow,
                     max_frame_per_col=fabric_config.maxFramesPerCol,
@@ -273,7 +273,7 @@ class TestGeneratedConfigMemRTL:
         generateConfigMem(
             writer,
             tile_config.name,
-            tile_config.globalConfigBits,
+            tile_config.total_config_bits,
             config_csv,
             frame_bits_per_row=fabric_config.frameBitsPerRow,
             max_frame_per_col=fabric_config.maxFramesPerCol,
@@ -281,7 +281,7 @@ class TestGeneratedConfigMemRTL:
 
         # Verify output file was created and contains expected content
         output_file = writer.outFileName
-        if tile_config.globalConfigBits != 0:
+        if tile_config.total_config_bits != 0:
             assert output_file.exists(), "Output file should be created"
         else:
             return  # Skip further checks if no config bits are generated
@@ -291,8 +291,8 @@ class TestGeneratedConfigMemRTL:
 
         # Count actual config_latch instantiations in content
         actual_instantiations = content.count("config_latch")
-        assert actual_instantiations == tile_config.globalConfigBits, (
-            f"Expected {tile_config.globalConfigBits} config_latch instantiations, "
+        assert actual_instantiations == tile_config.total_config_bits, (
+            f"Expected {tile_config.total_config_bits} config_latch instantiations, "
             f"found {actual_instantiations}"
         )
 
@@ -327,7 +327,7 @@ class TestGeneratedConfigMemRTL:
         generateConfigMem(
             writer,
             default_tile.name,
-            default_tile.globalConfigBits,
+            default_tile.total_config_bits,
             csv_path,
             frame_bits_per_row=default_fabric.frameBitsPerRow,
             max_frame_per_col=default_fabric.maxFramesPerCol,

--- a/tests/fabric_gen_test/conftest.py
+++ b/tests/fabric_gen_test/conftest.py
@@ -33,7 +33,7 @@ class TileConfig(NamedTuple):
     """Configuration parameters for tile testing."""
 
     name: str
-    global_config_bits: int
+    total_config_bits: int
 
 
 @pytest.fixture
@@ -64,7 +64,7 @@ def mk_tile(tmp_path: Path) -> Callable[[str], Tile]:
             tile_dir=tmp_path,
             matrix_dir=matrix_dir,
             gen_ios=[],
-            userCLK=False,
+            user_clk=False,
             switch_matrix=switch_matrix,
         )
 
@@ -86,7 +86,7 @@ def default_tile(mocker: MockerFixture) -> Tile:
     """Create a Tile instance with given parameters."""
     tile = mocker.create_autospec(Tile, spec_set=False)
     tile.name = "DefaultTile"
-    tile.globalConfigBits = 127
+    tile.total_config_bits = 127
     return tile
 
 
@@ -191,7 +191,7 @@ def tile_config(request: pytest.FixtureRequest, mocker: MockerFixture) -> Tile:
     config = request.param
     tile = mocker.create_autospec(Tile, spec_set=False)
     tile.name = config.name
-    tile.globalConfigBits = config.global_config_bits
+    tile.total_config_bits = config.total_config_bits
     return tile
 
 
@@ -362,7 +362,7 @@ def configmem_list(
             )
         )
         shuffle(poss)
-        config_final = poss[: tile.globalConfigBits]
+        config_final = poss[: tile.total_config_bits]
 
         def generate_mask(bits_used: int, total_bits: int) -> str:
             """Generate a random bit mask with specified number of '1's and '0's.

--- a/tests/fabric_gen_test/fabric_test/test_gen_fabric.py
+++ b/tests/fabric_gen_test/fabric_test/test_gen_fabric.py
@@ -63,7 +63,7 @@ def _supertile(tmp_path: Path) -> SuperTile:
         name="DSP",
         tile_dir=tmp_path,
         tiles=[top, bot],
-        tileMap=[[top], [bot]],
+        tile_map=[[top], [bot]],
         bels=[bel],
         switch_matrix=SwitchMatrix.from_file(mat, "DSP"),
     )
@@ -175,8 +175,8 @@ def test_iter_supertile_anchors_yields_top_left_anchor(tmp_path: Path) -> None:
     """
     supertile = _supertile(tmp_path)
     top, bot = supertile.tiles
-    top.partOfSuperTile = True
-    bot.partOfSuperTile = True
+    top.part_of_super_tile = True
+    bot.part_of_super_tile = True
     fabric = Fabric(
         fabric_dir=tmp_path,
         tile=[[top], [bot]],

--- a/tests/fabric_gen_test/fabric_test/test_gen_fabric_child_index.py
+++ b/tests/fabric_gen_test/fabric_test/test_gen_fabric_child_index.py
@@ -43,13 +43,13 @@ def test_supertile_bottom_child_usrclk_connects_to_global(
     """
     top = mk_tile("ST_top")
     bot = mk_tile("ST_bot")
-    top.partOfSuperTile = True
-    bot.partOfSuperTile = True
+    top.part_of_super_tile = True
+    bot.part_of_super_tile = True
     supertile = SuperTile(
         name="ST",
         tile_dir=top.tile_dir,
         tiles=[top, bot],
-        tileMap=[[top], [bot]],
+        tile_map=[[top], [bot]],
     )
     fabric = Fabric(
         fabric_dir=top.tile_dir,

--- a/tests/fabric_gen_test/fabric_test/test_gen_supertile.py
+++ b/tests/fabric_gen_test/fabric_test/test_gen_supertile.py
@@ -158,7 +158,7 @@ def supertile_netlist(
 
     def _build(tileMap: list[list[Tile | None]], **kwargs: object) -> GridConnectivity:
         tiles = [t for row in tileMap for t in row if t is not None]
-        st = SuperTile(name="ST", tile_dir=Path(), tiles=tiles, tileMap=tileMap)
+        st = SuperTile(name="ST", tile_dir=Path(), tiles=tiles, tile_map=tileMap)
         out = tmp_path / "ST.v"
         writer = VerilogCodeGenerator()
         writer.outFileName = out
@@ -344,7 +344,7 @@ class TestBelExternalPorts:
                 matrix_file=Path(), connections={}
             ),
             gen_ios=[],
-            userCLK=False,
+            user_clk=False,
         )
         net = supertile_netlist([[tile]])
 
@@ -383,7 +383,7 @@ class TestInterTileRouting:
                 matrix_file=Path(), connections={}
             ),
             gen_ios=[],
-            userCLK=False,
+            user_clk=False,
         )
         right = Tile(
             name="Right",
@@ -408,7 +408,7 @@ class TestInterTileRouting:
                 matrix_file=Path(), connections={}
             ),
             gen_ios=[],
-            userCLK=False,
+            user_clk=False,
         )
         net = supertile_netlist([[left, right]])
 

--- a/tests/fabric_gen_test/switchmatrix_test/test_gen_switchmatrix.py
+++ b/tests/fabric_gen_test/switchmatrix_test/test_gen_switchmatrix.py
@@ -351,7 +351,7 @@ class TestSuperTileSwitchMatrixConstants:
             name="DSP",
             tile_dir=tmp_path,
             tiles=[bot],
-            tileMap=[[bot]],
+            tile_map=[[bot]],
             bels=[bel],
             switch_matrix=SwitchMatrix.from_file(mat, "DSP"),
         )

--- a/tests/fabric_gen_test/switchmatrix_test/test_parse_switchmatrix.py
+++ b/tests/fabric_gen_test/switchmatrix_test/test_parse_switchmatrix.py
@@ -323,7 +323,7 @@ class TestSuperTileMatrixValidation:
             name="DSP",
             tile_dir=Path(),
             tiles=[bot],
-            tileMap=[[bot]],
+            tile_map=[[bot]],
             bels=[bel],
         )
 

--- a/tests/gds_flow_test/flow_test/test_gen_io_pin_config_yaml.py
+++ b/tests/gds_flow_test/flow_test/test_gen_io_pin_config_yaml.py
@@ -138,10 +138,13 @@ class TestSerializeTilePorts:
         west_port.get_port_regex.return_value = r"W\[\d+\]"
 
         # Set up side port methods
-        tile.getNorthSidePorts.return_value = [north_port]
-        tile.getEastSidePorts.return_value = [east_port]
-        tile.getSouthSidePorts.return_value = [south_port]
-        tile.getWestSidePorts.return_value = [west_port]
+        side_ports = {
+            Side.NORTH: [north_port],
+            Side.EAST: [east_port],
+            Side.SOUTH: [south_port],
+            Side.WEST: [west_port],
+        }
+        tile.get_port_on_side.side_effect = lambda side, _io=None: side_ports[side]
 
         # Pin order config for each side
         tile.pin_order_config = {
@@ -228,10 +231,7 @@ class TestSerializeTilePorts:
         tile = mocker.MagicMock()
 
         # Empty side ports
-        tile.getNorthSidePorts.return_value = []
-        tile.getEastSidePorts.return_value = []
-        tile.getSouthSidePorts.return_value = []
-        tile.getWestSidePorts.return_value = []
+        tile.get_port_on_side.return_value = []
 
         tile.pin_order_config = {
             Side.NORTH: PinOrderConfig(),
@@ -259,7 +259,7 @@ class TestSerializeTilePorts:
     def test_serialize_tile_ports_empty_port_regex(self, mock_tile: Tile) -> None:
         """Test handling of ports that return empty regex."""
         # Make one port return empty regex
-        mock_tile.getNorthSidePorts.return_value[0].get_port_regex.return_value = ""
+        mock_tile.get_port_on_side(Side.NORTH)[0].get_port_regex.return_value = ""
 
         result = _serialize_tile_ports(mock_tile)
 
@@ -287,7 +287,7 @@ class TestSerializeSupertilePorts:
         mock_tile.bels = []
 
         # 2x2 supertile
-        supertile.tileMap = [
+        supertile.tile_map = [
             [mock_tile, mock_tile],
             [mock_tile, mock_tile],
         ]
@@ -360,7 +360,7 @@ class TestSerializeSupertilePorts:
         tile_top = _tile()
         tile_bot = _tile()
         # 1-wide, 2-tall layout — tile_top above tile_bot
-        supertile.tileMap = [[tile_top], [tile_bot]]
+        supertile.tile_map = [[tile_top], [tile_bot]]
 
         # tile_top (0,0): only EAST has routing ports; NORTH and WEST do not
         east_port_top = mocker.MagicMock()
@@ -436,12 +436,12 @@ class TestSerializeSupertilePorts:
         )
 
     def test_serialize_supertile_ports_none_tile(self, mocker: MockerFixture) -> None:
-        """Test handling when tileMap has None entries."""
+        """Test handling when tile_map has None entries."""
         supertile = mocker.MagicMock()
         supertile.bels = []
 
         # TileMap with None
-        supertile.tileMap = [[None]]
+        supertile.tile_map = [[None]]
 
         port = mocker.MagicMock()
         port.side_of_tile = Side.SOUTH
@@ -475,10 +475,7 @@ class TestGenerateIOPinOrderConfig:
         tile = mocker.MagicMock(spec=Tile)
 
         # Empty side ports for simplicity
-        tile.getNorthSidePorts.return_value = []
-        tile.getEastSidePorts.return_value = []
-        tile.getSouthSidePorts.return_value = []
-        tile.getWestSidePorts.return_value = []
+        tile.get_port_on_side.return_value = []
 
         tile.pin_order_config = {
             Side.NORTH: PinOrderConfig(),
@@ -557,7 +554,7 @@ class TestGenerateIOPinOrderConfig:
         }
         mock_tile.bels = []
 
-        mock_supertile.tileMap = [[mock_tile]]
+        mock_supertile.tile_map = [[mock_tile]]
         mock_supertile.get_ports_around_tile.return_value = {}
 
         outfile = tmp_path / "test_supertile_config.yaml"
@@ -663,7 +660,7 @@ class TestGenerateIOPinOrderConfig:
         bel.external_output = []
         mock_tile.bels = [bel]
 
-        mock_supertile.tileMap = [[mock_tile]]
+        mock_supertile.tile_map = [[mock_tile]]
         mock_supertile.get_ports_around_tile.return_value = {"0,0": [[]]}
 
         mock_fabric = mocker.MagicMock(spec=Fabric)
@@ -706,7 +703,7 @@ class TestGenerateIOPinOrderConfig:
         bel.external_output = []
         mock_tile.bels = [bel]
 
-        mock_supertile.tileMap = [[mock_tile]]
+        mock_supertile.tile_map = [[mock_tile]]
         mock_supertile.get_ports_around_tile.return_value = {"0,0": [[]]}
 
         outfile = tmp_path / "test_config.yaml"

--- a/tests/gds_flow_test/step_test/test_fabric_area_opt.py
+++ b/tests/gds_flow_test/step_test/test_fabric_area_opt.py
@@ -361,7 +361,7 @@ def _make_tile(name: str) -> Tile:
         matrix_dir=Path(),
         switch_matrix=SwitchMatrix.from_connections(matrix_file=Path(), connections={}),
         gen_ios=[],
-        userCLK=False,
+        user_clk=False,
     )
 
 


### PR DESCRIPTION
Stacked PRs:
 * #961
 * __->__#960
 * #959
 * #958
 * #957
 * #956


--- --- ---

### feat(fabric): make Tile a composite


Give Tile the structure and the port API a supertile used to own, so a
single type can describe both a leaf tile and a former supertile:

- `tile_map` (a 2D grid of sub-tile objects, stored top row first),
  `sub_tiles`, `master_offset` and the derived `is_composite`, `max_width`
  and `max_height` views. A leaf tile is a 1x1 composite of itself, so
  `get_sub_tiles()` returns `[self]` and every composite-aware code path
  works unchanged on leaves.
- `__iter__` over the occupied `(x, y)` cells, plus `get_sub_tile_offset`,
  `get_anchor_offset`, `get_master_offset`, `part_of_tile` and
  `is_root_tile` for locating a sub-tile inside the grid.
- The perimeter/internal port split that lived on SuperTile:
  `get_ports_around_tile()` reports the side ports of each cell whose
  neighbour in the grid is absent, and `get_internal_connections()` reports
  the ones that face another present cell. Together they partition every
  side of every cell exactly once.
- `switch_matrix_config_bits` and `total_config_bits` for the tile's
  configuration-bit counts.

SuperTile still exists and still owns parsing and generation; this only
adds the composite view to Tile and points the consumers that can already
use it at the new API.
