### PR TITLE
chore(deps): restrict Dependabot uv updates to lockfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     open-pull-requests-limit: 2
     labels:
       - "dependencies"
+    # Our pyproject.toml constraints are deliberately loose lower bounds. Only
+    # refresh the resolved versions in uv.lock; never rewrite the manifests.
+    versioning-strategy: "lockfile-only"
     groups:
       minor-and-patch:
         update-types:


### PR DESCRIPTION
## What

Adds `versioning-strategy: "lockfile-only"` to the `uv` entry in `.github/dependabot.yml`.

## Why

Dependabot's default strategy for `uv` is `auto`: it tries to guess app vs. library, and for apps it raises the minimum version requirement in the manifest to match every new release. That is why our uv PRs keep rewriting `pyproject.toml` — e.g. #968 bumped `pre-commit >=4.2.0` → `>=4.6.1` purely because 4.6.1 was published.

Our constraints are deliberately loose lower bounds; we don't want them ratcheting up on every upstream release. Per the [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#versioning-strategy), `lockfile-only` means "only create pull requests to update lockfiles. Ignore any new versions that would require package manifest changes." The single entry covers both `/` and `/docs`.

## Trade-offs

Worth knowing before merging — this is not a free win:

1. **Exact pins stop getting PRs entirely.** `sphinx-prompt==1.10.2` in `docs/pyproject.toml` can only move via a manifest edit, so Dependabot will now skip it. Anything with an upper bound is in the same position. Everything else in both manifests uses bare `>=`, so the locks still refresh normally.
2. **Transitive dependencies may stop being updated.** [dependabot/dependabot-core#14073](https://github.com/dependabot/dependabot-core/issues/14073) (open since 2026-02-02) reports that `uv` + `lockfile-only` bails out with `Requirements to unlock update_not_possible / No update possible` for transitive deps. If our uv PRs get noticeably thinner after this lands, that's the cause.
3. **The `major` group under this ecosystem becomes advisory.** Majors still land in the lock (a bare `>=` needs no manifest change), so the floor in `pyproject.toml` no longer records that we've moved on.

If (2) turns out to bite, `versioning-strategy: "increase-if-necessary"` is the middle ground: it leaves the requirement untouched whenever it already permits the new release, and only widens when the release genuinely falls outside the constraint. That would have left #968 alone while still updating transitives.

## Not fixed by this

The `/docs`-scoped PRs that edit the **root** `pyproject.toml` (#968, #943, #985) are a separate, still-open upstream bug: [dependabot-core#15253](https://github.com/dependabot/dependabot-core/issues/15253) — the editable path dep (`fabulous-fpga = { path = "..", editable = true }`) is fetched as a support file and treated as a workspace member, so a `/docs` job edits files outside its own directory. Fix PR [#15777](https://github.com/dependabot/dependabot-core/pull/15777) is open and unmerged. `lockfile-only` should mask the symptom here, since neither manifest gets edited.

## Testing

Config-only change; YAML parses and `versioning-strategy` is confirmed valid for `uv`. Takes effect on the next Monday schedule.
