### PR TITLE
feat: add xsim support with fixes to HDL for supporting

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -20,50 +20,30 @@ tasks:
       - uv run --directory . make livehtml
 
   smoke-test:
-    desc: Create the demo project and run the simulation flow
+    desc: Create the demo project and run the simulation flow (SIMULATOR=iverilog|xvlog|nvc|ghdl|xvhdl)
     # FABULOUS is the launcher prefix. It defaults to `uv run FABulous` for the
     # uv-managed dev/container environment; in the Nix devshell FABulous is on
     # PATH directly, so pass `FABULOUS=FABulous` to skip uv (whose .venv is a
     # different Python and ABI-incompatible with the devshell's packages).
+    #
+    # SIMULATOR also picks the project language: iverilog and xvlog build a
+    # Verilog project, nvc, ghdl and xvhdl a VHDL one.
     vars:
       FABULOUS: '{{.FABULOUS | default "uv run FABulous"}}'
+      SIMULATOR: '{{.SIMULATOR | default "iverilog"}}'
+      LANGUAGE_FLAG:
+        sh: 'case "{{.SIMULATOR}}" in nvc|ghdl|xvhdl) echo "-w vhdl" ;; esac'
+    preconditions:
+      # Membership, not emptiness: LANGUAGE_FLAG is legitimately empty for Verilog.
+      - sh: 'case "{{.SIMULATOR}}" in iverilog|xvlog|nvc|ghdl|xvhdl) exit 0 ;; *) exit 1 ;; esac'
+        msg: >-
+          Unknown SIMULATOR '{{.SIMULATOR}}'. Use iverilog or xvlog for Verilog,
+          or nvc, ghdl or xvhdl for VHDL.
     cmds:
       - rm -rf demo-smoke-test
-      - '{{.FABULOUS}} c demo-smoke-test'
+      - '{{.FABULOUS}} c demo-smoke-test {{.LANGUAGE_FLAG}}'
       - '{{.FABULOUS}} -p demo-smoke-test run "run_fab"'
-      - task --dir ./demo-smoke-test/Test fab-sim
-
-  smoke-test-xsim:
-    desc: Create the demo project and run the simulation flow under Vivado xsim
-    # Needs xvlog/xelab/xsim on PATH from a Vivado installation.
-    vars:
-      FABULOUS: '{{.FABULOUS | default "uv run FABulous"}}'
-    cmds:
-      - rm -rf demo-smoke-test
-      - '{{.FABULOUS}} c demo-smoke-test'
-      - '{{.FABULOUS}} -p demo-smoke-test run "run_fab"'
-      - task --dir ./demo-smoke-test/Test fab-sim-xsim
-
-  smoke-test-vhdl:
-    desc: Create the demo project and run the simulation flow
-    vars:
-      FABULOUS: '{{.FABULOUS | default "uv run FABulous"}}'
-    cmds:
-      - rm -rf demo-smoke-test
-      - '{{.FABULOUS}} c demo-smoke-test -w vhdl'
-      - '{{.FABULOUS}} -p demo-smoke-test run "run_fab"'
-      - task --dir ./demo-smoke-test/Test fab-sim
-
-  smoke-test-vhdl-xsim:
-    desc: Create the VHDL demo project and run the simulation flow under Vivado xsim
-    # Needs xvhdl/xelab/xsim on PATH from a Vivado installation.
-    vars:
-      FABULOUS: '{{.FABULOUS | default "uv run FABulous"}}'
-    cmds:
-      - rm -rf demo-smoke-test
-      - '{{.FABULOUS}} c demo-smoke-test -w vhdl'
-      - '{{.FABULOUS}} -p demo-smoke-test run "run_fab"'
-      - task --dir ./demo-smoke-test/Test fab-sim-xsim
+      - task --dir ./demo-smoke-test/Test fab-sim SIMULATOR={{.SIMULATOR}}
 
   ci:
     desc: Run code checks, tests, and the docs build

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -54,6 +54,17 @@ tasks:
       - '{{.FABULOUS}} -p demo-smoke-test run "run_fab"'
       - task --dir ./demo-smoke-test/Test fab-sim
 
+  smoke-test-vhdl-xsim:
+    desc: Create the VHDL demo project and run the simulation flow under Vivado xsim
+    # Needs xvhdl/xelab/xsim on PATH from a Vivado installation.
+    vars:
+      FABULOUS: '{{.FABULOUS | default "uv run FABulous"}}'
+    cmds:
+      - rm -rf demo-smoke-test
+      - '{{.FABULOUS}} c demo-smoke-test -w vhdl'
+      - '{{.FABULOUS}} -p demo-smoke-test run "run_fab"'
+      - task --dir ./demo-smoke-test/Test fab-sim-xsim
+
   ci:
     desc: Run code checks, tests, and the docs build
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -20,28 +20,30 @@ tasks:
       - uv run --directory . make livehtml
 
   smoke-test:
-    desc: Create the demo project and run the simulation flow
+    desc: Create the demo project and run the simulation flow (SIMULATOR=iverilog|xvlog|nvc|ghdl|xvhdl)
     # FABULOUS is the launcher prefix. It defaults to `uv run FABulous` for the
     # uv-managed dev/container environment; in the Nix devshell FABulous is on
     # PATH directly, so pass `FABULOUS=FABulous` to skip uv (whose .venv is a
     # different Python and ABI-incompatible with the devshell's packages).
+    #
+    # SIMULATOR also picks the project language: iverilog and xvlog build a
+    # Verilog project, nvc, ghdl and xvhdl a VHDL one.
     vars:
       FABULOUS: '{{.FABULOUS | default "uv run FABulous"}}'
+      SIMULATOR: '{{.SIMULATOR | default "iverilog"}}'
+      LANGUAGE_FLAG:
+        sh: 'case "{{.SIMULATOR}}" in nvc|ghdl|xvhdl) echo "-w vhdl" ;; esac'
+    preconditions:
+      # Membership, not emptiness: LANGUAGE_FLAG is legitimately empty for Verilog.
+      - sh: 'case "{{.SIMULATOR}}" in iverilog|xvlog|nvc|ghdl|xvhdl) exit 0 ;; *) exit 1 ;; esac'
+        msg: >-
+          Unknown SIMULATOR '{{.SIMULATOR}}'. Use iverilog or xvlog for Verilog,
+          or nvc, ghdl or xvhdl for VHDL.
     cmds:
       - rm -rf demo-smoke-test
-      - '{{.FABULOUS}} c demo-smoke-test'
+      - '{{.FABULOUS}} c demo-smoke-test {{.LANGUAGE_FLAG}}'
       - '{{.FABULOUS}} -p demo-smoke-test run "run_fab"'
-      - task --dir ./demo-smoke-test/Test fab-sim
-
-  smoke-test-vhdl:
-    desc: Create the demo project and run the simulation flow
-    vars:
-      FABULOUS: '{{.FABULOUS | default "uv run FABulous"}}'
-    cmds:
-      - rm -rf demo-smoke-test
-      - '{{.FABULOUS}} c demo-smoke-test -w vhdl'
-      - '{{.FABULOUS}} -p demo-smoke-test run "run_fab"'
-      - task --dir ./demo-smoke-test/Test fab-sim
+      - task --dir ./demo-smoke-test/Test fab-sim SIMULATOR={{.SIMULATOR}}
 
   ci:
     desc: Run code checks, tests, and the docs build

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -33,6 +33,17 @@ tasks:
       - '{{.FABULOUS}} -p demo-smoke-test run "run_fab"'
       - task --dir ./demo-smoke-test/Test fab-sim
 
+  smoke-test-xsim:
+    desc: Create the demo project and run the simulation flow under Vivado xsim
+    # Needs xvlog/xelab/xsim on PATH from a Vivado installation.
+    vars:
+      FABULOUS: '{{.FABULOUS | default "uv run FABulous"}}'
+    cmds:
+      - rm -rf demo-smoke-test
+      - '{{.FABULOUS}} c demo-smoke-test'
+      - '{{.FABULOUS}} -p demo-smoke-test run "run_fab"'
+      - task --dir ./demo-smoke-test/Test fab-sim-xsim
+
   smoke-test-vhdl:
     desc: Create the demo project and run the simulation flow
     vars:

--- a/docs/source/user_guide/simulation/simulation.md
+++ b/docs/source/user_guide/simulation/simulation.md
@@ -122,7 +122,7 @@ The available variables are:
 | `WAVEFORM_TYPE` | `fst` | Waveform output format (`fst` or `vcd`) |
 | `BUILD_DIR` | `build` | Build output directory |
 | `FAB_PROJ_ROOT` | `..` | Path to the project root |
-| `SIMULATOR` | `auto` | Simulator selection (`auto`, `nvc`, or `ghdl`). `auto` uses NVC if available, falls back to GHDL |
+| `SIMULATOR` | `iverilog` (Verilog), `auto` (VHDL) | Simulator backend. Verilog: `iverilog` or `xvlog`. VHDL: `nvc`, `ghdl`, `xvhdl`, or `auto`, where `auto` uses NVC if available and GHDL otherwise |
 | `BITSTREAM_BIN` | `build/<DESIGN>.bin` | Path to the `.bin` bitstream file |
 | `EXTRA_IVERILOG_FLAGS` | *(empty)* | Extra flags passed to iverilog (Verilog only) |
 | `EXTRA_NVC_FLAGS` | *(empty)* | Extra flags passed to NVC (VHDL only) |
@@ -152,9 +152,10 @@ FABulous> run_simulation fst path/to/design.bin --extra-iverilog-flag="-DDEBUG"
 FABulous> run_simulation fst path/to/design.bin --extra-nvc-flag="--ieee-warnings=error"
 FABulous> run_simulation fst path/to/design.bin --extra-ghdl-flag="--warn-error"
 
-# Force a specific VHDL simulator
+# Force a specific simulator backend
 FABulous> run_simulation fst path/to/design.bin --simulator=nvc
 FABulous> run_simulation fst path/to/design.bin --simulator=ghdl
+FABulous> run_simulation fst path/to/design.bin --simulator=xvhdl
 
 # Combine options
 FABulous> run_simulation vcd path/to/design.bin -d my_design -if "-DDEBUG -DTRACE"
@@ -163,7 +164,7 @@ FABulous> run_simulation vcd path/to/design.bin -d my_design -if "-DDEBUG -DTRAC
 | Flag | Short | Description |
 |---|---|---|
 | `--design` | `-d` | Override the design name (default: inferred from bitstream filename) |
-| `--simulator` | `-s` | VHDL simulator: `nvc`, `ghdl`, or `auto` (default: auto-detect) |
+| `--simulator` | `-s` | Simulator backend: `iverilog` or `xvlog` (Verilog), `nvc`, `ghdl`, `xvhdl`, or `auto` (VHDL). Unset leaves the choice to the Taskfile |
 | `--extra-iverilog-flag` | `-if` | Extra flags for iverilog (Verilog projects) |
 | `--extra-nvc-flag` | `-nf` | Extra flags for NVC (VHDL projects) |
 | `--extra-ghdl-flag` | `-gf` | Extra flags for GHDL (VHDL projects) |
@@ -180,6 +181,16 @@ toolchain.
   compiles packages (`models_pack`) first, then tile files, then fabric
   infrastructure, and finally the user design and testbench.
   You can force a specific simulator by setting `SIMULATOR=nvc` or `SIMULATOR=ghdl`.
+
+AMD Vivado's xsim runs both languages, selected by `SIMULATOR=xvlog` in a
+Verilog project and `SIMULATOR=xvhdl` in a VHDL one. Either needs that analyser,
+`xelab` and `xsim` on `PATH` from a Vivado installation. xsim exits 0 after a
+testbench failure, so the task fails the run by grepping the simulator log; see
+the `Test/README.md` of each template for the rest.
+
+The same value drives the repository-level smoke test, where it also picks the
+project language, so `task smoke-test SIMULATOR=xvhdl` creates a VHDL demo
+project and runs it under xsim.
 
 :::{note}
 The `Taskfile.yml` is a regular YAML file that you can freely edit to add

--- a/docs/source/user_guide/simulation/simulation.md
+++ b/docs/source/user_guide/simulation/simulation.md
@@ -122,11 +122,15 @@ The available variables are:
 | `WAVEFORM_TYPE` | `fst` | Waveform output format (`fst` or `vcd`) |
 | `BUILD_DIR` | `build` | Build output directory |
 | `FAB_PROJ_ROOT` | `..` | Path to the project root |
-| `SIMULATOR` | `auto` | Simulator selection (`auto`, `nvc`, or `ghdl`). `auto` uses NVC if available, falls back to GHDL |
+| `SIMULATOR` | `iverilog` (Verilog), `auto` (VHDL) | Simulator backend. Verilog: `iverilog` or `xvlog`. VHDL: `nvc`, `ghdl`, `xvhdl`, or `auto`, where `auto` uses NVC if available and GHDL otherwise |
 | `BITSTREAM_BIN` | `build/<DESIGN>.bin` | Path to the `.bin` bitstream file |
 | `EXTRA_IVERILOG_FLAGS` | *(empty)* | Extra flags passed to iverilog (Verilog only) |
 | `EXTRA_NVC_FLAGS` | *(empty)* | Extra flags passed to NVC (VHDL only) |
 | `EXTRA_GHDL_FLAGS` | *(empty)* | Extra flags passed to GHDL (VHDL only) |
+| `EXTRA_XVLOG_FLAGS` | *(empty)* | Extra flags passed to xvlog (Verilog, xsim only) |
+| `EXTRA_XVHDL_FLAGS` | *(empty)* | Extra flags passed to xvhdl (VHDL, xsim only) |
+| `EXTRA_XELAB_FLAGS` | *(empty)* | Extra flags passed to xelab (xsim only) |
+| `XSIM_SNAPSHOT` | `<DESIGN>_xsim` | xelab snapshot name; also names the xsim log and waveform (xsim only) |
 | `MAX_BITBYTES` | `16384` | Maximum bitstream size in bytes |
 
 Variables can also be set via environment variables or the project's
@@ -152,9 +156,10 @@ FABulous> run_simulation fst path/to/design.bin --extra-iverilog-flag="-DDEBUG"
 FABulous> run_simulation fst path/to/design.bin --extra-nvc-flag="--ieee-warnings=error"
 FABulous> run_simulation fst path/to/design.bin --extra-ghdl-flag="--warn-error"
 
-# Force a specific VHDL simulator
+# Force a specific simulator backend
 FABulous> run_simulation fst path/to/design.bin --simulator=nvc
 FABulous> run_simulation fst path/to/design.bin --simulator=ghdl
+FABulous> run_simulation fst path/to/design.bin --simulator=xvhdl
 
 # Combine options
 FABulous> run_simulation vcd path/to/design.bin -d my_design -if "-DDEBUG -DTRACE"
@@ -163,7 +168,7 @@ FABulous> run_simulation vcd path/to/design.bin -d my_design -if "-DDEBUG -DTRAC
 | Flag | Short | Description |
 |---|---|---|
 | `--design` | `-d` | Override the design name (default: inferred from bitstream filename) |
-| `--simulator` | `-s` | VHDL simulator: `nvc`, `ghdl`, or `auto` (default: auto-detect) |
+| `--simulator` | `-s` | Simulator backend: `iverilog` or `xvlog` (Verilog), `nvc`, `ghdl`, `xvhdl`, or `auto` (VHDL). Unset leaves the choice to the Taskfile |
 | `--extra-iverilog-flag` | `-if` | Extra flags for iverilog (Verilog projects) |
 | `--extra-nvc-flag` | `-nf` | Extra flags for NVC (VHDL projects) |
 | `--extra-ghdl-flag` | `-gf` | Extra flags for GHDL (VHDL projects) |
@@ -180,6 +185,16 @@ toolchain.
   compiles packages (`models_pack`) first, then tile files, then fabric
   infrastructure, and finally the user design and testbench.
   You can force a specific simulator by setting `SIMULATOR=nvc` or `SIMULATOR=ghdl`.
+
+AMD Vivado's xsim runs both languages, selected by `SIMULATOR=xvlog` in a
+Verilog project and `SIMULATOR=xvhdl` in a VHDL one. Either needs that analyser,
+`xelab` and `xsim` on `PATH` from a Vivado installation. xsim exits 0 after a
+testbench failure, so the task fails the run by grepping the simulator log; see
+the `Test/README.md` of each template for the rest.
+
+The same value drives the repository-level smoke test, where it also picks the
+project language, so `task smoke-test SIMULATOR=xvhdl` creates a VHDL demo
+project and runs it under xsim.
 
 :::{note}
 The `Taskfile.yml` is a regular YAML file that you can freely edit to add

--- a/fabulous/fabric_files/FABulous_project_template_common/user_design/top_wrapper.v
+++ b/fabulous/fabric_files/FABulous_project_template_common/user_design/top_wrapper.v
@@ -156,4 +156,4 @@ module top_wrapper;
     );
 
 endmodule
-`default_nettype wire
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/BlockRAM_1KB.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/BlockRAM_1KB.v
@@ -8,18 +8,18 @@ module BlockRAM_1KB #(
     // Default 20 means bit wr_data[20] will become the dynamic write enable input
     parameter integer WRITE_ENABLE_FROM_DATA          = 20
 ) (
-    input         clk    ,
-    input  [ 7:0] rd_addr,
-    output [31:0] rd_data,
-    input  [ 7:0] wr_addr,
-    input  [31:0] wr_data,
+    input  wire        clk    ,
+    input  wire [ 7:0] rd_addr,
+    output wire [31:0] rd_data,
+    input  wire [ 7:0] wr_addr,
+    input  wire [31:0] wr_data,
     // Configuration bit inputs
-    input         C0     , // C0 and C1 select write port width
-    input         C1     ,
-    input         C2     , // C2 and C3 select read port width
-    input         C3     ,
-    input         C4     , // C4 selects the always_write_enable
-    input         C5       // C5 selects register bypass
+    input  wire        C0     , // C0 and C1 select write port width
+    input  wire        C1     ,
+    input  wire        C2     , // C2 and C3 select read port width
+    input  wire        C3     ,
+    input  wire        C4     , // C4 selects the always_write_enable
+    input  wire        C5       // C5 selects register bypass
 );
     // NOTE: the read enable is currently constantly ON
     // NOTE: the R/W port on the standard cell is used only in write mode
@@ -200,18 +200,18 @@ module sram_1rw1r_32_256_8_sky130 #(
     parameter integer DELAY      = 3
 ) (
     // Port 0: RW
-    input                   clk0  , // clock
-    input                   csb0  , // active low chip select
-    input                   web0  , // active low write control
-    input  [NUM_WMASKS-1:0] wmask0, // write mask
-    input  [ADDR_WIDTH-1:0] addr0 ,
-    input  [DATA_WIDTH-1:0] din0  ,
-    output [DATA_WIDTH-1:0] dout0 ,
+    input  wire                  clk0  , // clock
+    input  wire                  csb0  , // active low chip select
+    input  wire                  web0  , // active low write control
+    input  wire [NUM_WMASKS-1:0] wmask0, // write mask
+    input  wire [ADDR_WIDTH-1:0] addr0 ,
+    input  wire [DATA_WIDTH-1:0] din0  ,
+    output wire [DATA_WIDTH-1:0] dout0 ,
     // Port 1: R
-    input                   clk1  , // clock
-    input                   csb1  , // active low chip select
-    input  [ADDR_WIDTH-1:0] addr1 ,
-    output [DATA_WIDTH-1:0] dout1
+    input  wire                  clk1  , // clock
+    input  wire                  csb1  , // active low chip select
+    input  wire [ADDR_WIDTH-1:0] addr1 ,
+    output wire [DATA_WIDTH-1:0] dout1
 );
 endmodule
 `default_nettype wire

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/BlockRAM_1KB.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/BlockRAM_1KB.v
@@ -190,7 +190,7 @@ module BlockRAM_1KB #(
                 end
         end
 endmodule
-`default_nettype wire (* blackbox *)
+(* blackbox *)
 module sram_1rw1r_32_256_8_sky130 #(
     parameter integer NUM_WMASKS = 4              ,
     parameter integer DATA_WIDTH = 32             ,
@@ -214,3 +214,4 @@ module sram_1rw1r_32_256_8_sky130 #(
     output [DATA_WIDTH-1:0] dout1
 );
 endmodule
+`default_nettype wire

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/BlockRAM_1KB.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/BlockRAM_1KB.v
@@ -8,18 +8,18 @@ module BlockRAM_1KB #(
     // Default 20 means bit wr_data[20] will become the dynamic write enable input
     parameter integer WRITE_ENABLE_FROM_DATA          = 20
 ) (
-    input         clk    ,
-    input  [ 7:0] rd_addr,
-    output [31:0] rd_data,
-    input  [ 7:0] wr_addr,
-    input  [31:0] wr_data,
+    input  wire        clk    ,
+    input  wire [ 7:0] rd_addr,
+    output wire [31:0] rd_data,
+    input  wire [ 7:0] wr_addr,
+    input  wire [31:0] wr_data,
     // Configuration bit inputs
-    input         C0     , // C0 and C1 select write port width
-    input         C1     ,
-    input         C2     , // C2 and C3 select read port width
-    input         C3     ,
-    input         C4     , // C4 selects the always_write_enable
-    input         C5       // C5 selects register bypass
+    input  wire        C0     , // C0 and C1 select write port width
+    input  wire        C1     ,
+    input  wire        C2     , // C2 and C3 select read port width
+    input  wire        C3     ,
+    input  wire        C4     , // C4 selects the always_write_enable
+    input  wire        C5       // C5 selects register bypass
 );
     // NOTE: the read enable is currently constantly ON
     // NOTE: the R/W port on the standard cell is used only in write mode
@@ -190,7 +190,7 @@ module BlockRAM_1KB #(
                 end
         end
 endmodule
-`default_nettype wire (* blackbox *)
+(* blackbox *)
 module sram_1rw1r_32_256_8_sky130 #(
     parameter integer NUM_WMASKS = 4              ,
     parameter integer DATA_WIDTH = 32             ,
@@ -200,17 +200,18 @@ module sram_1rw1r_32_256_8_sky130 #(
     parameter integer DELAY      = 3
 ) (
     // Port 0: RW
-    input                   clk0  , // clock
-    input                   csb0  , // active low chip select
-    input                   web0  , // active low write control
-    input  [NUM_WMASKS-1:0] wmask0, // write mask
-    input  [ADDR_WIDTH-1:0] addr0 ,
-    input  [DATA_WIDTH-1:0] din0  ,
-    output [DATA_WIDTH-1:0] dout0 ,
+    input  wire                  clk0  , // clock
+    input  wire                  csb0  , // active low chip select
+    input  wire                  web0  , // active low write control
+    input  wire [NUM_WMASKS-1:0] wmask0, // write mask
+    input  wire [ADDR_WIDTH-1:0] addr0 ,
+    input  wire [DATA_WIDTH-1:0] din0  ,
+    output wire [DATA_WIDTH-1:0] dout0 ,
     // Port 1: R
-    input                   clk1  , // clock
-    input                   csb1  , // active low chip select
-    input  [ADDR_WIDTH-1:0] addr1 ,
-    output [DATA_WIDTH-1:0] dout1
+    input  wire                  clk1  , // clock
+    input  wire                  csb1  , // active low chip select
+    input  wire [ADDR_WIDTH-1:0] addr1 ,
+    output wire [DATA_WIDTH-1:0] dout1
 );
 endmodule
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/ConfigFSM.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/ConfigFSM.v
@@ -6,11 +6,11 @@ module ConfigFSM #(
     parameter integer FrameBitsPerRow = 32,
     parameter integer desync_flag = 20
 ) (
-    input CLK,
-    input reset_n,
-    input [31:0] write_data,
-    input write_strobe,
-    input fsm_reset,
+    input wire CLK,
+    input wire reset_n,
+    input wire [31:0] write_data,
+    input wire write_strobe,
+    input wire fsm_reset,
     output reg [FrameBitsPerRow-1:0] frame_address_register,
     output reg long_frame_strobe,
     output reg [RowSelectWidth-1:0] row_select
@@ -59,8 +59,8 @@ module ConfigFSM #(
                                 state <= UNSYNCED;
                             end else begin
                                 frame_address_register <= write_data;
-                                // Width-cast to silence WIDTHTRUNC warning
-                                row_index <= 5'(NumberOfRows);
+                                // Deliberate narrowing, silences WIDTHTRUNC
+                                row_index <= NumberOfRows[4:0];
                                 state <= WRITE_FRAME_DATA;
                             end
                         end

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/ConfigFSM.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/ConfigFSM.v
@@ -59,8 +59,8 @@ module ConfigFSM #(
                                 state <= UNSYNCED;
                             end else begin
                                 frame_address_register <= write_data;
-                                // Width-cast to silence WIDTHTRUNC warning
-                                row_index <= 5'(NumberOfRows);
+                                // Part-select to silence WIDTHTRUNC warning
+                                row_index <= NumberOfRows[4:0];
                                 state <= WRITE_FRAME_DATA;
                             end
                         end

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/ConfigFSM.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/ConfigFSM.v
@@ -59,8 +59,8 @@ module ConfigFSM #(
                                 state <= UNSYNCED;
                             end else begin
                                 frame_address_register <= write_data;
-                                // Part-select to silence WIDTHTRUNC warning
-                                row_index <= NumberOfRows[4:0];
+                                // Width-cast to silence WIDTHTRUNC warning
+                                row_index <= 5'(NumberOfRows);
                                 state <= WRITE_FRAME_DATA;
                             end
                         end

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/ConfigFSM.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/ConfigFSM.v
@@ -6,11 +6,11 @@ module ConfigFSM #(
     parameter integer FrameBitsPerRow = 32,
     parameter integer desync_flag = 20
 ) (
-    input CLK,
-    input reset_n,
-    input [31:0] write_data,
-    input write_strobe,
-    input fsm_reset,
+    input wire CLK,
+    input wire reset_n,
+    input wire [31:0] write_data,
+    input wire write_strobe,
+    input wire fsm_reset,
     output reg [FrameBitsPerRow-1:0] frame_address_register,
     output reg long_frame_strobe,
     output reg [RowSelectWidth-1:0] row_select
@@ -59,8 +59,8 @@ module ConfigFSM #(
                                 state <= UNSYNCED;
                             end else begin
                                 frame_address_register <= write_data;
-                                // Width-cast to silence WIDTHTRUNC warning
-                                row_index <= 5'(NumberOfRows);
+                                // Deliberate narrowing, silences WIDTHTRUNC
+                                row_index <= NumberOfRows[4:0];
                                 state <= WRITE_FRAME_DATA;
                             end
                         end
@@ -103,4 +103,4 @@ module ConfigFSM #(
     end
 
 endmodule
-`default_nettype wire
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/Frame_Data_Reg.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/Frame_Data_Reg.v
@@ -3,7 +3,7 @@
 module Frame_Data_Reg #(
     parameter integer FrameBitsPerRow = 32,
     parameter integer RowSelectWidth = 5,
-    parameter [RowSelectWidth-1:0] Row = 1
+    parameter reg [RowSelectWidth-1:0] Row = 1
 ) (
     input wire CLK,
     input wire [FrameBitsPerRow-1:0] FrameData_I,

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/Frame_Data_Reg.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/Frame_Data_Reg.v
@@ -3,12 +3,12 @@
 module Frame_Data_Reg #(
     parameter integer FrameBitsPerRow = 32,
     parameter integer RowSelectWidth = 5,
-    parameter reg [RowSelectWidth-1:0] Row = 1
+    parameter [RowSelectWidth-1:0] Row = 1
 ) (
-    input CLK,
-    input reg [FrameBitsPerRow-1:0] FrameData_I,
+    input wire CLK,
+    input wire [FrameBitsPerRow-1:0] FrameData_I,
     output reg [FrameBitsPerRow-1:0] FrameData_O,
-    input reg [RowSelectWidth-1:0] RowSelect
+    input wire [RowSelectWidth-1:0] RowSelect
 );
 
     always @(posedge CLK) begin

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/Frame_Data_Reg.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/Frame_Data_Reg.v
@@ -5,10 +5,10 @@ module Frame_Data_Reg #(
     parameter integer RowSelectWidth = 5,
     parameter reg [RowSelectWidth-1:0] Row = 1
 ) (
-    input CLK,
-    input reg [FrameBitsPerRow-1:0] FrameData_I,
+    input wire CLK,
+    input wire [FrameBitsPerRow-1:0] FrameData_I,
     output reg [FrameBitsPerRow-1:0] FrameData_O,
-    input reg [RowSelectWidth-1:0] RowSelect
+    input wire [RowSelectWidth-1:0] RowSelect
 );
 
     always @(posedge CLK) begin
@@ -16,4 +16,4 @@ module Frame_Data_Reg #(
     end
 
 endmodule
-`default_nettype wire
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/Frame_Select.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/Frame_Select.v
@@ -3,7 +3,7 @@
 module Frame_Select #(
     parameter integer MaxFramesPerCol = 20,
     parameter integer FrameSelectWidth = 5,
-    parameter reg [FrameSelectWidth-1:0] Col = 18
+    parameter [FrameSelectWidth-1:0] Col = 18
 ) (
     input [MaxFramesPerCol-1:0] FrameStrobe_I,
     output reg [MaxFramesPerCol-1:0] FrameStrobe_O,

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/Frame_Select.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/Frame_Select.v
@@ -3,7 +3,7 @@
 module Frame_Select #(
     parameter integer MaxFramesPerCol = 20,
     parameter integer FrameSelectWidth = 5,
-    parameter [FrameSelectWidth-1:0] Col = 18
+    parameter reg [FrameSelectWidth-1:0] Col = 18
 ) (
     input [MaxFramesPerCol-1:0] FrameStrobe_I,
     output reg [MaxFramesPerCol-1:0] FrameStrobe_O,

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/Frame_Select.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/Frame_Select.v
@@ -5,10 +5,10 @@ module Frame_Select #(
     parameter integer FrameSelectWidth = 5,
     parameter reg [FrameSelectWidth-1:0] Col = 18
 ) (
-    input [MaxFramesPerCol-1:0] FrameStrobe_I,
+    input wire [MaxFramesPerCol-1:0] FrameStrobe_I,
     output reg [MaxFramesPerCol-1:0] FrameStrobe_O,
-    input [FrameSelectWidth-1:0] FrameSelect,
-    input FrameStrobe
+    input wire [FrameSelectWidth-1:0] FrameSelect,
+    input wire FrameStrobe
 );
 
 

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/Frame_Select.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/Frame_Select.v
@@ -5,10 +5,10 @@ module Frame_Select #(
     parameter integer FrameSelectWidth = 5,
     parameter reg [FrameSelectWidth-1:0] Col = 18
 ) (
-    input [MaxFramesPerCol-1:0] FrameStrobe_I,
+    input wire [MaxFramesPerCol-1:0] FrameStrobe_I,
     output reg [MaxFramesPerCol-1:0] FrameStrobe_O,
-    input [FrameSelectWidth-1:0] FrameSelect,
-    input FrameStrobe
+    input wire [FrameSelectWidth-1:0] FrameSelect,
+    input wire FrameStrobe
 );
 
 
@@ -18,4 +18,4 @@ module Frame_Select #(
     end
 
 endmodule
-`default_nettype wire
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/bitbang.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/bitbang.v
@@ -1,13 +1,13 @@
 `default_nettype none
 
 module bitbang (
-    input s_clk,
-    input s_data,
+    input wire s_clk,
+    input wire s_data,
     output reg strobe,
     output reg [31:0] data,
     output reg active,
-    input clk,
-    input reset_n
+    input wire clk,
+    input wire reset_n
 );
 
     localparam [15:0] ON_PATTERN = 16'hFAB1;

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/bitbang.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/bitbang.v
@@ -1,13 +1,13 @@
 `default_nettype none
 
 module bitbang (
-    input s_clk,
-    input s_data,
+    input wire s_clk,
+    input wire s_data,
     output reg strobe,
     output reg [31:0] data,
     output reg active,
-    input clk,
-    input reset_n
+    input wire clk,
+    input wire reset_n
 );
 
     localparam [15:0] ON_PATTERN = 16'hFAB1;
@@ -81,4 +81,4 @@ module bitbang (
     end
 
 endmodule
-`default_nettype wire
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/config_UART.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/config_UART.v
@@ -1,7 +1,7 @@
 `default_nettype none
 
 module config_UART #(
-        parameter [1:0] Mode = 2'd0,
+        parameter reg [1:0] Mode = 2'd0,
         // The default mode is "auto", which switches between "hex" and "binary" mode,
         // but takes a bit more logic.
         // Mode "bin" is the faster binary mode, but might not work on all machines/boards.

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/config_UART.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/config_UART.v
@@ -12,13 +12,13 @@ module config_UART #(
         // com_rate = f_CLK / Baudrate (e.g., 25 MHz/115200 Baud = 217)
         parameter [11:0] ComRate = 12'd217
     ) (
-        input CLK,
-        input reset_n,
-        input Rx,
+        input wire CLK,
+        input wire reset_n,
+        input wire Rx,
         output reg [31:0] WriteData,
-        output ComActive,
+        output wire ComActive,
         output reg WriteStrobe,
-        output [7:0] Command,
+        output wire [7:0] Command,
         output reg ReceiveLED
     );
 

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/config_UART.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/config_UART.v
@@ -1,7 +1,7 @@
 `default_nettype none
 
 module config_UART #(
-        parameter reg [1:0] Mode = 2'd0,
+        parameter [1:0] Mode = 2'd0,
         // The default mode is "auto", which switches between "hex" and "binary" mode,
         // but takes a bit more logic.
         // Mode "bin" is the faster binary mode, but might not work on all machines/boards.

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/config_UART.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/config_UART.v
@@ -12,13 +12,13 @@ module config_UART #(
         // com_rate = f_CLK / Baudrate (e.g., 25 MHz/115200 Baud = 217)
         parameter [11:0] ComRate = 12'd217
     ) (
-        input CLK,
-        input reset_n,
-        input Rx,
+        input wire CLK,
+        input wire reset_n,
+        input wire Rx,
         output reg [31:0] WriteData,
-        output ComActive,
+        output wire ComActive,
         output reg WriteStrobe,
-        output [7:0] Command,
+        output wire [7:0] Command,
         output reg ReceiveLED
     );
 
@@ -630,4 +630,4 @@ module config_UART #(
     end
 
 endmodule
-`default_nettype wire
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/eFPGA_Config.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/eFPGA_Config.v
@@ -6,23 +6,23 @@ module eFPGA_Config #(
     parameter integer FrameBitsPerRow = 32,
     parameter integer desync_flag = 20
 ) (
-    input CLK,
-    input resetn,
+    input wire CLK,
+    input wire resetn,
     // UART configuration port
-    input Rx,
-    output ComActive,
-    output ReceiveLED,
+    input wire Rx,
+    output wire ComActive,
+    output wire ReceiveLED,
     // BitBang configuration port
-    input s_clk,
-    input s_data,
+    input wire s_clk,
+    input wire s_data,
     // Parallel configuration port
-    input [31:0] SelfWriteData,
-    input SelfWriteStrobe,
-    output [31:0] ConfigWriteData,
-    output ConfigWriteStrobe,
-    output [FrameBitsPerRow-1:0] FrameAddressRegister,
-    output LongFrameStrobe,
-    output [RowSelectWidth-1:0] RowSelect
+    input wire [31:0] SelfWriteData,
+    input wire SelfWriteStrobe,
+    output wire [31:0] ConfigWriteData,
+    output wire ConfigWriteStrobe,
+    output wire [FrameBitsPerRow-1:0] FrameAddressRegister,
+    output wire LongFrameStrobe,
+    output wire [RowSelectWidth-1:0] RowSelect
 );
 
     wire [7:0] Command;

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/eFPGA_Config.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/eFPGA_Config.v
@@ -6,23 +6,23 @@ module eFPGA_Config #(
     parameter integer FrameBitsPerRow = 32,
     parameter integer desync_flag = 20
 ) (
-    input CLK,
-    input resetn,
+    input wire CLK,
+    input wire resetn,
     // UART configuration port
-    input Rx,
-    output ComActive,
-    output ReceiveLED,
+    input wire Rx,
+    output wire ComActive,
+    output wire ReceiveLED,
     // BitBang configuration port
-    input s_clk,
-    input s_data,
+    input wire s_clk,
+    input wire s_data,
     // Parallel configuration port
-    input [31:0] SelfWriteData,
-    input SelfWriteStrobe,
-    output [31:0] ConfigWriteData,
-    output ConfigWriteStrobe,
-    output [FrameBitsPerRow-1:0] FrameAddressRegister,
-    output LongFrameStrobe,
-    output [RowSelectWidth-1:0] RowSelect
+    input wire [31:0] SelfWriteData,
+    input wire SelfWriteStrobe,
+    output wire [31:0] ConfigWriteData,
+    output wire ConfigWriteStrobe,
+    output wire [FrameBitsPerRow-1:0] FrameAddressRegister,
+    output wire LongFrameStrobe,
+    output wire [RowSelectWidth-1:0] RowSelect
 );
 
     wire [7:0] Command;
@@ -96,4 +96,4 @@ module eFPGA_Config #(
     );
 
 endmodule
-`default_nettype wire
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/models_pack.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/models_pack.v
@@ -17,7 +17,6 @@ module config_latch (
     end
     /* verilator lint_on LATCH */
 endmodule
-`default_nettype wire
 
 module my_buf (
     input  A,
@@ -202,3 +201,4 @@ module cus_mux161 (
         .X  (X)
     );
 endmodule
+`default_nettype wire

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/models_pack.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/models_pack.v
@@ -2,7 +2,7 @@
 
 // Models for the embedded FPGA fabric
 module config_latch (
-    input D,
+    input wire D,
     E,
     output reg Q,
     QN
@@ -19,29 +19,29 @@ module config_latch (
 endmodule
 
 module my_buf (
-    input  A,
-    output X
+    input  wire A,
+    output wire X
 );
     assign X = A;
 endmodule
 
 module clk_buf (
-    input  A,
-    output X
+    input  wire A,
+    output wire X
 );
     assign X = A;
 endmodule
 
 module cus_mux41 (
-    input  A0,
-    input  A1,
-    input  A2,
-    input  A3,
-    input  S0,
-    input  S0N,
-    input  S1,
-    input  S1N,
-    output X
+    input  wire A0 ,
+    input  wire A1 ,
+    input  wire A2 ,
+    input  wire A3 ,
+    input  wire S0 ,
+    input  wire S0N,
+    input  wire S1 ,
+    input  wire S1N,
+    output wire X
 );
     wire B0 = S0 ? A1 : A0;
     wire B1 = S0 ? A3 : A2;
@@ -49,30 +49,30 @@ module cus_mux41 (
 endmodule
 
 module cus_mux21 (
-    input  A0,
-    input  A1,
-    input  S,
-    output X
+    input  wire A0,
+    input  wire A1,
+    input  wire S ,
+    output wire X
 );
     assign X = S ? A1 : A0;
 endmodule
 
 module cus_mux81 (
-    input  A0,
-    input  A1,
-    input  A2,
-    input  A3,
-    input  A4,
-    input  A5,
-    input  A6,
-    input  A7,
-    input  S0,
-    input  S0N,
-    input  S1,
-    input  S1N,
-    input  S2,
-    input  S2N,
-    output X
+    input  wire A0 ,
+    input  wire A1 ,
+    input  wire A2 ,
+    input  wire A3 ,
+    input  wire A4 ,
+    input  wire A5 ,
+    input  wire A6 ,
+    input  wire A7 ,
+    input  wire S0 ,
+    input  wire S0N,
+    input  wire S1 ,
+    input  wire S1N,
+    input  wire S2 ,
+    input  wire S2N,
+    output wire X
 );
     wire cus_mux41_out0;
     wire cus_mux41_out1;
@@ -110,31 +110,31 @@ module cus_mux81 (
 endmodule
 
 module cus_mux161 (
-    input  A0,
-    input  A1,
-    input  A2,
-    input  A3,
-    input  A4,
-    input  A5,
-    input  A6,
-    input  A7,
-    input  A8,
-    input  A9,
-    input  A10,
-    input  A11,
-    input  A12,
-    input  A13,
-    input  A14,
-    input  A15,
-    input  S0,
-    input  S0N,
-    input  S1,
-    input  S1N,
-    input  S2,
-    input  S2N,
-    input  S3,
-    input  S3N,
-    output X
+    input  wire A0 ,
+    input  wire A1 ,
+    input  wire A2 ,
+    input  wire A3 ,
+    input  wire A4 ,
+    input  wire A5 ,
+    input  wire A6 ,
+    input  wire A7 ,
+    input  wire A8 ,
+    input  wire A9 ,
+    input  wire A10,
+    input  wire A11,
+    input  wire A12,
+    input  wire A13,
+    input  wire A14,
+    input  wire A15,
+    input  wire S0 ,
+    input  wire S0N,
+    input  wire S1 ,
+    input  wire S1N,
+    input  wire S2 ,
+    input  wire S2N,
+    input  wire S3 ,
+    input  wire S3N,
+    output wire X
 );
     wire cus_mux41_out0;
     wire cus_mux41_out1;

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/models_pack.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Fabric/models_pack.v
@@ -2,7 +2,7 @@
 
 // Models for the embedded FPGA fabric
 module config_latch (
-    input D,
+    input wire D,
     E,
     output reg Q,
     QN
@@ -17,32 +17,31 @@ module config_latch (
     end
     /* verilator lint_on LATCH */
 endmodule
-`default_nettype wire
 
 module my_buf (
-    input  A,
-    output X
+    input  wire A,
+    output wire X
 );
     assign X = A;
 endmodule
 
 module clk_buf (
-    input  A,
-    output X
+    input  wire A,
+    output wire X
 );
     assign X = A;
 endmodule
 
 module cus_mux41 (
-    input  A0,
-    input  A1,
-    input  A2,
-    input  A3,
-    input  S0,
-    input  S0N,
-    input  S1,
-    input  S1N,
-    output X
+    input  wire A0 ,
+    input  wire A1 ,
+    input  wire A2 ,
+    input  wire A3 ,
+    input  wire S0 ,
+    input  wire S0N,
+    input  wire S1 ,
+    input  wire S1N,
+    output wire X
 );
     wire B0 = S0 ? A1 : A0;
     wire B1 = S0 ? A3 : A2;
@@ -50,30 +49,30 @@ module cus_mux41 (
 endmodule
 
 module cus_mux21 (
-    input  A0,
-    input  A1,
-    input  S,
-    output X
+    input  wire A0,
+    input  wire A1,
+    input  wire S ,
+    output wire X
 );
     assign X = S ? A1 : A0;
 endmodule
 
 module cus_mux81 (
-    input  A0,
-    input  A1,
-    input  A2,
-    input  A3,
-    input  A4,
-    input  A5,
-    input  A6,
-    input  A7,
-    input  S0,
-    input  S0N,
-    input  S1,
-    input  S1N,
-    input  S2,
-    input  S2N,
-    output X
+    input  wire A0 ,
+    input  wire A1 ,
+    input  wire A2 ,
+    input  wire A3 ,
+    input  wire A4 ,
+    input  wire A5 ,
+    input  wire A6 ,
+    input  wire A7 ,
+    input  wire S0 ,
+    input  wire S0N,
+    input  wire S1 ,
+    input  wire S1N,
+    input  wire S2 ,
+    input  wire S2N,
+    output wire X
 );
     wire cus_mux41_out0;
     wire cus_mux41_out1;
@@ -111,31 +110,31 @@ module cus_mux81 (
 endmodule
 
 module cus_mux161 (
-    input  A0,
-    input  A1,
-    input  A2,
-    input  A3,
-    input  A4,
-    input  A5,
-    input  A6,
-    input  A7,
-    input  A8,
-    input  A9,
-    input  A10,
-    input  A11,
-    input  A12,
-    input  A13,
-    input  A14,
-    input  A15,
-    input  S0,
-    input  S0N,
-    input  S1,
-    input  S1N,
-    input  S2,
-    input  S2N,
-    input  S3,
-    input  S3N,
-    output X
+    input  wire A0 ,
+    input  wire A1 ,
+    input  wire A2 ,
+    input  wire A3 ,
+    input  wire A4 ,
+    input  wire A5 ,
+    input  wire A6 ,
+    input  wire A7 ,
+    input  wire A8 ,
+    input  wire A9 ,
+    input  wire A10,
+    input  wire A11,
+    input  wire A12,
+    input  wire A13,
+    input  wire A14,
+    input  wire A15,
+    input  wire S0 ,
+    input  wire S0N,
+    input  wire S1 ,
+    input  wire S1N,
+    input  wire S2 ,
+    input  wire S2N,
+    input  wire S3 ,
+    input  wire S3N,
+    output wire X
 );
     wire cus_mux41_out0;
     wire cus_mux41_out1;
@@ -202,3 +201,4 @@ module cus_mux161 (
         .X  (X)
     );
 endmodule
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Test/README.md
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Test/README.md
@@ -26,3 +26,26 @@ Other useful make targets are:
 - `make run_GTKWave` to run the GTKWave waveform viewer with the generated simulation waveform
 
 Take a look into the Makefile to build your own flow.
+
+## Simulating with Vivado xsim
+
+`task run-simulation-xsim` runs the same testbench under AMD Vivado's xsim, and
+`task fab-sim-xsim` wraps it in the full build-fabric, build-design, simulate,
+clean cycle. It needs `xvlog`, `xelab` and `xsim` on `PATH` from a Vivado
+installation; nothing else in the flow changes.
+
+The value of the xsim path is the analysis mode, not the simulator. xvlog reads
+the fabric and the user design as IEEE 1364-2005 Verilog, whereas the Icarus
+flow uses `iverilog -g2012`, so constructs that are legal only in
+SystemVerilog fail here and pass there. The testbench is exempt and compiles
+with `-sv`, because it uses `$fatal` and an unsized array bound.
+
+Two behaviours are worth knowing. xsim writes VCD and has no FST writer, so
+`WAVEFORM_TYPE` does not apply and the waveform lands at
+`build/<design>_xsim.vcd`. And xsim exits 0 even after `$fatal`, so the task
+greps its log for a fatal report and fails on that instead of trusting the exit
+status.
+
+If `xelab` stops at `cannot find crt1.o`, its linker is not picking up the host
+C runtime; point it at the directory holding those objects, for example
+`LIBRARY_PATH=/usr/lib/x86_64-linux-gnu task run-simulation-xsim`.

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Test/README.md
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Test/README.md
@@ -26,3 +26,27 @@ Other useful make targets are:
 - `make run_GTKWave` to run the GTKWave waveform viewer with the generated simulation waveform
 
 Take a look into the Makefile to build your own flow.
+
+## Simulating with Vivado xsim
+
+`task run-simulation SIMULATOR=xvlog` runs the same testbench under AMD
+Vivado's xsim, and `task fab-sim SIMULATOR=xvlog` wraps it in the full
+build-fabric, build-design, simulate, clean cycle. It needs `xvlog`, `xelab`
+and `xsim` on `PATH` from a Vivado installation; nothing else in the flow
+changes.
+
+The value of the xsim path is the analysis mode, not the simulator. xvlog reads
+the fabric and the user design as IEEE 1364-2005 Verilog, whereas the Icarus
+flow uses `iverilog -g2012`, so constructs that are legal only in
+SystemVerilog fail here and pass there. The testbench is exempt and compiles
+with `-sv`, because it uses `$fatal` and an unsized array bound.
+
+Two behaviours are worth knowing. xsim writes VCD and has no FST writer, so
+`WAVEFORM_TYPE` does not apply and the waveform lands at
+`build/<design>_xsim.vcd`. And xsim exits 0 even after `$fatal`, so the task
+greps its log for a fatal report and fails on that instead of trusting the exit
+status.
+
+If `xelab` stops at `cannot find crt1.o`, its linker is not picking up the host
+C runtime; point it at the directory holding those objects, for example
+`LIBRARY_PATH=/usr/lib/x86_64-linux-gnu task run-simulation SIMULATOR=xvlog`.

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Test/README.md
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Test/README.md
@@ -29,10 +29,11 @@ Take a look into the Makefile to build your own flow.
 
 ## Simulating with Vivado xsim
 
-`task run-simulation-xsim` runs the same testbench under AMD Vivado's xsim, and
-`task fab-sim-xsim` wraps it in the full build-fabric, build-design, simulate,
-clean cycle. It needs `xvlog`, `xelab` and `xsim` on `PATH` from a Vivado
-installation; nothing else in the flow changes.
+`task run-simulation SIMULATOR=xvlog` runs the same testbench under AMD
+Vivado's xsim, and `task fab-sim SIMULATOR=xvlog` wraps it in the full
+build-fabric, build-design, simulate, clean cycle. It needs `xvlog`, `xelab`
+and `xsim` on `PATH` from a Vivado installation; nothing else in the flow
+changes.
 
 The value of the xsim path is the analysis mode, not the simulator. xvlog reads
 the fabric and the user design as IEEE 1364-2005 Verilog, whereas the Icarus
@@ -48,4 +49,4 @@ status.
 
 If `xelab` stops at `cannot find crt1.o`, its linker is not picking up the host
 C runtime; point it at the directory holding those objects, for example
-`LIBRARY_PATH=/usr/lib/x86_64-linux-gnu task run-simulation-xsim`.
+`LIBRARY_PATH=/usr/lib/x86_64-linux-gnu task run-simulation SIMULATOR=xvlog`.

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Test/Taskfile.yml
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Test/Taskfile.yml
@@ -20,6 +20,7 @@ vars:
   TOP_WRAPPER: '{{.TOP_WRAPPER | default "top_wrapper"}}'
   USER_DESIGN_DIR: "{{.FAB_PROJ_ROOT}}/user_design"
   WAVEFORM_TYPE: '{{.WAVEFORM_TYPE | default "fst"}}'
+  SIMULATOR: '{{.SIMULATOR | default "iverilog"}}'
   EXTRA_IVERILOG_FLAGS: '{{.EXTRA_IVERILOG_FLAGS | default ""}}'
   EXTRA_XVLOG_FLAGS: '{{.EXTRA_XVLOG_FLAGS | default ""}}'
   EXTRA_XELAB_FLAGS: '{{.EXTRA_XELAB_FLAGS | default ""}}'
@@ -127,6 +128,17 @@ tasks:
       - find {{.FAB_PROJ_ROOT}}/Fabric/ -name '*.v' -type f -exec cp {} {{.FABRIC_FILES_DIR}}/ \;
 
   run-simulation:
+    desc: Run simulation (SIMULATOR=iverilog, or xvlog for AMD Vivado xsim)
+    vars:
+      BACKEND:
+        sh: 'case "{{.SIMULATOR}}" in iverilog) echo iverilog ;; xvlog) echo xsim ;; esac'
+    preconditions:
+      - sh: 'test -n "{{.BACKEND}}"'
+        msg: "Unknown SIMULATOR '{{.SIMULATOR}}'. Use iverilog or xvlog."
+    cmds:
+      - task: run-simulation-{{.BACKEND}}
+
+  run-simulation-iverilog:
     desc: Run simulation using Icarus Verilog (iverilog)
     deps: [mkdir-build, copy-files]
     cmds:
@@ -158,8 +170,7 @@ tasks:
       - >-
         cd {{.XSIM_DIR}} &&
         xvlog -sv {{.EXTRA_XVLOG_FLAGS}} {{.TASKFILE_DIR}}/{{.TESTBENCH}}.v
-      # Only the testbench has a `timescale, and xsim rejects a design where
-      # some modules carry one and others do not.
+      # xsim rejects a design where only some modules carry a `timescale.
       - >-
         cd {{.XSIM_DIR}} &&
         xelab -timescale 1ps/1ps {{.EXTRA_XELAB_FLAGS}}
@@ -171,14 +182,6 @@ tasks:
         --testplusarg bitstream_hex={{.TASKFILE_DIR}}/{{.BUILD_DIR}}/{{.DESIGN}}.hex
       # xsim exits 0 even after $fatal, so without this a mismatch reads as a pass.
       - cd {{.XSIM_DIR}} && ! grep -q '^Fatal:' {{.XSIM_SNAPSHOT}}.log
-
-  fab-sim-xsim:
-    desc: Build demo fabric, build test design, run the xsim simulation, then clean up
-    cmds:
-      - task: build-demo-fabric
-      - task: build-test-design
-      - task: run-simulation-xsim
-      - task: clean
 
   gen-force-block:
     desc: Generate force_block.vh (gate-level X-init) from the hardened netlists

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Test/Taskfile.yml
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Test/Taskfile.yml
@@ -21,8 +21,12 @@ vars:
   USER_DESIGN_DIR: "{{.FAB_PROJ_ROOT}}/user_design"
   WAVEFORM_TYPE: '{{.WAVEFORM_TYPE | default "fst"}}'
   EXTRA_IVERILOG_FLAGS: '{{.EXTRA_IVERILOG_FLAGS | default ""}}'
+  EXTRA_XVLOG_FLAGS: '{{.EXTRA_XVLOG_FLAGS | default ""}}'
+  EXTRA_XELAB_FLAGS: '{{.EXTRA_XELAB_FLAGS | default ""}}'
   BITSTREAM_BIN: '{{.BITSTREAM_BIN | default "{{.BUILD_DIR}}/{{.DESIGN}}.bin"}}'
   FABRIC_FILES_DIR: "{{.BUILD_DIR}}/fabric_files"
+  XSIM_DIR: '{{.XSIM_DIR | default (printf "%s/xsim" .BUILD_DIR)}}'
+  XSIM_SNAPSHOT: '{{.XSIM_SNAPSHOT | default (printf "%s_xsim" .DESIGN)}}'
 
 tasks:
   fab-sim:
@@ -139,6 +143,42 @@ tasks:
         +output_waveform={{.BUILD_DIR}}/{{.DESIGN}}.{{.WAVEFORM_TYPE}}
         +bitstream_hex={{.BUILD_DIR}}/{{.DESIGN}}.hex
         {{if eq .WAVEFORM_TYPE "fst"}}-fst{{end}}
+
+  run-simulation-xsim:
+    desc: Run simulation using AMD Vivado xsim
+    deps: [mkdir-build, copy-files]
+    cmds:
+      - mkdir -p {{.XSIM_DIR}}
+      # Never add -sv here: analysing the fabric as Verilog-2005 is the point.
+      - >-
+        cd {{.XSIM_DIR}} &&
+        xvlog {{.EXTRA_XVLOG_FLAGS}}
+        {{.TASKFILE_DIR}}/{{.FABRIC_FILES_DIR}}/*.v
+        {{.TASKFILE_DIR}}/{{.USER_DESIGN_DIR}}/{{.DESIGN}}.v
+      - >-
+        cd {{.XSIM_DIR}} &&
+        xvlog -sv {{.EXTRA_XVLOG_FLAGS}} {{.TASKFILE_DIR}}/{{.TESTBENCH}}.v
+      # Only the testbench has a `timescale, and xsim rejects a design where
+      # some modules carry one and others do not.
+      - >-
+        cd {{.XSIM_DIR}} &&
+        xelab -timescale 1ps/1ps {{.EXTRA_XELAB_FLAGS}}
+        -s {{.XSIM_SNAPSHOT}} {{.TESTBENCH}}
+      - >-
+        cd {{.XSIM_DIR}} &&
+        xsim {{.XSIM_SNAPSHOT}} -R --log {{.XSIM_SNAPSHOT}}.log
+        --testplusarg output_waveform={{.TASKFILE_DIR}}/{{.BUILD_DIR}}/{{.XSIM_SNAPSHOT}}.vcd
+        --testplusarg bitstream_hex={{.TASKFILE_DIR}}/{{.BUILD_DIR}}/{{.DESIGN}}.hex
+      # xsim exits 0 even after $fatal, so without this a mismatch reads as a pass.
+      - cd {{.XSIM_DIR}} && ! grep -q '^Fatal:' {{.XSIM_SNAPSHOT}}.log
+
+  fab-sim-xsim:
+    desc: Build demo fabric, build test design, run the xsim simulation, then clean up
+    cmds:
+      - task: build-demo-fabric
+      - task: build-test-design
+      - task: run-simulation-xsim
+      - task: clean
 
   gen-force-block:
     desc: Generate force_block.vh (gate-level X-init) from the hardened netlists

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Test/Taskfile.yml
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Test/Taskfile.yml
@@ -20,9 +20,13 @@ vars:
   TOP_WRAPPER: '{{.TOP_WRAPPER | default "top_wrapper"}}'
   USER_DESIGN_DIR: "{{.FAB_PROJ_ROOT}}/user_design"
   WAVEFORM_TYPE: '{{.WAVEFORM_TYPE | default "fst"}}'
+  SIMULATOR: '{{.SIMULATOR | default "iverilog"}}'
   EXTRA_IVERILOG_FLAGS: '{{.EXTRA_IVERILOG_FLAGS | default ""}}'
+  EXTRA_XVLOG_FLAGS: '{{.EXTRA_XVLOG_FLAGS | default ""}}'
+  EXTRA_XELAB_FLAGS: '{{.EXTRA_XELAB_FLAGS | default ""}}'
   BITSTREAM_BIN: '{{.BITSTREAM_BIN | default "{{.BUILD_DIR}}/{{.DESIGN}}.bin"}}'
   FABRIC_FILES_DIR: "{{.BUILD_DIR}}/fabric_files"
+  XSIM_SNAPSHOT: '{{.XSIM_SNAPSHOT | default (printf "%s_xsim" .DESIGN)}}'
 
 tasks:
   fab-sim:
@@ -123,6 +127,17 @@ tasks:
       - find {{.FAB_PROJ_ROOT}}/Fabric/ -name '*.v' -type f -exec cp {} {{.FABRIC_FILES_DIR}}/ \;
 
   run-simulation:
+    desc: Run simulation (SIMULATOR=iverilog, or xvlog for AMD Vivado xsim)
+    vars:
+      BACKEND:
+        sh: 'case "{{.SIMULATOR}}" in iverilog) echo iverilog ;; xvlog) echo xsim ;; esac'
+    preconditions:
+      - sh: 'test -n "{{.BACKEND}}"'
+        msg: "Unknown SIMULATOR '{{.SIMULATOR}}'. Use iverilog or xvlog."
+    cmds:
+      - task: run-simulation-{{.BACKEND}}
+
+  run-simulation-iverilog:
     desc: Run simulation using Icarus Verilog (iverilog)
     deps: [mkdir-build, copy-files]
     cmds:
@@ -139,6 +154,25 @@ tasks:
         +output_waveform={{.BUILD_DIR}}/{{.DESIGN}}.{{.WAVEFORM_TYPE}}
         +bitstream_hex={{.BUILD_DIR}}/{{.DESIGN}}.hex
         {{if eq .WAVEFORM_TYPE "fst"}}-fst{{end}}
+
+  run-simulation-xsim:
+    desc: Run simulation using AMD Vivado xsim
+    deps: [mkdir-build, copy-files]
+    cmds:
+      # Drop the design units a previous run left in the work library.
+      - rm -rf xsim.dir
+      # Never add -sv here: analysing the fabric as Verilog-2005 is the point.
+      - xvlog --nolog {{.EXTRA_XVLOG_FLAGS}} {{.FABRIC_FILES_DIR}}/*.v {{.USER_DESIGN_DIR}}/{{.DESIGN}}.v
+      - xvlog --nolog -sv {{.EXTRA_XVLOG_FLAGS}} {{.TESTBENCH}}.v
+      # xsim rejects a design where only some modules carry a `timescale.
+      - xelab --nolog -timescale 1ps/1ps {{.EXTRA_XELAB_FLAGS}} -s {{.XSIM_SNAPSHOT}} {{.TESTBENCH}}
+      - >-
+        xsim {{.XSIM_SNAPSHOT}} -R --log {{.BUILD_DIR}}/{{.XSIM_SNAPSHOT}}.log
+        -wdb {{.BUILD_DIR}}/{{.XSIM_SNAPSHOT}}.wdb
+        --testplusarg output_waveform={{.BUILD_DIR}}/{{.XSIM_SNAPSHOT}}.vcd
+        --testplusarg bitstream_hex={{.BUILD_DIR}}/{{.DESIGN}}.hex
+      # xsim exits 0 even after $fatal, so without this a mismatch reads as a pass.
+      - '! grep -q ''^Fatal:'' {{.BUILD_DIR}}/{{.XSIM_SNAPSHOT}}.log'
 
   gen-force-block:
     desc: Generate force_block.vh (gate-level X-init) from the hardened netlists
@@ -225,6 +259,7 @@ tasks:
       - test -d {{.FABRIC_FILES_DIR}}
 
   clean:
-    desc: Remove build directory
+    desc: Remove build directory and xsim leftovers
     cmds:
-      - rm -rf {{.BUILD_DIR}}
+      # xsim.dir and the .pb/.jou droppings are xsim's; --nolog does not cover them.
+      - rm -rf {{.BUILD_DIR}} xsim.dir xvlog.pb xelab.pb xsim.jou

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Test/sequential_16bit_en_tb.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Test/sequential_16bit_en_tb.v
@@ -49,7 +49,7 @@ module sequential_16bit_en_tb ();
     assign T_top_gold = ~oeb_gold;
 
     localparam integer       MAX_BITBYTES               = 16384;
-    reg                [7:0] bitstream   [MAX_BITBYTES]        ;
+    reg                [7:0] bitstream   [0:MAX_BITBYTES-1]    ;
 
     // a slower clock to make it easier to meet timing in gate-level sim
     always #500000 CLK = (CLK === 1'b0);

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Test/sequential_16bit_en_tb.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Test/sequential_16bit_en_tb.v
@@ -49,7 +49,7 @@ module sequential_16bit_en_tb ();
     assign T_top_gold = ~oeb_gold;
 
     localparam integer       MAX_BITBYTES               = 16384;
-    reg                [7:0] bitstream   [0:MAX_BITBYTES-1]    ;
+    reg                [7:0] bitstream   [MAX_BITBYTES]        ;
 
     // a slower clock to make it easier to meet timing in gate-level sim
     always #500000 CLK = (CLK === 1'b0);

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Test/sequential_16bit_en_tb.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Test/sequential_16bit_en_tb.v
@@ -123,4 +123,4 @@ module sequential_16bit_en_tb ();
 
 endmodule
 `endif
-`default_nettype wire
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/DSP/DSP_bot/MULADD.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/DSP/DSP_bot/MULADD.v
@@ -25,18 +25,18 @@
 module MULADD #(parameter integer NoConfigBits = 6) (
     // ConfigBits has to be adjusted manually
     // (we don't use an arithmetic parser for the value)
-    input  [ 7:0] A  , // operand A
-    input  [ 7:0] B  , // operand B
-    input  [19:0] C  , // operand C
-    output [19:0] Q  , // result
-    input         clr,
+    input  wire [ 7:0] A  , // operand A
+    input  wire [ 7:0] B  , // operand B
+    input  wire [19:0] C  , // operand C
+    output wire [19:0] Q  , // result
+    input  wire        clr,
     //The "EXTERNAL" keyword will send this signal all the way to top
     //The "SHARED" keyword allows multiple BELs using the same port
     // (e.g. for exporting a clock to the top)
-    (* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK,
+    (* FABulous, EXTERNAL, SHARED_PORT *) input wire UserCLK,
     // All primitive pins that are connected to the switch matrix have
     // to go before the "GLOBAL" label
-    (* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
+    (* FABulous, GLOBAL *) input wire [NoConfigBits-1:0] ConfigBits
 );
     reg  [ 7:0] A_reg           ; // port A read data register
     reg  [ 7:0] B_reg           ; // port B read data register

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/DSP/DSP_bot/MULADD.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/DSP/DSP_bot/MULADD.v
@@ -1,5 +1,3 @@
-`default_nettype none
-
 // Copyright 2021 University of Manchester
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+`default_nettype none
+
 (* FABulous, BelMap,
     A_reg=0,
     B_reg=1,
@@ -25,18 +25,18 @@
 module MULADD #(parameter integer NoConfigBits = 6) (
     // ConfigBits has to be adjusted manually
     // (we don't use an arithmetic parser for the value)
-    input  [ 7:0] A  , // operand A
-    input  [ 7:0] B  , // operand B
-    input  [19:0] C  , // operand C
-    output [19:0] Q  , // result
-    input         clr,
+    input  wire [ 7:0] A  , // operand A
+    input  wire [ 7:0] B  , // operand B
+    input  wire [19:0] C  , // operand C
+    output wire [19:0] Q  , // result
+    input  wire        clr,
     //The "EXTERNAL" keyword will send this signal all the way to top
     //The "SHARED" keyword allows multiple BELs using the same port
     // (e.g. for exporting a clock to the top)
-    (* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK,
+    (* FABulous, EXTERNAL, SHARED_PORT *) input wire UserCLK,
     // All primitive pins that are connected to the switch matrix have
     // to go before the "GLOBAL" label
-    (* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
+    (* FABulous, GLOBAL *) input wire [NoConfigBits-1:0] ConfigBits
 );
     reg  [ 7:0] A_reg           ; // port A read data register
     reg  [ 7:0] B_reg           ; // port B read data register
@@ -83,4 +83,4 @@ module MULADD #(parameter integer NoConfigBits = 6) (
         end
 
 endmodule
-`default_nettype wire
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/LUT4AB/LUT4c_frame_config_dffesr.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/LUT4AB/LUT4c_frame_config_dffesr.v
@@ -40,14 +40,14 @@ module LUT4c_frame_config_dffesr #(
     parameter integer NoConfigBits = 19
 ) (
     // ConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
-    input [3:0] I,  // Vector for I0, I1, I2, I3
-    output O,  // Single output for LUT result
-    input Ci,  // Carry chain input
-    output Co,  // Carry chain output
-    input SR,  // Shared reset
-    input EN,  // Shared enable
-    (* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK,
-    (* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits  // Config bits as vector
+    input wire [3:0] I,  // Vector for I0, I1, I2, I3
+    output wire O,  // Single output for LUT result
+    input wire Ci,  // Carry chain input
+    output wire Co,  // Carry chain output
+    input wire SR,  // Shared reset
+    input wire EN,  // Shared enable
+    (* FABulous, EXTERNAL, SHARED_PORT *) input wire UserCLK,
+    (* FABulous, GLOBAL *) input wire [NoConfigBits-1:0] ConfigBits  // Config bits as vector
 );
     localparam integer LUT_SIZE = 4;
     localparam integer N_LUT_FLOPS = 2 ** LUT_SIZE;

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/LUT4AB/LUT4c_frame_config_dffesr.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/LUT4AB/LUT4c_frame_config_dffesr.v
@@ -40,14 +40,14 @@ module LUT4c_frame_config_dffesr #(
     parameter integer NoConfigBits = 19
 ) (
     // ConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
-    input [3:0] I,  // Vector for I0, I1, I2, I3
-    output O,  // Single output for LUT result
-    input Ci,  // Carry chain input
-    output Co,  // Carry chain output
-    input SR,  // Shared reset
-    input EN,  // Shared enable
-    (* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK,
-    (* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits  // Config bits as vector
+    input wire [3:0] I,  // Vector for I0, I1, I2, I3
+    output wire O,  // Single output for LUT result
+    input wire Ci,  // Carry chain input
+    output wire Co,  // Carry chain output
+    input wire SR,  // Shared reset
+    input wire EN,  // Shared enable
+    (* FABulous, EXTERNAL, SHARED_PORT *) input wire UserCLK,
+    (* FABulous, GLOBAL *) input wire [NoConfigBits-1:0] ConfigBits  // Config bits as vector
 );
     localparam integer LUT_SIZE = 4;
     localparam integer N_LUT_FLOPS = 2 ** LUT_SIZE;
@@ -120,4 +120,4 @@ module LUT4c_frame_config_dffesr #(
     end
 
 endmodule
-`default_nettype wire
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/LUT4AB/MUX8LUT_frame_config_mux.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/LUT4AB/MUX8LUT_frame_config_mux.v
@@ -22,21 +22,21 @@ module MUX8LUT_frame_config_mux #(
     parameter integer NoConfigBits = 2
 ) (
     // ConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
-    input A,  // MUX inputs
-    input B,
-    input C,
-    input D,
-    input E,
-    input F,
-    input G,
-    input H,
-    input [3:0] S,
-    output M_AB,
-    output M_AD,
-    output M_AH,
-    output M_EF,
+    input wire A,  // MUX inputs
+    input wire B,
+    input wire C,
+    input wire D,
+    input wire E,
+    input wire F,
+    input wire G,
+    input wire H,
+    input wire [3:0] S,
+    output wire M_AB,
+    output wire M_AD,
+    output wire M_AH,
+    output wire M_EF,
     // All primitive pins that are connected to the switch matrix have to go before the "GLOBAL" label
-    (* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
+    (* FABulous, GLOBAL *) input wire [NoConfigBits-1:0] ConfigBits
 );
 
     wire AB, CD, EF, GH;

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/LUT4AB/MUX8LUT_frame_config_mux.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/LUT4AB/MUX8LUT_frame_config_mux.v
@@ -22,21 +22,21 @@ module MUX8LUT_frame_config_mux #(
     parameter integer NoConfigBits = 2
 ) (
     // ConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
-    input A,  // MUX inputs
-    input B,
-    input C,
-    input D,
-    input E,
-    input F,
-    input G,
-    input H,
-    input [3:0] S,
-    output M_AB,
-    output M_AD,
-    output M_AH,
-    output M_EF,
+    input wire A,  // MUX inputs
+    input wire B,
+    input wire C,
+    input wire D,
+    input wire E,
+    input wire F,
+    input wire G,
+    input wire H,
+    input wire [3:0] S,
+    output wire M_AB,
+    output wire M_AD,
+    output wire M_AH,
+    output wire M_EF,
     // All primitive pins that are connected to the switch matrix have to go before the "GLOBAL" label
-    (* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
+    (* FABulous, GLOBAL *) input wire [NoConfigBits-1:0] ConfigBits
 );
 
     wire AB, CD, EF, GH;
@@ -153,4 +153,4 @@ module MUX8LUT_frame_config_mux #(
     assign M_EF = EF;
 
 endmodule
-`default_nettype wire
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/Config_access.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/Config_access.v
@@ -10,9 +10,9 @@ module Config_access #(
     parameter integer NoConfigBits = 4
 ) (
     // ConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
-    (* FABulous, EXTERNAL *) output [3:0] C_bit,  // EXTERNAL
+    (* FABulous, EXTERNAL *) output wire [3:0] C_bit,  // EXTERNAL
     // All primitive pins that are connected to the switch matrix have to go before the "GLOBAL" label
-    (* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
+    (* FABulous, GLOBAL *) input wire [NoConfigBits-1:0] ConfigBits
 );
     // Configuration bits are wired to the fabric top module so that fabric-external functionality can be controlled from the user design
     assign C_bit = ConfigBits;

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/Config_access.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/Config_access.v
@@ -10,12 +10,12 @@ module Config_access #(
     parameter integer NoConfigBits = 4
 ) (
     // ConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
-    (* FABulous, EXTERNAL *) output [3:0] C_bit,  // EXTERNAL
+    (* FABulous, EXTERNAL *) output wire [3:0] C_bit,  // EXTERNAL
     // All primitive pins that are connected to the switch matrix have to go before the "GLOBAL" label
-    (* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
+    (* FABulous, GLOBAL *) input wire [NoConfigBits-1:0] ConfigBits
 );
     // Configuration bits are wired to the fabric top module so that fabric-external functionality can be controlled from the user design
     assign C_bit = ConfigBits;
 
 endmodule
-`default_nettype wire
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/InPass4_frame_config_mux.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/InPass4_frame_config_mux.v
@@ -24,14 +24,14 @@
 module InPass4_frame_config_mux #(
     parameter integer NoConfigBits = 4
 ) (
-    (* FABulous, EXTERNAL *) input [3:0] I,
-    output [3:0] O,
+    (* FABulous, EXTERNAL *) input wire [3:0] I,
+    output wire [3:0] O,
     // The "EXTERNAL" keyword will send this signal all the way to top
     // The "SHARED" keyword allows multiple BELs using the same port (e.g. for exporting a clock to the top)
     (* FABulous, EXTERNAL, SHARED_PORT *)
-    input UserCLK,
+    input wire UserCLK,
     // All primitive pins that are connected to the switch matrix have to go before the "GLOBAL" label
-    (* FABulous, GLOBAL *) input [NoConfigBits - 1 : 0] ConfigBits
+    (* FABulous, GLOBAL *) input wire [NoConfigBits - 1 : 0] ConfigBits
     //_____   ______
     //    I----+--->|FLOP|-Q-|1 M |
     //         |             |  U |-------> O

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/InPass4_frame_config_mux.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/InPass4_frame_config_mux.v
@@ -24,14 +24,14 @@
 module InPass4_frame_config_mux #(
     parameter integer NoConfigBits = 4
 ) (
-    (* FABulous, EXTERNAL *) input [3:0] I,
-    output [3:0] O,
+    (* FABulous, EXTERNAL *) input wire [3:0] I,
+    output wire [3:0] O,
     // The "EXTERNAL" keyword will send this signal all the way to top
     // The "SHARED" keyword allows multiple BELs using the same port (e.g. for exporting a clock to the top)
     (* FABulous, EXTERNAL, SHARED_PORT *)
-    input UserCLK,
+    input wire UserCLK,
     // All primitive pins that are connected to the switch matrix have to go before the "GLOBAL" label
-    (* FABulous, GLOBAL *) input [NoConfigBits - 1 : 0] ConfigBits
+    (* FABulous, GLOBAL *) input wire [NoConfigBits - 1 : 0] ConfigBits
     //_____   ______
     //    I----+--->|FLOP|-Q-|1 M |
     //         |             |  U |-------> O
@@ -72,4 +72,4 @@ module InPass4_frame_config_mux #(
         .X (O[3])
     );
 endmodule
-`default_nettype wire
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/OutPass4_frame_config_mux.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/OutPass4_frame_config_mux.v
@@ -26,14 +26,14 @@ module OutPass4_frame_config_mux #(
     parameter integer NoConfigBits = 4
 ) (
     // NoConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
-    input [3:0] I,
-    (* FABulous, EXTERNAL *) output [3:0] O,
+    input wire [3:0] I,
+    (* FABulous, EXTERNAL *) output wire [3:0] O,
     // The "EXTERNAL" keyword will send this signal all the way to top
     // The "SHARED" keyword allows multiple BELs using the same port (e.g. for exporting a clock to the top)
     (* FABulous, EXTERNAL, SHARED_PORT *)
-    input UserCLK,
+    input wire UserCLK,
     // All primitive pins that are connected to the switch matrix have to go before the "GLOBAL" label
-    (* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
+    (* FABulous, GLOBAL *) input wire [NoConfigBits-1:0] ConfigBits
 );
 
     //              ______   ______

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/OutPass4_frame_config_mux.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/OutPass4_frame_config_mux.v
@@ -26,14 +26,14 @@ module OutPass4_frame_config_mux #(
     parameter integer NoConfigBits = 4
 ) (
     // NoConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
-    input [3:0] I,
-    (* FABulous, EXTERNAL *) output [3:0] O,
+    input wire [3:0] I,
+    (* FABulous, EXTERNAL *) output wire [3:0] O,
     // The "EXTERNAL" keyword will send this signal all the way to top
     // The "SHARED" keyword allows multiple BELs using the same port (e.g. for exporting a clock to the top)
     (* FABulous, EXTERNAL, SHARED_PORT *)
-    input UserCLK,
+    input wire UserCLK,
     // All primitive pins that are connected to the switch matrix have to go before the "GLOBAL" label
-    (* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
+    (* FABulous, GLOBAL *) input wire [NoConfigBits-1:0] ConfigBits
 );
 
     //              ______   ______
@@ -76,4 +76,4 @@ module OutPass4_frame_config_mux #(
     );
 
 endmodule
-`default_nettype wire
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RegFile/RegFile_32x4.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RegFile/RegFile_32x4.v
@@ -40,7 +40,7 @@ module RegFile_32x4 #(
     (* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
 );
 
-    reg     [3:0] mem                                         [0:31];
+    reg     [3:0] mem                                         [32];
 
     wire    [3:0] AD_comb;  // port A read data, combinatorial
     wire    [3:0] BD_comb;  // port B read data, combinatorial

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RegFile/RegFile_32x4.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RegFile/RegFile_32x4.v
@@ -40,7 +40,7 @@ module RegFile_32x4 #(
     (* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
 );
 
-    reg     [3:0] mem                                         [32];
+    reg     [3:0] mem                                         [0:31];
 
     wire    [3:0] AD_comb;  // port A read data, combinatorial
     wire    [3:0] BD_comb;  // port B read data, combinatorial

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RegFile/RegFile_32x4.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RegFile/RegFile_32x4.v
@@ -23,24 +23,24 @@ module RegFile_32x4 #(
     parameter integer NoConfigBits = 2
 ) (
     // ConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
-    input [3:0] D,      // Write port
-    input [4:0] W_ADR,
-    input       W_en,
+    input  wire [3:0] D    ,      // Write port
+    input  wire [4:0] W_ADR,
+    input  wire       W_en ,
 
-    output [3:0] AD,    // Read port A
-    input  [4:0] A_ADR,
+    output wire [3:0] AD   ,    // Read port A
+    input  wire [4:0] A_ADR,
 
-    output [3:0] BD,    // Read port B
-    input  [4:0] B_ADR,
+    output wire [3:0] BD   ,    // Read port B
+    input  wire [4:0] B_ADR,
 
     // The "EXTERNAL" keyword will send this signal all the way to top
     // The "SHARED" allows multiple BELs using the same port (e.g. for exporting a clock to the top)
-    (* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK,
+    (* FABulous, EXTERNAL, SHARED_PORT *) input wire UserCLK,
     // All primitive pins that are connected to the switch matrix have to go before the "GLOBAL" label
-    (* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
+    (* FABulous, GLOBAL *) input wire [NoConfigBits-1:0] ConfigBits
 );
 
-    reg     [3:0] mem                                         [32];
+    reg     [3:0] mem                                         [0:31];
 
     wire    [3:0] AD_comb;  // port A read data, combinatorial
     wire    [3:0] BD_comb;  // port B read data, combinatorial

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RegFile/RegFile_32x4.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/RegFile/RegFile_32x4.v
@@ -23,24 +23,24 @@ module RegFile_32x4 #(
     parameter integer NoConfigBits = 2
 ) (
     // ConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
-    input [3:0] D,      // Write port
-    input [4:0] W_ADR,
-    input       W_en,
+    input  wire [3:0] D    ,      // Write port
+    input  wire [4:0] W_ADR,
+    input  wire       W_en ,
 
-    output [3:0] AD,    // Read port A
-    input  [4:0] A_ADR,
+    output wire [3:0] AD   ,    // Read port A
+    input  wire [4:0] A_ADR,
 
-    output [3:0] BD,    // Read port B
-    input  [4:0] B_ADR,
+    output wire [3:0] BD   ,    // Read port B
+    input  wire [4:0] B_ADR,
 
     // The "EXTERNAL" keyword will send this signal all the way to top
     // The "SHARED" allows multiple BELs using the same port (e.g. for exporting a clock to the top)
-    (* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK,
+    (* FABulous, EXTERNAL, SHARED_PORT *) input wire UserCLK,
     // All primitive pins that are connected to the switch matrix have to go before the "GLOBAL" label
-    (* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
+    (* FABulous, GLOBAL *) input wire [NoConfigBits-1:0] ConfigBits
 );
 
-    reg     [3:0] mem                                         [32];
+    reg     [3:0] mem                                         [0:31];
 
     wire    [3:0] AD_comb;  // port A read data, combinatorial
     wire    [3:0] BD_comb;  // port B read data, combinatorial
@@ -74,4 +74,4 @@ module RegFile_32x4 #(
     assign BD = ConfigBits[1] ? BD_reg : BD_comb;
 
 endmodule
-`default_nettype wire
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/W_IO/Config_access.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/W_IO/Config_access.v
@@ -11,9 +11,9 @@ module Config_access #(
         parameter integer NoConfigBits = 4
     ) (
         // ConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
-        (* FABulous, EXTERNAL *) output [3:0] C_bit,
+        (* FABulous, EXTERNAL *) output wire [3:0] C_bit,
         // All primitive pins that are connected to the switch matrix have to go before the "GLOBAL" label
-        (* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
+        (* FABulous, GLOBAL *) input wire [NoConfigBits-1:0] ConfigBits
     );
     // Configuration bits are wired to the fabric top module so that fabric-external functionality
     // can be controlled from the user design

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/W_IO/Config_access.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/W_IO/Config_access.v
@@ -11,13 +11,13 @@ module Config_access #(
         parameter integer NoConfigBits = 4
     ) (
         // ConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
-        (* FABulous, EXTERNAL *) output [3:0] C_bit,
+        (* FABulous, EXTERNAL *) output wire [3:0] C_bit,
         // All primitive pins that are connected to the switch matrix have to go before the "GLOBAL" label
-        (* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
+        (* FABulous, GLOBAL *) input wire [NoConfigBits-1:0] ConfigBits
     );
     // Configuration bits are wired to the fabric top module so that fabric-external functionality
     // can be controlled from the user design
     assign C_bit = ConfigBits;
 
 endmodule
-`default_nettype wire
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/W_IO/IO_1_bidirectional_frame_config_pass.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/W_IO/IO_1_bidirectional_frame_config_pass.v
@@ -16,19 +16,19 @@
 
 
 module IO_1_bidirectional_frame_config_pass (
-    input I,  // from fabric to external pin
-    input T,  // tristate control
-    output O,  // from external pin to fabric
+    input wire I,  // from fabric to external pin
+    input wire T,  // tristate control
+    output wire O,  // from external pin to fabric
     output reg Q,  // from external pin to fabric (registered)
 
     //These ports need to be available at the top-level, not the switch matrix
-    (* FABulous, EXTERNAL *) output I_top,
-    (* FABulous, EXTERNAL *) output T_top,
-    (* FABulous, EXTERNAL *) input O_top,
+    (* FABulous, EXTERNAL *) output wire I_top,
+    (* FABulous, EXTERNAL *) output wire T_top,
+    (* FABulous, EXTERNAL *) input wire O_top,
 
     // The "EXTERNAL" keyword will send this signal all the way to top
     // The "SHARED" keyword allows multiple BELs to use the same port (e.g. for exporting a clock to the top)
-    (* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK
+    (* FABulous, EXTERNAL, SHARED_PORT *) input wire UserCLK
     // All primitive pins that are connected to the switch matrix have to go before the "GLOBAL" label
 );
     //                        _____

--- a/fabulous/fabric_files/FABulous_project_template_verilog/Tile/W_IO/IO_1_bidirectional_frame_config_pass.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/Tile/W_IO/IO_1_bidirectional_frame_config_pass.v
@@ -16,19 +16,19 @@
 
 
 module IO_1_bidirectional_frame_config_pass (
-    input I,  // from fabric to external pin
-    input T,  // tristate control
-    output O,  // from external pin to fabric
+    input wire I,  // from fabric to external pin
+    input wire T,  // tristate control
+    output wire O,  // from external pin to fabric
     output reg Q,  // from external pin to fabric (registered)
 
     //These ports need to be available at the top-level, not the switch matrix
-    (* FABulous, EXTERNAL *) output I_top,
-    (* FABulous, EXTERNAL *) output T_top,
-    (* FABulous, EXTERNAL *) input O_top,
+    (* FABulous, EXTERNAL *) output wire I_top,
+    (* FABulous, EXTERNAL *) output wire T_top,
+    (* FABulous, EXTERNAL *) input wire O_top,
 
     // The "EXTERNAL" keyword will send this signal all the way to top
     // The "SHARED" keyword allows multiple BELs to use the same port (e.g. for exporting a clock to the top)
-    (* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK
+    (* FABulous, EXTERNAL, SHARED_PORT *) input wire UserCLK
     // All primitive pins that are connected to the switch matrix have to go before the "GLOBAL" label
 );
     //                        _____
@@ -47,4 +47,4 @@ module IO_1_bidirectional_frame_config_pass (
 
 
 endmodule
-`default_nettype wire
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_verilog/user_design/sequential_16bit_en.v
+++ b/fabulous/fabric_files/FABulous_project_template_verilog/user_design/sequential_16bit_en.v
@@ -19,4 +19,4 @@ module sequential_16bit_en (
     assign io_out = {12'b0, ctr};
     assign io_oeb = 28'b0000000000000000000000000001;
 endmodule
-`default_nettype wire
+`resetall

--- a/fabulous/fabric_files/FABulous_project_template_vhdl/Test/README.md
+++ b/fabulous/fabric_files/FABulous_project_template_vhdl/Test/README.md
@@ -31,3 +31,26 @@ Other useful make targets are:
 - `make run_GTKWave` to run the GTKWave waveform viewer with the generated simulation waveform
 
 Take a look into the Makefile to build your own flow.
+
+## Simulating with Vivado xsim
+
+`task run-simulation SIMULATOR=xvhdl` runs the same testbench under AMD
+Vivado's xsim, and `task fab-sim SIMULATOR=xvhdl` wraps it in the full
+build-fabric, build-design, simulate, clean cycle. It needs `xvhdl`, `xelab`
+and `xsim` on `PATH` from a Vivado installation.
+
+xvhdl analyses the fabric as VHDL-2008, the same standard nvc and ghdl are
+given, so this is a second opinion on the generated VHDL rather than a
+stricter one. The analysis order is the same as the nvc path, since a design
+unit has to reach the library before anything that instantiates it.
+
+Two behaviours are worth knowing. The run produces no waveform, because the
+testbench has no dump mechanism of its own and xsim takes no equivalent of
+nvc's `-w`; use the nvc or ghdl path when a waveform is wanted. And a mismatch
+between the fabric and the golden reference is reported at severity error,
+which leaves xsim's exit status at 0, so the task greps its log for that report
+instead of trusting the status.
+
+If `xelab` stops at `cannot find crt1.o`, its linker is not picking up the host
+C runtime; point it at the directory holding those objects, for example
+`LIBRARY_PATH=/usr/lib/x86_64-linux-gnu task run-simulation SIMULATOR=xvhdl`.

--- a/fabulous/fabric_files/FABulous_project_template_vhdl/Test/README.md
+++ b/fabulous/fabric_files/FABulous_project_template_vhdl/Test/README.md
@@ -34,10 +34,10 @@ Take a look into the Makefile to build your own flow.
 
 ## Simulating with Vivado xsim
 
-`task run-simulation-xsim` runs the same testbench under AMD Vivado's xsim, and
-`task fab-sim-xsim` wraps it in the full build-fabric, build-design, simulate,
-clean cycle. It needs `xvhdl`, `xelab` and `xsim` on `PATH` from a Vivado
-installation.
+`task run-simulation SIMULATOR=xvhdl` runs the same testbench under AMD
+Vivado's xsim, and `task fab-sim SIMULATOR=xvhdl` wraps it in the full
+build-fabric, build-design, simulate, clean cycle. It needs `xvhdl`, `xelab`
+and `xsim` on `PATH` from a Vivado installation.
 
 xvhdl analyses the fabric as VHDL-2008, the same standard nvc and ghdl are
 given, so this is a second opinion on the generated VHDL rather than a
@@ -53,4 +53,4 @@ instead of trusting the status.
 
 If `xelab` stops at `cannot find crt1.o`, its linker is not picking up the host
 C runtime; point it at the directory holding those objects, for example
-`LIBRARY_PATH=/usr/lib/x86_64-linux-gnu task run-simulation-xsim`.
+`LIBRARY_PATH=/usr/lib/x86_64-linux-gnu task run-simulation SIMULATOR=xvhdl`.

--- a/fabulous/fabric_files/FABulous_project_template_vhdl/Test/README.md
+++ b/fabulous/fabric_files/FABulous_project_template_vhdl/Test/README.md
@@ -31,3 +31,26 @@ Other useful make targets are:
 - `make run_GTKWave` to run the GTKWave waveform viewer with the generated simulation waveform
 
 Take a look into the Makefile to build your own flow.
+
+## Simulating with Vivado xsim
+
+`task run-simulation-xsim` runs the same testbench under AMD Vivado's xsim, and
+`task fab-sim-xsim` wraps it in the full build-fabric, build-design, simulate,
+clean cycle. It needs `xvhdl`, `xelab` and `xsim` on `PATH` from a Vivado
+installation.
+
+xvhdl analyses the fabric as VHDL-2008, the same standard nvc and ghdl are
+given, so this is a second opinion on the generated VHDL rather than a
+stricter one. The analysis order is the same as the nvc path, since a design
+unit has to reach the library before anything that instantiates it.
+
+Two behaviours are worth knowing. The run produces no waveform, because the
+testbench has no dump mechanism of its own and xsim takes no equivalent of
+nvc's `-w`; use the nvc or ghdl path when a waveform is wanted. And a mismatch
+between the fabric and the golden reference is reported at severity error,
+which leaves xsim's exit status at 0, so the task greps its log for that report
+instead of trusting the status.
+
+If `xelab` stops at `cannot find crt1.o`, its linker is not picking up the host
+C runtime; point it at the directory holding those objects, for example
+`LIBRARY_PATH=/usr/lib/x86_64-linux-gnu task run-simulation-xsim`.

--- a/fabulous/fabric_files/FABulous_project_template_vhdl/Test/Taskfile.yml
+++ b/fabulous/fabric_files/FABulous_project_template_vhdl/Test/Taskfile.yml
@@ -120,33 +120,24 @@ tasks:
         {{.BUILD_DIR}}/{{.DESIGN}}.hex
 
   run-simulation:
-    desc: Run simulation (auto-detects NVC/GHDL, or use SIMULATOR=nvc/ghdl)
-    deps: [mkdir-build]
-    env:
-      BUILD_DIR: '{{.BUILD_DIR}}'
+    desc: Run simulation (SIMULATOR=auto|nvc|ghdl, or xvhdl for AMD Vivado xsim)
+    vars:
+      BACKEND:
+        sh: |
+          case "{{.SIMULATOR}}" in
+            auto) which nvc >/dev/null 2>&1 && echo nvc || echo ghdl ;;
+            nvc|ghdl) echo "{{.SIMULATOR}}" ;;
+            xvhdl) echo xsim ;;
+          esac
+    preconditions:
+      - sh: 'test -n "{{.BACKEND}}"'
+        msg: "Unknown SIMULATOR '{{.SIMULATOR}}'. Use auto, nvc, ghdl or xvhdl."
     cmds:
-      - |
-        SIM="{{.SIMULATOR}}"
-        if [ "$SIM" = "nvc" ]; then
-          if ! which nvc >/dev/null 2>&1; then
-            echo "Error: SIMULATOR=nvc but nvc is not installed or not found in PATH" >&2
-            exit 1
-          fi
-          task run-simulation-nvc
-        elif [ "$SIM" = "ghdl" ]; then
-          task run-simulation-ghdl
-        elif [ "$SIM" = "auto" ]; then
-          if which nvc >/dev/null 2>&1; then
-            task run-simulation-nvc
-          else
-            task run-simulation-ghdl
-          fi
-        else
-          echo "Error: Unknown SIMULATOR value '$SIM'. Use nvc, ghdl, or auto." >&2
-          exit 1
-        fi
+      - task: run-simulation-{{.BACKEND}}
 
   run-simulation-nvc:
+    desc: Run simulation using NVC
+    deps: [mkdir-build]
     env:
       FAB_PROJ_ROOT: '{{.FAB_PROJ_ROOT}}'
       USER_DESIGN_DIR: '{{.USER_DESIGN_DIR}}'
@@ -163,6 +154,8 @@ tasks:
       - sh -c 'ulimit -s unlimited; nvc {{.NVC_GLOBAL_FLAGS}} -r {{.EXTRA_NVC_FLAGS}} $TESTBENCH -w$BUILD_DIR/$TESTBENCH.$WAVEFORM_TYPE --stats'
 
   run-simulation-ghdl:
+    desc: Run simulation using GHDL
+    deps: [mkdir-build]
     env:
       FAB_PROJ_ROOT: '{{.FAB_PROJ_ROOT}}'
       USER_DESIGN_DIR: '{{.USER_DESIGN_DIR}}'
@@ -187,28 +180,17 @@ tasks:
       DESIGN: '{{.DESIGN}}'
       TESTBENCH: '{{.TESTBENCH}}'
     cmds:
-      # The testbench opens the bitstream at a path relative to the working
-      # directory, so xsim runs from here as nvc and ghdl do.
+      # The testbench opens the bitstream relative to the working directory.
       - rm -rf xsim.dir
-      # Analysis order matters: a design unit has to be in the library before
-      # anything that instantiates it.
+      # A design unit must reach the library before anything instantiating it.
       - xvhdl --nolog -2008 {{.EXTRA_XVHDL_FLAGS}} $FAB_PROJ_ROOT/Fabric/models_pack.vhdl
       - sh -c 'for f in $(find $FAB_PROJ_ROOT/Tile/ -name "*.vhdl" -type f); do xvhdl --nolog -2008 {{.EXTRA_XVHDL_FLAGS}} "$f"; done'
       - sh -c 'for f in $(find $FAB_PROJ_ROOT/Fabric/ -name "*.vhdl" -type f ! -name "models_pack.vhdl"); do xvhdl --nolog -2008 {{.EXTRA_XVHDL_FLAGS}} "$f"; done'
       - xvhdl --nolog -2008 {{.EXTRA_XVHDL_FLAGS}} $USER_DESIGN_DIR/$DESIGN.vhdl $TESTBENCH.vhdl
       - xelab --nolog {{.EXTRA_XELAB_FLAGS}} -s {{.XSIM_SNAPSHOT}} $TESTBENCH
       - xsim {{.XSIM_SNAPSHOT}} -R --log {{.BUILD_DIR}}/{{.XSIM_SNAPSHOT}}.log
-      # A mismatch is reported at severity error, which neither aborts the run
-      # nor changes xsim's exit status, so without this it reads as a pass.
+      # A mismatch is a severity error, which leaves xsim's exit status at 0.
       - '! grep -qE ''^(Error|Fatal)'' {{.BUILD_DIR}}/{{.XSIM_SNAPSHOT}}.log'
-
-  fab-sim-xsim:
-    desc: Build demo fabric, build test design, run the xsim simulation, then clean up
-    cmds:
-      - task: build-demo-fabric
-      - task: build-test-design
-      - task: run-simulation-xsim
-      - task: clean
 
   gtkwave:
     desc: Open waveform in GTKWave

--- a/fabulous/fabric_files/FABulous_project_template_vhdl/Test/Taskfile.yml
+++ b/fabulous/fabric_files/FABulous_project_template_vhdl/Test/Taskfile.yml
@@ -29,6 +29,9 @@ vars:
   GHDL_ANALYZE_FLAGS: '{{.GHDL_ANALYZE_FLAGS | default ""}}'
   GHDL_ELAB_FLAGS: '{{.GHDL_ELAB_FLAGS | default "-fexplicit"}}'
   EXTRA_GHDL_FLAGS: '{{.EXTRA_GHDL_FLAGS | default ""}}'
+  EXTRA_XVHDL_FLAGS: '{{.EXTRA_XVHDL_FLAGS | default ""}}'
+  EXTRA_XELAB_FLAGS: '{{.EXTRA_XELAB_FLAGS | default ""}}'
+  XSIM_SNAPSHOT: '{{.XSIM_SNAPSHOT | default (printf "%s_xsim" .DESIGN)}}'
   BITSTREAM_BIN: '{{.BITSTREAM_BIN | default "{{.BUILD_DIR}}/{{.DESIGN}}.bin"}}'
 
 tasks:
@@ -175,6 +178,38 @@ tasks:
       - ghdl -e {{.GHDL_GLOBAL_FLAGS}} {{.GHDL_ELAB_FLAGS}} {{.EXTRA_GHDL_FLAGS}} $TESTBENCH
       - sh -c 'ulimit -s unlimited; ghdl -r {{.GHDL_GLOBAL_FLAGS}} {{.EXTRA_GHDL_FLAGS}} $TESTBENCH --stats --ieee-asserts=disable --{{.WAVEFORM_TYPE}}=$BUILD_DIR/$TESTBENCH.{{.WAVEFORM_TYPE}}'
 
+  run-simulation-xsim:
+    desc: Run simulation using AMD Vivado xsim
+    deps: [mkdir-build]
+    env:
+      FAB_PROJ_ROOT: '{{.FAB_PROJ_ROOT}}'
+      USER_DESIGN_DIR: '{{.USER_DESIGN_DIR}}'
+      DESIGN: '{{.DESIGN}}'
+      TESTBENCH: '{{.TESTBENCH}}'
+    cmds:
+      # The testbench opens the bitstream at a path relative to the working
+      # directory, so xsim runs from here as nvc and ghdl do.
+      - rm -rf xsim.dir
+      # Analysis order matters: a design unit has to be in the library before
+      # anything that instantiates it.
+      - xvhdl --nolog -2008 {{.EXTRA_XVHDL_FLAGS}} $FAB_PROJ_ROOT/Fabric/models_pack.vhdl
+      - sh -c 'for f in $(find $FAB_PROJ_ROOT/Tile/ -name "*.vhdl" -type f); do xvhdl --nolog -2008 {{.EXTRA_XVHDL_FLAGS}} "$f"; done'
+      - sh -c 'for f in $(find $FAB_PROJ_ROOT/Fabric/ -name "*.vhdl" -type f ! -name "models_pack.vhdl"); do xvhdl --nolog -2008 {{.EXTRA_XVHDL_FLAGS}} "$f"; done'
+      - xvhdl --nolog -2008 {{.EXTRA_XVHDL_FLAGS}} $USER_DESIGN_DIR/$DESIGN.vhdl $TESTBENCH.vhdl
+      - xelab --nolog {{.EXTRA_XELAB_FLAGS}} -s {{.XSIM_SNAPSHOT}} $TESTBENCH
+      - xsim {{.XSIM_SNAPSHOT}} -R --log {{.BUILD_DIR}}/{{.XSIM_SNAPSHOT}}.log
+      # A mismatch is reported at severity error, which neither aborts the run
+      # nor changes xsim's exit status, so without this it reads as a pass.
+      - '! grep -qE ''^(Error|Fatal)'' {{.BUILD_DIR}}/{{.XSIM_SNAPSHOT}}.log'
+
+  fab-sim-xsim:
+    desc: Build demo fabric, build test design, run the xsim simulation, then clean up
+    cmds:
+      - task: build-demo-fabric
+      - task: build-test-design
+      - task: run-simulation-xsim
+      - task: clean
+
   gtkwave:
     desc: Open waveform in GTKWave
     cmds:
@@ -190,4 +225,5 @@ tasks:
   clean:
     desc: Remove build directory and work library
     cmds:
-      - rm -rf {{.BUILD_DIR}}
+      # xsim.dir and the .pb/.jou droppings are xsim's; --nolog does not cover them.
+      - rm -rf {{.BUILD_DIR}} xsim.dir xvhdl.pb xelab.pb xsim.jou

--- a/fabulous/fabric_files/FABulous_project_template_vhdl/Test/Taskfile.yml
+++ b/fabulous/fabric_files/FABulous_project_template_vhdl/Test/Taskfile.yml
@@ -29,6 +29,9 @@ vars:
   GHDL_ANALYZE_FLAGS: '{{.GHDL_ANALYZE_FLAGS | default ""}}'
   GHDL_ELAB_FLAGS: '{{.GHDL_ELAB_FLAGS | default "-fexplicit"}}'
   EXTRA_GHDL_FLAGS: '{{.EXTRA_GHDL_FLAGS | default ""}}'
+  EXTRA_XVHDL_FLAGS: '{{.EXTRA_XVHDL_FLAGS | default ""}}'
+  EXTRA_XELAB_FLAGS: '{{.EXTRA_XELAB_FLAGS | default ""}}'
+  XSIM_SNAPSHOT: '{{.XSIM_SNAPSHOT | default (printf "%s_xsim" .DESIGN)}}'
   BITSTREAM_BIN: '{{.BITSTREAM_BIN | default "{{.BUILD_DIR}}/{{.DESIGN}}.bin"}}'
 
 tasks:
@@ -117,33 +120,24 @@ tasks:
         {{.BUILD_DIR}}/{{.DESIGN}}.hex
 
   run-simulation:
-    desc: Run simulation (auto-detects NVC/GHDL, or use SIMULATOR=nvc/ghdl)
-    deps: [mkdir-build]
-    env:
-      BUILD_DIR: '{{.BUILD_DIR}}'
+    desc: Run simulation (SIMULATOR=auto|nvc|ghdl, or xvhdl for AMD Vivado xsim)
+    vars:
+      BACKEND:
+        sh: |
+          case "{{.SIMULATOR}}" in
+            auto) which nvc >/dev/null 2>&1 && echo nvc || echo ghdl ;;
+            nvc|ghdl) echo "{{.SIMULATOR}}" ;;
+            xvhdl) echo xsim ;;
+          esac
+    preconditions:
+      - sh: 'test -n "{{.BACKEND}}"'
+        msg: "Unknown SIMULATOR '{{.SIMULATOR}}'. Use auto, nvc, ghdl or xvhdl."
     cmds:
-      - |
-        SIM="{{.SIMULATOR}}"
-        if [ "$SIM" = "nvc" ]; then
-          if ! which nvc >/dev/null 2>&1; then
-            echo "Error: SIMULATOR=nvc but nvc is not installed or not found in PATH" >&2
-            exit 1
-          fi
-          task run-simulation-nvc
-        elif [ "$SIM" = "ghdl" ]; then
-          task run-simulation-ghdl
-        elif [ "$SIM" = "auto" ]; then
-          if which nvc >/dev/null 2>&1; then
-            task run-simulation-nvc
-          else
-            task run-simulation-ghdl
-          fi
-        else
-          echo "Error: Unknown SIMULATOR value '$SIM'. Use nvc, ghdl, or auto." >&2
-          exit 1
-        fi
+      - task: run-simulation-{{.BACKEND}}
 
   run-simulation-nvc:
+    desc: Run simulation using NVC
+    deps: [mkdir-build]
     env:
       FAB_PROJ_ROOT: '{{.FAB_PROJ_ROOT}}'
       USER_DESIGN_DIR: '{{.USER_DESIGN_DIR}}'
@@ -160,6 +154,8 @@ tasks:
       - sh -c 'ulimit -s unlimited; nvc {{.NVC_GLOBAL_FLAGS}} -r {{.EXTRA_NVC_FLAGS}} $TESTBENCH -w$BUILD_DIR/$TESTBENCH.$WAVEFORM_TYPE --stats'
 
   run-simulation-ghdl:
+    desc: Run simulation using GHDL
+    deps: [mkdir-build]
     env:
       FAB_PROJ_ROOT: '{{.FAB_PROJ_ROOT}}'
       USER_DESIGN_DIR: '{{.USER_DESIGN_DIR}}'
@@ -174,6 +170,29 @@ tasks:
       - ghdl -a {{.GHDL_GLOBAL_FLAGS}} {{.GHDL_ANALYZE_FLAGS}} {{.EXTRA_GHDL_FLAGS}} $USER_DESIGN_DIR/$DESIGN.vhdl $TESTBENCH.vhdl
       - ghdl -e {{.GHDL_GLOBAL_FLAGS}} {{.GHDL_ELAB_FLAGS}} {{.EXTRA_GHDL_FLAGS}} $TESTBENCH
       - sh -c 'ulimit -s unlimited; ghdl -r {{.GHDL_GLOBAL_FLAGS}} {{.EXTRA_GHDL_FLAGS}} $TESTBENCH --stats --ieee-asserts=disable --{{.WAVEFORM_TYPE}}=$BUILD_DIR/$TESTBENCH.{{.WAVEFORM_TYPE}}'
+
+  run-simulation-xsim:
+    desc: Run simulation using AMD Vivado xsim
+    deps: [mkdir-build]
+    env:
+      FAB_PROJ_ROOT: '{{.FAB_PROJ_ROOT}}'
+      USER_DESIGN_DIR: '{{.USER_DESIGN_DIR}}'
+      DESIGN: '{{.DESIGN}}'
+      TESTBENCH: '{{.TESTBENCH}}'
+    # Runs from Test/ rather than a build subdirectory, because the testbench
+    # opens the bitstream at a path relative to the working directory.
+    cmds:
+      # Drop the design units a previous run left in the work library.
+      - rm -rf xsim.dir
+      # A design unit must reach the library before anything instantiating it.
+      - xvhdl --nolog -2008 {{.EXTRA_XVHDL_FLAGS}} $FAB_PROJ_ROOT/Fabric/models_pack.vhdl
+      - sh -c 'for f in $(find $FAB_PROJ_ROOT/Tile/ -name "*.vhdl" -type f); do xvhdl --nolog -2008 {{.EXTRA_XVHDL_FLAGS}} "$f"; done'
+      - sh -c 'for f in $(find $FAB_PROJ_ROOT/Fabric/ -name "*.vhdl" -type f ! -name "models_pack.vhdl"); do xvhdl --nolog -2008 {{.EXTRA_XVHDL_FLAGS}} "$f"; done'
+      - xvhdl --nolog -2008 {{.EXTRA_XVHDL_FLAGS}} $USER_DESIGN_DIR/$DESIGN.vhdl $TESTBENCH.vhdl
+      - xelab --nolog {{.EXTRA_XELAB_FLAGS}} -s {{.XSIM_SNAPSHOT}} $TESTBENCH
+      - xsim {{.XSIM_SNAPSHOT}} -R --log {{.BUILD_DIR}}/{{.XSIM_SNAPSHOT}}.log -wdb {{.BUILD_DIR}}/{{.XSIM_SNAPSHOT}}.wdb
+      # A mismatch is a severity error, which leaves xsim's exit status at 0.
+      - '! grep -qE ''^(Error|Fatal)'' {{.BUILD_DIR}}/{{.XSIM_SNAPSHOT}}.log'
 
   gtkwave:
     desc: Open waveform in GTKWave
@@ -190,4 +209,5 @@ tasks:
   clean:
     desc: Remove build directory and work library
     cmds:
-      - rm -rf {{.BUILD_DIR}}
+      # xsim.dir and the .pb/.jou droppings are xsim's; --nolog does not cover them.
+      - rm -rf {{.BUILD_DIR}} xsim.dir xvhdl.pb xelab.pb xsim.jou

--- a/fabulous/fabulous_repl/cmd_user_design.py
+++ b/fabulous/fabulous_repl/cmd_user_design.py
@@ -583,12 +583,15 @@ class UserDesignCommandSet(ReplCommandSet):
             ),
         ] = "",
         simulator: Annotated[
-            Literal["nvc", "ghdl", "auto", ""],
+            Literal["iverilog", "xvlog", "nvc", "ghdl", "xvhdl", "auto", ""],
             Option(
                 "--simulator",
                 "-s",
                 help_text=(
-                    "VHDL simulator to use: nvc, ghdl, or auto (default: auto-detect)"
+                    "Simulator backend: iverilog or xvlog for Verilog projects, "
+                    "nvc, ghdl, xvhdl or auto for VHDL ones. xvlog/xvhdl name the "
+                    "two AMD Vivado xsim front ends. Unset leaves the project "
+                    "Taskfile to choose: iverilog for Verilog, auto for VHDL"
                 ),
             ),
         ] = "",

--- a/tests/repl_test/test_cli.py
+++ b/tests/repl_test/test_cli.py
@@ -332,7 +332,7 @@ def test_run_simulation_with_simulator_flag(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test simulation passes --simulator to Taskfile as SIMULATOR."""
-    for sim in ("nvc", "ghdl", "auto"):
+    for sim in ("iverilog", "xvlog", "nvc", "ghdl", "xvhdl", "auto"):
         run_cmd(cli, f"{SIM_CMD} --simulator={sim}")
         log = normalize_and_check_for_errors(caplog.text)
         assert "Simulation finished" in log[-1]


### PR DESCRIPTION
Closes #977.

**fix(hdl)**. Every ANSI port in the template Verilog names `wire`, `input reg` in Frame_Data_Reg is `input wire` again, the `5'()` cast and the unsized `mem [32]` take their Verilog-2005 forms, and the `default_nettype wire` restore moves to end of file in models_pack.v and BlockRAM_1KB.v, where it sat after the first module and left the rest outside the `none` region. Generated fabric HDL, chip database and bitstream are byte-identical. `parameter reg [..]` in three files is left as is because xvlog, Yosys, iverilog and Verilator all accept it.

**feat(test)**. `SIMULATOR=xvlog` (Verilog) or `SIMULATOR=xvhdl` (VHDL) runs the existing testbench under Vivado xsim, from `task run-simulation` in a project, `run_simulation --simulator` in the REPL, or `task smoke-test SIMULATOR=...` at the repo root, where the value also picks the project language. xvlog reads the fabric as IEEE 1364-2005, so this is the check that would have caught #977. The VHDL `run-simulation` dispatcher no longer shells out to `task`, which had dropped CLI variables such as `DESIGN=`.

Verified locally with Vivado 2025.2: `task smoke-test SIMULATOR=<v>` passes for iverilog, xvlog, nvc and xvhdl, and a corrupted bitstream fails both xsim paths through the log grep.
