### PR TITLE
doc: fix the comment about the default config mode in fabric.csv

### DIFF
--- a/docs/source/user_guide/building_doc/fabric_definition.md
+++ b/docs/source/user_guide/building_doc/fabric_definition.md
@@ -41,7 +41,7 @@ W_IO,  RegFile,  DSP_bot,  LUT4AB,  LUT4AB,  CPU_IO
 FabricEnd
 
 ParametersBegin
-ConfigBitMode, frame_based        # default is FlipFlopChain
+ConfigBitMode, frame_based        # default is frame_based
 FrameBitsPerRow, 32               # configuration bits per tile row
 MaxFramesPerCol, 20               # configuration bits per tile column
 Package, use work.my_package.all; # populate package fields in VHDL code generation

--- a/fabulous/fabric_files/FABulous_project_template_common/fabric.csv
+++ b/fabulous/fabric_files/FABulous_project_template_common/fabric.csv
@@ -19,7 +19,7 @@ FabricEnd,,,,,,,,,,,,,,,,,,
 
 ,,,,,,,,,,,,,,,,,,
 ParametersBegin,,,,,,,,,,,,,,,,,,
-ConfigBitMode,frame_based,# default is FlipFlopChain,,frame_based,,,,,,,,,,,,,,
+ConfigBitMode,frame_based,# default is frame_based,,frame_based,,,,,,,,,,,,,,
 #FrameBitsPerRow,32,"# we configure an entire configuration frame over the full height of the device (like Virtex-II) and we write FrameBitsPerRow bits per, well, tile=CLB height",,,,,,,,,,,,,,,,
 #MaxFramesPerCol,20,,,,,,,,,,,,,,,,,
 #Package,use work.my_package.all;,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
Our default (and currently only supported) mode is frame based configuration. so the comment in `fabric.csv` as well as in the `fabric.csv` example in the docs  is updated accordingly. 