### PR TITLE
fix: typos in Docs and python files

### DIFF
--- a/docs/source/user_guide/building_doc/configuration.md
+++ b/docs/source/user_guide/building_doc/configuration.md
@@ -47,8 +47,6 @@ The bitbang adapter offers a quick asynchronous serial configuration port interf
 :alt: Bitbang description
 :::
 
-### Bitbang
-
 - **Signals:** `s_clk` and `s_data`, as well as a one-cycle strobe output (active 1).
 - **Protocol:** Data is sampled on each rising edge of `s_clk`, and control is sampled on the falling edge.
 - **Word assembly:** Both values get shifted in a separate register; if the control register sees the bit-pattern x"FAB0", it samples the data shift register into a hold register and issues a one-cycle strobe output (active 1).

--- a/fabulous/fabric_generator/code_generator/code_generator_Verilog.py
+++ b/fabulous/fabric_generator/code_generator/code_generator_Verilog.py
@@ -371,7 +371,7 @@ class VerilogCodeGenerator(CodeGenerator):
         cfgBit = int(math.ceil(configBits / 2.0)) * 2
         template = f"""
     genvar k;
-    assign ConfigBitsInput = {{ConfigBits[{cfgBit}-1-1:0], CONFin;}}
+    assign ConfigBitsInput = {{ConfigBits[{cfgBit}-1-1:0], CONFin}};
     // for k in 0 to Conf/2 generate
     for (k=0; k < {cfgBit - 1}; k = k + 1) begin: L
         config_latch inst_config_latch_a(

--- a/fabulous/fabric_generator/gen_fabric/gen_fabric.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_fabric.py
@@ -229,7 +229,7 @@ def generateFabric(writer: CodeGenerator, fabric: Fabric) -> None:
     # (so we can modify this here without side effects)
     if fabric.configBitMode == "FlipFlopChain":
         writer.addComment("configuration data daisy chaining", onNewLine=True)
-        writer.addAssignScalar("conf_dat'low", "CONFin")
+        writer.addAssignScalar("conf_data'low", "CONFin")
         writer.addComment("conf_data'low=0 and CONFin is from tile entity")
         writer.addAssignScalar("CONFout", "conf_data'high")
         writer.addComment("CONFout is from tile entity")


### PR DESCRIPTION
#### 1. Documentation cleanup
 * **File:** `Docs/user_guide/building_doc/configuration.md`
 * **Fix:** Removed the duplicate `Bitbang` header to fix document formatting.
* [Issue #970 (comment)](https://github.com/FPGA-Research/FABulous/issues/970#issuecomment-5095934236)

#### 2. Verilog Syntax Error in Switch Matrix Modules
* **File:** `FABulous/fabulous/fabric_generator/code_generator/code_generator_Verilog.py` (Line 374)
* **Issue:** The code generator was placing a semicolon inside the concatenation braces, resulting in an invalid Verilog syntax error across all generated `*_switch_matrix` modules.
* **Fix:** Corrected the string formatting so the Verilog assignment is properly terminated outside the braces.
  * **From:** `assign ConfigBitsInput = {{ConfigBits[{cfgBit}-1-1:0], CONFin;}}`
  * **To:** `assign ConfigBitsInput = {{ConfigBits[{cfgBit}-1-1:0], CONFin}};`

#### 3. Signal Naming Typo
* **File:** `FABulous/fabulous/fabric_generator/gen_fabric/gen_fabric.py` (Line 232)
* **Issue:** A typo in the signal name string (`conf_dat'low`) was generating incorrect scalar assignments.
* **Fix:** Corrected the spelling to ensure proper signal mapping.
  * **From:** `writer.addAssignScalar("conf_dat'low", "CONFin")`
  * **To:** `writer.addAssignScalar("conf_data'low", "CONFin")`