### PR TITLE
Fix: added support for FlipFlopChain mode in tile and switch_matrix generation. 

### DIFF
--- a/fabulous/fabric_generator/code_generator/code_generator.py
+++ b/fabulous/fabric_generator/code_generator/code_generator.py
@@ -561,30 +561,6 @@ class CodeGenerator(abc.ABC):
         """
 
     @abc.abstractmethod
-    def addShiftRegister(self, configBits: int, indentLevel: int = 0) -> None:
-        """Add a shift register.
-
-        Parameters
-        ----------
-        configBits : int
-            The number of configuration bits.
-        indentLevel : int, optional
-            The level of indentation. Defaults to 0.
-        """
-
-    @abc.abstractmethod
-    def addFlipFlopChain(self, configBits: int, indentLevel: int = 0) -> None:
-        """Add a flip flop chain.
-
-        Parameters
-        ----------
-        configBits : int
-            The number of configuration bits.
-        indentLevel : int, optional
-            The level of indentation. Defaults to 0.
-        """
-
-    @abc.abstractmethod
     def addRegister(
         self,
         reg: str,

--- a/fabulous/fabric_generator/code_generator/code_generator_VHDL.py
+++ b/fabulous/fabric_generator/code_generator/code_generator_VHDL.py
@@ -1,6 +1,5 @@
 """The VHDL code generator."""
 
-import math
 import re
 from pathlib import Path
 from typing import Never
@@ -575,56 +574,6 @@ end process;
         self._add("\n".join(resultList))
         self.addNewLine()
         return configPortUsed
-
-    def addFlipFlopChain(self, configBitCounter: int) -> None:
-        """Add a flip-flop chain for configuration bits.
-
-        Parameters
-        ----------
-        configBitCounter : int
-            Total number of configuration bits.
-        """
-        template = f"""
-ConfigBitsInput <= ConfigBits(ConfigBitsInput'high-1 downto 0) & CONFin;
--- for k in 0 to Conf/2 generate
-L: for k in 0 to {int(math.ceil(configBitCounter / 2.0)) - 1} generate
-        inst_config_latch_a : config_latch
-        Port Map(
-            D    => ConfigBitsInput(k*2),
-            E    => CLK,
-            Q    => ConfigBits(k*2) );
-        inst_config_latch_b : config_latch
-        Port Map(
-            D    => ConfigBitsInput((k*2)+1),
-            E    => MODE,
-            Q    => ConfigBits((k*2)+1) );
-end generate;
-CONFout <= ConfigBits(ConfigBits'high);
-    """
-        self._add(template)
-
-    def addShiftRegister(self, indentLevel: int = 0) -> None:
-        """Add a shift register for configuration bits.
-
-        Parameters
-        ----------
-        indentLevel : int, optional
-            The indentation level. Defaults to 0.
-        """
-        template = """
--- the configuration bits shift register
-process(CLK)
-begin
-    if CLK'event and CLK='1' then
-        if mode='1' then    --configuration mode
-            ConfigBits <= CONFin & ConfigBits(ConfigBits'high downto 1);
-        end if;
-    end if;
-end process;
-CONFout <= ConfigBits(ConfigBits'high);
-
-    """
-        self._add(template, indentLevel)
 
     def addPreprocIfDef(self, _macro: str, _indentLevel: int = 0) -> Never:
         """Define to keep parity with Verilog.

--- a/fabulous/fabric_generator/code_generator/code_generator_Verilog.py
+++ b/fabulous/fabric_generator/code_generator/code_generator_Verilog.py
@@ -1,6 +1,5 @@
 """The Verilog code generator."""
 
-import math
 import re
 from pathlib import Path
 
@@ -340,54 +339,6 @@ class VerilogCodeGenerator(CodeGenerator):
                 configPortUsed = 0
 
         return configPortUsed
-
-    def addShiftRegister(self, configBits: int, indentLevel: int = 0) -> None:
-        """Add a shift register for configuration bits.
-
-        Args:
-            configBits: Number of configuration bits
-            indentLevel: The indentation level
-        """
-        template = f"""
-// the configuration bits shift register
-    always @ (posedge CLK)
-        begin
-            if (MODE=1b'1) begin    //configuration mode
-                ConfigBits <= {{CONFin,ConfigBits[{configBits}-1:1]}};
-            end
-        end
-    assign CONFout = ConfigBits[{configBits}-1];
-
-        """
-        self._add(template, indentLevel)
-
-    def addFlipFlopChain(self, configBits: int, indentLevel: int = 0) -> None:
-        """Add a flip-flop chain for configuration bits.
-
-        Args:
-            configBits: Number of configuration bits
-            indentLevel: The indentation level
-        """
-        cfgBit = int(math.ceil(configBits / 2.0)) * 2
-        template = f"""
-    genvar k;
-    assign ConfigBitsInput = {{ConfigBits[{cfgBit}-1-1:0], CONFin}};
-    // for k in 0 to Conf/2 generate
-    for (k=0; k < {cfgBit - 1}; k = k + 1) begin: L
-        config_latch inst_config_latch_a(
-            .D(ConfigBitsInput[k*2]),
-            .E(CLK),
-            .Q(ConfigBits[k*2])
-        );
-        config_latch inst_config_latch_b(
-            .D(ConfigBitsInput[(k*2)+1]),
-            .E(MODE),
-            .Q(ConfigBits[(k*2)+1])
-        );
-    end
-    assign CONFout = ConfigBits[{cfgBit}-1];
-"""
-        self._add(template, indentLevel)
 
     def addRegister(
         self,

--- a/fabulous/fabric_generator/gds_generator/flows/plugin_tile_flow.py
+++ b/fabulous/fabric_generator/gds_generator/flows/plugin_tile_flow.py
@@ -251,7 +251,6 @@ def _emit_regular_tile_verilog(
         writer,
         tile,
         switch_matrix_debug_signal,
-        config_bit_mode=config_bit_mode,
         multiplexer_style=multiplexer_style,
         default_pip_delay=_SWITCH_MATRIX_PIP_DELAY,
     )

--- a/fabulous/fabric_generator/gen_fabric/gen_fabric.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_fabric.py
@@ -531,7 +531,6 @@ def generateFabric(writer: CodeGenerator, fabric: Fabric) -> None:
                         )
 
             elif fabric.configBitMode == ConfigBitMode.FLIPFLOP_CHAIN:
-
                 portsPairs.append(("CONFin", f"conf_data[{chain_counter}]"))
                 portsPairs.append(("CONFout", f"conf_data[{chain_counter + 1}]"))
                 portsPairs.append(("CONF_CLK", "CONF_CLK"))

--- a/fabulous/fabric_generator/gen_fabric/gen_fabric.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_fabric.py
@@ -129,6 +129,14 @@ def generateFabric(writer: CodeGenerator, fabric: Fabric) -> None:
         )
         writer.addComment("CONFIG_PORT", onNewLine=False)
 
+    elif fabric.configBitMode == ConfigBitMode.FLIPFLOP_CHAIN:
+        writer.addPortScalar("CONFin", IO.INPUT, indentLevel=2)
+        writer.addComment("CONFIG_PORT", onNewLine=False)
+        writer.addPortScalar("CONFout", IO.OUTPUT, indentLevel=2)
+        writer.addComment("CONFIG_PORT", onNewLine=False)
+        writer.addPortScalar("CONF_CLK", IO.INPUT, indentLevel=2)
+        writer.addComment("CONFIG_CLK", onNewLine=False)
+
     if not fabric.disableUserCLK:
         writer.addPortScalar("UserCLK", IO.INPUT, indentLevel=2)
 
@@ -167,7 +175,7 @@ def generateFabric(writer: CodeGenerator, fabric: Fabric) -> None:
 
     writer.addComment("configuration signal declarations", onNewLine=True, end="\n")
 
-    if fabric.configBitMode == "FlipFlopChain":
+    if fabric.configBitMode == ConfigBitMode.FLIPFLOP_CHAIN:
         tileCounter = 0
         for row in fabric.tile:
             for t in row:
@@ -224,16 +232,6 @@ def generateFabric(writer: CodeGenerator, fabric: Fabric) -> None:
     # VHDL architecture body
     writer.addLogicStart()
 
-    # top configuration data daisy chaining
-    # this is copy and paste from tile code generation
-    # (so we can modify this here without side effects)
-    if fabric.configBitMode == "FlipFlopChain":
-        writer.addComment("configuration data daisy chaining", onNewLine=True)
-        writer.addAssignScalar("conf_data'low", "CONFin")
-        writer.addComment("conf_data'low=0 and CONFin is from tile entity")
-        writer.addAssignScalar("CONFout", "conf_data'high")
-        writer.addComment("CONFout is from tile entity")
-
     if fabric.configBitMode == ConfigBitMode.FRAME_BASED:
         for y in range(len(fabric.tile)):
             writer.addAssignVector(
@@ -251,6 +249,7 @@ def generateFabric(writer: CodeGenerator, fabric: Fabric) -> None:
             )
 
     instantiatedPosition = []
+    chain_counter = 0
     # Tile instantiations
     for y, row in enumerate(fabric.tile):
         for x, tile in enumerate(row):
@@ -530,6 +529,14 @@ def generateFabric(writer: CodeGenerator, fabric: Fabric) -> None:
                                 f"Tile_X{supertile_x}Y{supertile_y}_FrameStrobe_O",
                             )
                         )
+
+            elif fabric.configBitMode == ConfigBitMode.FLIPFLOP_CHAIN:
+
+                portsPairs.append(("CONFin", f"conf_data[{chain_counter}]"))
+                portsPairs.append(("CONFout", f"conf_data[{chain_counter + 1}]"))
+                portsPairs.append(("CONF_CLK", "CONF_CLK"))
+
+                chain_counter += 1
 
             name = ""
             emulateParamPairs = []

--- a/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
@@ -17,7 +17,6 @@ from loguru import logger
 from fabulous.fabric_definition.define import (
     IO,
     SWITCH_MATRIX_CONSTANTS,
-    ConfigBitMode,
     Direction,
     MultiplexerStyle,
 )
@@ -382,7 +381,6 @@ def _gen_switch_matrix_body(
 def gen_super_tile_switch_matrix(
     writer: CodeGenerator,
     superTile: SuperTile,
-    config_bit_mode: ConfigBitMode = ConfigBitMode.FRAME_BASED,
     multiplexer_style: MultiplexerStyle = MultiplexerStyle.CUSTOM,
     default_pip_delay: int = 80,
 ) -> None:
@@ -399,8 +397,6 @@ def gen_super_tile_switch_matrix(
         Code generator instance for RTL output.
     superTile : SuperTile
         The supertile whose BELs and SJUMP ports drive this matrix.
-    config_bit_mode : ConfigBitMode
-        Frame-based or flipflop-chain configuration.
     multiplexer_style : MultiplexerStyle
         Custom or generic multiplexer implementation.
     default_pip_delay : int
@@ -459,18 +455,8 @@ def gen_super_tile_switch_matrix(
 
     writer.addComment("global", onNewLine=True)
     if noConfigBits > 0:
-        if config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN:
-            writer.addPortScalar("MODE", IO.INPUT, indentLevel=2)
-            writer.addPortScalar("CONFin", IO.INPUT, indentLevel=2)
-            writer.addPortScalar("CONFout", IO.OUTPUT, indentLevel=2)
-            writer.addPortScalar("CLK", IO.INPUT, indentLevel=2)
-        if config_bit_mode == ConfigBitMode.FRAME_BASED:
-            writer.addPortVector(
-                "ConfigBits", IO.INPUT, "NoConfigBits-1", indentLevel=2
-            )
-            writer.addPortVector(
-                "ConfigBits_N", IO.INPUT, "NoConfigBits-1", indentLevel=2
-            )
+        writer.addPortVector("ConfigBits", IO.INPUT, "NoConfigBits-1", indentLevel=2)
+        writer.addPortVector("ConfigBits_N", IO.INPUT, "NoConfigBits-1", indentLevel=2)
     writer.addPortEnd()
     writer.addHeaderEnd(module_name)
     writer.addDesignDescriptionStart(module_name)

--- a/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
@@ -12,8 +12,6 @@ Key features:
 - Multiple configuration modes (FlipFlop chain, Frame-based)
 """
 
-import math
-
 from loguru import logger
 
 from fabulous.fabric_definition.define import (
@@ -195,19 +193,8 @@ def genTileSwitchMatrix(
 
     writer.addComment("global", onNewLine=True)
     if noConfigBits > 0:
-        if config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN:
-            writer.addPortScalar("MODE", IO.INPUT, indentLevel=2)
-            writer.addComment("global signal 1: configuration, 0: operation")
-            writer.addPortScalar("CONFin", IO.INPUT, indentLevel=2)
-            writer.addPortScalar("CONFout", IO.OUTPUT, indentLevel=2)
-            writer.addPortScalar("CLK", IO.INPUT, indentLevel=2)
-        if config_bit_mode == ConfigBitMode.FRAME_BASED:
-            writer.addPortVector(
-                "ConfigBits", IO.INPUT, "NoConfigBits-1", indentLevel=2
-            )
-            writer.addPortVector(
-                "ConfigBits_N", IO.INPUT, "NoConfigBits-1", indentLevel=2
-            )
+        writer.addPortVector("ConfigBits", IO.INPUT, "NoConfigBits-1", indentLevel=2)
+        writer.addPortVector("ConfigBits_N", IO.INPUT, "NoConfigBits-1", indentLevel=2)
     writer.addPortEnd()
     writer.addHeaderEnd(f"{tile.name}_switch_matrix")
     writer.addDesignDescriptionStart(f"{tile.name}_switch_matrix")
@@ -294,27 +281,7 @@ def _gen_switch_matrix_body(
         onNewLine=True,
     )
 
-    if noConfigBits > 0:
-        if config_bit_mode == "ff_chain":
-            writer.addConnectionVector("ConfigBits", noConfigBits)
-        if config_bit_mode == "FlipFlopChain":
-            writer.addConnectionVector(
-                "ConfigBits", int(math.ceil(noConfigBits / 2.0)) * 2
-            )
-            writer.addConnectionVector(
-                "ConfigBitsInput", int(math.ceil(noConfigBits / 2.0)) * 2
-            )
-
     writer.addLogicStart()
-
-    # TODO Should ff_chain be the same as FlipFlopChain?
-    if noConfigBits > 0:
-        if config_bit_mode == "ff_chain":
-            writer.addShiftRegister(noConfigBits)
-        elif config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN:
-            writer.addFlipFlopChain(noConfigBits)
-        elif config_bit_mode == ConfigBitMode.FRAME_BASED:
-            pass
 
     # the switch matrix implementation
     # we use the following variable to count the configuration bits of a

--- a/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
@@ -78,7 +78,6 @@ def genTileSwitchMatrix(
     writer: CodeGenerator,
     tile: Tile,
     switch_matrix_debug_signal: bool,
-    config_bit_mode: ConfigBitMode = ConfigBitMode.FRAME_BASED,
     multiplexer_style: MultiplexerStyle = MultiplexerStyle.CUSTOM,
     default_pip_delay: int = 80,
 ) -> None:
@@ -97,8 +96,6 @@ def genTileSwitchMatrix(
         The tile object containing BELs and port information
     switch_matrix_debug_signal : bool
         Whether to generate debug signals for the switch matrix.
-    config_bit_mode : ConfigBitMode
-        The configuration-bit mode for the tile (frame-based or flip-flop chain).
     multiplexer_style : MultiplexerStyle
         The multiplexer style used to implement switch-matrix muxes.
     default_pip_delay : int
@@ -202,8 +199,6 @@ def genTileSwitchMatrix(
         writer,
         tile.name,
         connections,
-        noConfigBits,
-        config_bit_mode,
         multiplexer_style,
         default_pip_delay,
         switch_matrix_debug_signal,
@@ -214,8 +209,6 @@ def _gen_switch_matrix_body(
     writer: CodeGenerator,
     name: str,
     connections: dict[str, list[str]],
-    noConfigBits: int,
-    config_bit_mode: ConfigBitMode,
     multiplexer_style: MultiplexerStyle,
     default_pip_delay: int,
     switch_matrix_debug_signal: bool,
@@ -234,10 +227,6 @@ def _gen_switch_matrix_body(
         Module/tile name used in log messages.
     connections : dict[str, list[str]]
         Mapping from sink port name to list of source port names.
-    noConfigBits : int
-        Total number of configuration bits for this matrix.
-    config_bit_mode : ConfigBitMode
-        Frame-based or flip-flop chain configuration.
     multiplexer_style : MultiplexerStyle
         Custom or generic multiplexer implementation.
     default_pip_delay : int
@@ -495,8 +484,6 @@ def gen_super_tile_switch_matrix(
         writer,
         superTile.name,
         connections,
-        noConfigBits,
-        config_bit_mode,
         multiplexer_style,
         default_pip_delay,
         switch_matrix_debug_signal=False,

--- a/fabulous/fabric_generator/gen_fabric/gen_tile.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_tile.py
@@ -404,7 +404,7 @@ def generateTile(
         )
 
     elif config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN and tile.globalConfigBits > 0:
-        writer.addComment("configuration storage latches", onNewLine=True)
+        writer.addComment("configuration storage FlipFlop", onNewLine=True)
         writer.addInstantiation(
             compName=f"{tile.name}_ConfigMem",
             compInsName=f"Inst_{tile.name}_ConfigMem",

--- a/fabulous/fabric_generator/gen_fabric/gen_tile.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_tile.py
@@ -301,7 +301,6 @@ def generateTile(
         writer.addLogicStart()
 
     if config_bit_mode == ConfigBitMode.FRAME_BASED:
-
         # buffer FrameData signals
         writer.addAssignScalar("FrameData_O_i", "FrameData_i")
         writer.addNewLine()
@@ -342,7 +341,9 @@ def generateTile(
             )
 
     elif config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN and tile.globalConfigBits == 0:
-        writer.addComment("Passthrough scan chain for unconfigured tile", onNewLine=True)
+        writer.addComment(
+            "Passthrough scan chain for unconfigured tile", onNewLine=True
+        )
         writer.addAssignScalar("CONFout", "CONFin")
 
     added = set()
@@ -588,7 +589,6 @@ def generateTile(
 
     writer.addDesignDescriptionEnd()
     writer.writeToFile()
-
 
 
 def generateSuperTile(

--- a/fabulous/fabric_generator/gen_fabric/gen_tile.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_tile.py
@@ -737,6 +737,15 @@ def generateSuperTile(
                         indentLevel=2,
                     )
                     writer.addComment("CONFIG_PORT", onNewLine=False)
+
+    elif config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN:
+        writer.addPortScalar("CONFin", IO.INPUT, indentLevel=2)
+        writer.addComment("CONFIG_PORT", onNewLine=False)
+        writer.addPortScalar("CONFout", IO.OUTPUT, indentLevel=2)
+        writer.addComment("CONFIG_PORT", onNewLine=False)
+        writer.addPortScalar("CONF_CLK", IO.INPUT, indentLevel=2)
+        writer.addComment("CONFIG_PORT", onNewLine=False)
+
     if not disable_user_clk:
         for y, row in enumerate(superTile.tileMap):
             for x, tile in enumerate(row):
@@ -782,7 +791,7 @@ def generateSuperTile(
                     "Need to run matrix generation first"
                 )
             writer.addComponentDeclarationForFile(str(sm_file))
-        if st_config_bits > 0 and config_bit_mode == ConfigBitMode.FRAME_BASED:
+        if st_config_bits > 0:
             cm_file = basePath / f"{superTile.name}_ConfigMem.vhdl"
             if not cm_file.exists():
                 raise FileNotFoundError(
@@ -848,22 +857,29 @@ def generateSuperTile(
                 0 <= y - 1 < len(superTile.tileMap)
                 and superTile.tileMap[y - 1][x] is not None
             ):
-                writer.addConnectionVector(
-                    f"Tile_X{x}Y{y}_FrameStrobe_O",
-                    "MaxFramesPerCol-1",
-                    indentLevel=1,
-                )
+                if config_bit_mode == ConfigBitMode.FRAME_BASED:
+                    writer.addConnectionVector(
+                        f"Tile_X{x}Y{y}_FrameStrobe_O",
+                        "MaxFramesPerCol-1",
+                        indentLevel=1,
+                    )
                 if not disable_user_clk:
                     writer.addConnectionScalar(f"Tile_X{x}Y{y}_UserCLKo", indentLevel=1)
             if (
                 0 <= x + 1 < len(superTile.tileMap[y])
                 and superTile.tileMap[y][x + 1] is not None
+                and config_bit_mode == ConfigBitMode.FRAME_BASED
             ):
                 writer.addConnectionVector(
                     f"Tile_X{x}Y{y}_FrameData_O", "FrameBitsPerRow-1", indentLevel=1
                 )
 
-    if st_config_bits > 0 and config_bit_mode == ConfigBitMode.FRAME_BASED:
+            if config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN:
+                writer.addNewLine()
+                writer.addComment("Internal FlipFLop Chain connections", onNewLine=True)
+                writer.addConnectionScalar(f"Tile_X{x}Y{y}_CONFout", indentLevel=1)
+
+    if st_config_bits > 0:
         writer.addConnectionVector(
             "ST_ConfigBits", f"{st_config_bits}-1", indentLevel=1
         )
@@ -874,6 +890,8 @@ def generateSuperTile(
     writer.addNewLine()
 
     writer.addLogicStart()
+
+    last_confout_wire = "CONFin"
 
     # pair up the connection for tile instantiation
     for y, row in enumerate(superTile.tileMap):
@@ -996,6 +1014,17 @@ def generateSuperTile(
 
                 ports_pairs.append(("FrameStrobe_O", f"Tile_X{x}Y{y}_FrameStrobe_O"))
 
+            elif config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN:
+                # add connection for CONF_CLK, CONFin and CONFout
+                ports_pairs.append(("CONF_CLK", "CONF_CLK"))
+
+                ports_pairs.append(("CONFin", last_confout_wire))
+
+                current_confout = f"Tile_X{x}Y{y}_CONFout"
+                ports_pairs.append(("CONFout", current_confout))
+
+                last_confout_wire = current_confout
+
             emulateParamPairs = [
                 ("Emulate_Bitstream", f"Tile_X{x}Y{y}_Emulate_Bitstream")
             ]
@@ -1008,38 +1037,57 @@ def generateSuperTile(
             )
 
     # Instantiate supertile ConfigMem (shares free slots in master tile's frame space)
-    if st_config_bits > 0 and config_bit_mode == ConfigBitMode.FRAME_BASED:
-        mx, my = superTile.get_master_tile_coords()
-        if (
-            0 <= mx - 1 < len(superTile.tileMap[0])
-            and superTile.tileMap[my][mx - 1] is not None
-        ):
-            cm_frame_data = f"Tile_X{mx - 1}Y{my}_FrameData_O"
-        else:
-            cm_frame_data = f"Tile_X{mx}Y{my}_FrameData"
-        if (
-            0 <= my + 1 < len(superTile.tileMap)
-            and superTile.tileMap[my + 1][mx] is not None
-        ):
-            cm_frame_strobe = f"Tile_X{mx}Y{my + 1}_FrameStrobe_O"
-        else:
-            cm_frame_strobe = f"Tile_X{mx}Y{my}_FrameStrobe"
-        writer.addInstantiation(
-            compName=f"{superTile.name}_ConfigMem",
-            compInsName=f"Inst_{superTile.name}_ConfigMem",
-            portsPairs=[
-                ("FrameData", cm_frame_data),
-                ("FrameStrobe", cm_frame_strobe),
-                ("ConfigBits", f"ST_ConfigBits[{st_config_bits}-1:0]"),
-                ("ConfigBits_N", f"ST_ConfigBits_N[{st_config_bits}-1:0]"),
-            ],
-            # The supertile config bits live in free slots of the master tile's
-            # frame space, so in emulation they are preloaded from the master
-            # tile's bitstream parameter (not its own frame shift register).
-            emulateParamPairs=[
-                ("Emulate_Bitstream", f"Tile_X{mx}Y{my}_Emulate_Bitstream")
-            ],
-        )
+    if st_config_bits > 0:
+        if config_bit_mode == ConfigBitMode.FRAME_BASED:
+            mx, my = superTile.get_master_tile_coords()
+            if (
+                0 <= mx - 1 < len(superTile.tileMap[0])
+                and superTile.tileMap[my][mx - 1] is not None
+            ):
+                cm_frame_data = f"Tile_X{mx - 1}Y{my}_FrameData_O"
+            else:
+                cm_frame_data = f"Tile_X{mx}Y{my}_FrameData"
+            if (
+                0 <= my + 1 < len(superTile.tileMap)
+                and superTile.tileMap[my + 1][mx] is not None
+            ):
+                cm_frame_strobe = f"Tile_X{mx}Y{my + 1}_FrameStrobe_O"
+            else:
+                cm_frame_strobe = f"Tile_X{mx}Y{my}_FrameStrobe"
+            writer.addInstantiation(
+                compName=f"{superTile.name}_ConfigMem",
+                compInsName=f"Inst_{superTile.name}_ConfigMem",
+                portsPairs=[
+                    ("FrameData", cm_frame_data),
+                    ("FrameStrobe", cm_frame_strobe),
+                    ("ConfigBits", f"ST_ConfigBits[{st_config_bits}-1:0]"),
+                    ("ConfigBits_N", f"ST_ConfigBits_N[{st_config_bits}-1:0]"),
+                ],
+                # The supertile config bits live in free slots of the master tile's
+                # frame space, so in emulation they are preloaded from the master
+                # tile's bitstream parameter (not its own frame shift register).
+                emulateParamPairs=[
+                    ("Emulate_Bitstream", f"Tile_X{mx}Y{my}_Emulate_Bitstream")
+                ],
+            )
+
+        elif config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN:
+            st_confout = f"{superTile.name}_CONFout"
+            writer.addConnectionScalar(st_confout, indentLevel=1)
+
+            writer.addInstantiation(
+                compName=f"{superTile.name}_ConfigMem",
+                compInsName=f"Inst_{superTile.name}_ConfigMem",
+                portsPairs=[
+                    ("CONFin", last_confout_wire),
+                    ("CONFout", st_confout),
+                    ("CONF_CLK", "CONF_CLK"),
+                    ("ConfigBits", f"ST_ConfigBits[{st_config_bits}-1:0]"),
+                    ("ConfigBits_N", f"ST_ConfigBits_N[{st_config_bits}-1:0]"),
+                ],
+            )
+
+            last_confout_wire = st_confout
 
     # Instantiate supertile switch matrix (if a matrix file was found)
     if superTile.supertile_matrix_dir is not None:
@@ -1071,10 +1119,7 @@ def generateSuperTile(
                             sm_ports_pairs.append(
                                 (f"{tileName}_{p.name}{k}", f"{tileName}_{p.name}[{k}]")
                             )
-        if (
-            superTile.supertile_matrix_config_bits > 0
-            and config_bit_mode == ConfigBitMode.FRAME_BASED
-        ):
+        if superTile.supertile_matrix_config_bits > 0:
             sm_ports_pairs.append(
                 (
                     "ConfigBits",
@@ -1134,7 +1179,7 @@ def generateSuperTile(
             else:
                 bel_user_clk = f"Tile_X{mx}Y{my}_UserCLK"
             bel_ports_pairs.append(("UserCLK", bel_user_clk))
-        if bel.configBit > 0 and config_bit_mode == ConfigBitMode.FRAME_BASED:
+        if bel.configBit > 0:
             bel_ports_pairs.append(
                 (
                     "ConfigBits",
@@ -1148,6 +1193,10 @@ def generateSuperTile(
             compInsName=f"Inst_ST_{bel.prefix}{bel.name}",
             portsPairs=bel_ports_pairs,
         )
+
+    if config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN:
+        writer.addAssignScalar("CONFout", last_confout_wire)
+        writer.addNewLine()
 
     writer.addDesignDescriptionEnd()
     writer.writeToFile()

--- a/fabulous/fabric_generator/gen_fabric/gen_tile.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_tile.py
@@ -297,8 +297,8 @@ def generateTile(
             )
             added.add((port.sourceName, port.destinationName))
 
-        writer.addNewLine()
-        writer.addLogicStart()
+    writer.addNewLine()
+    writer.addLogicStart()
 
     if config_bit_mode == ConfigBitMode.FRAME_BASED:
         # buffer FrameData signals

--- a/fabulous/fabric_generator/gen_fabric/gen_tile.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_tile.py
@@ -178,10 +178,9 @@ def generateTile(
         )
 
     elif config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN:
-        writer.addPortScalar("MODE", IO.INPUT, indentLevel=2)
         writer.addPortScalar("CONFin", IO.INPUT, indentLevel=2)
         writer.addPortScalar("CONFout", IO.OUTPUT, indentLevel=2)
-        writer.addPortScalar("CLK", IO.INPUT, indentLevel=2)
+        writer.addPortScalar("CONF_CLK", IO.INPUT, indentLevel=2)
 
     writer.addComment("global", onNewLine=True, indentLevel=1)
 
@@ -277,12 +276,13 @@ def generateTile(
         writer.addConnectionVector("ConfigBits", "NoConfigBits-1", 0)
         writer.addConnectionVector("ConfigBits_N", "NoConfigBits-1", 0)
 
-    writer.addNewLine()
-    writer.addComment("Connection for outgoing wires", onNewLine=True)
-    writer.addConnectionVector("FrameData_i", "FrameBitsPerRow-1", 0)
-    writer.addConnectionVector("FrameData_O_i", "FrameBitsPerRow-1", 0)
-    writer.addConnectionVector("FrameStrobe_i", "MaxFramesPerCol-1", 0)
-    writer.addConnectionVector("FrameStrobe_O_i", "MaxFramesPerCol-1", 0)
+    if config_bit_mode == ConfigBitMode.FRAME_BASED:
+        writer.addNewLine()
+        writer.addComment("Connection for outgoing wires", onNewLine=True)
+        writer.addConnectionVector("FrameData_i", "FrameBitsPerRow-1", 0)
+        writer.addConnectionVector("FrameData_O_i", "FrameBitsPerRow-1", 0)
+        writer.addConnectionVector("FrameStrobe_i", "MaxFramesPerCol-1", 0)
+        writer.addConnectionVector("FrameStrobe_O_i", "MaxFramesPerCol-1", 0)
 
     added = set()
     for port in tile.portsInfo:
@@ -297,47 +297,53 @@ def generateTile(
             )
             added.add((port.sourceName, port.destinationName))
 
-    writer.addNewLine()
-    writer.addLogicStart()
+        writer.addNewLine()
+        writer.addLogicStart()
 
-    # buffer FrameData signals
-    writer.addAssignScalar("FrameData_O_i", "FrameData_i")
-    writer.addNewLine()
-    for i in range(frame_bits_per_row):
-        writer.addInstantiation(
-            "my_buf",
-            f"data_inbuf_{i}",
-            portsPairs=[("A", f"FrameData[{i}]"), ("X", f"FrameData_i[{i}]")],
-        )
-    for i in range(frame_bits_per_row):
-        writer.addInstantiation(
-            "my_buf",
-            f"data_outbuf_{i}",
-            portsPairs=[
-                ("A", f"FrameData_O_i[{i}]"),
-                ("X", f"FrameData_O[{i}]"),
-            ],
-        )
+    if config_bit_mode == ConfigBitMode.FRAME_BASED:
 
-    # strobe is always added even when config bits are 0
-    writer.addAssignScalar("FrameStrobe_O_i", "FrameStrobe_i")
-    writer.addNewLine()
-    for i in range(max_frame_per_col):
-        writer.addInstantiation(
-            "my_buf",
-            f"strobe_inbuf_{i}",
-            portsPairs=[("A", f"FrameStrobe[{i}]"), ("X", f"FrameStrobe_i[{i}]")],
-        )
+        # buffer FrameData signals
+        writer.addAssignScalar("FrameData_O_i", "FrameData_i")
+        writer.addNewLine()
+        for i in range(frame_bits_per_row):
+            writer.addInstantiation(
+                "my_buf",
+                f"data_inbuf_{i}",
+                portsPairs=[("A", f"FrameData[{i}]"), ("X", f"FrameData_i[{i}]")],
+            )
+        for i in range(frame_bits_per_row):
+            writer.addInstantiation(
+                "my_buf",
+                f"data_outbuf_{i}",
+                portsPairs=[
+                    ("A", f"FrameData_O_i[{i}]"),
+                    ("X", f"FrameData_O[{i}]"),
+                ],
+            )
 
-    for i in range(max_frame_per_col):
-        writer.addInstantiation(
-            "my_buf",
-            f"strobe_outbuf_{i}",
-            portsPairs=[
-                ("A", f"FrameStrobe_O_i[{i}]"),
-                ("X", f"FrameStrobe_O[{i}]"),
-            ],
-        )
+        # strobe is always added even when config bits are 0
+        writer.addAssignScalar("FrameStrobe_O_i", "FrameStrobe_i")
+        writer.addNewLine()
+        for i in range(max_frame_per_col):
+            writer.addInstantiation(
+                "my_buf",
+                f"strobe_inbuf_{i}",
+                portsPairs=[("A", f"FrameStrobe[{i}]"), ("X", f"FrameStrobe_i[{i}]")],
+            )
+
+        for i in range(max_frame_per_col):
+            writer.addInstantiation(
+                "my_buf",
+                f"strobe_outbuf_{i}",
+                portsPairs=[
+                    ("A", f"FrameStrobe_O_i[{i}]"),
+                    ("X", f"FrameStrobe_O[{i}]"),
+                ],
+            )
+
+    elif config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN and tile.globalConfigBits == 0:
+        writer.addComment("Passthrough scan chain for unconfigured tile", onNewLine=True)
+        writer.addAssignScalar("CONFout", "CONFin")
 
     added = set()
     for port in tile.portsInfo:
@@ -383,13 +389,6 @@ def generateTile(
         )
 
     writer.addNewLine()
-    # top configuration data daisy chaining
-    if config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN:
-        writer.addComment("top configuration data daisy chaining", onNewLine=True)
-        writer.addAssignScalar("conf_data(conf_data'low)", "CONFin")
-        writer.addComment("conf_data'low=0 and CONFin is from tile entity")
-        writer.addAssignScalar("conf_data(conf_data'high)", "CONFout")
-        writer.addComment("CONFout is from tile entity")
 
     if config_bit_mode == ConfigBitMode.FRAME_BASED and tile.globalConfigBits > 0:
         writer.addComment("configuration storage latches", onNewLine=True)
@@ -405,12 +404,26 @@ def generateTile(
             emulateParamPairs=[("Emulate_Bitstream", "Emulate_Bitstream")],
         )
 
+    elif config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN and tile.globalConfigBits > 0:
+        writer.addComment("configuration storage latches", onNewLine=True)
+        writer.addInstantiation(
+            compName=f"{tile.name}_ConfigMem",
+            compInsName=f"Inst_{tile.name}_ConfigMem",
+            portsPairs=[
+                ("CONFin", "CONFin"),
+                ("CONFout", "CONFout"),
+                ("CONF_CLK", "CONF_CLK"),
+                ("ConfigBits", "ConfigBits"),
+                ("ConfigBits_N", "ConfigBits_N"),
+            ],
+            emulateParamPairs=[("Emulate_Bitstream", "Emulate_Bitstream")],
+        )
+
     # BEL component instantiations
     if tile.bels:
         writer.addNewLine()
         writer.addComment("BEL component instantiations", onNewLine=True)
 
-    belCounter = 0
     belConfigBitsCounter = 0
     for bel in tile.bels:
         port_dict = defaultdict(list)
@@ -458,20 +471,14 @@ def generateTile(
         if userclk_pair is not None:
             portsPairs.append(userclk_pair)
 
-        if config_bit_mode == ConfigBitMode.FRAME_BASED:
-            if bel.configBit > 0:
-                portsPairs.append(
-                    (
-                        "ConfigBits",
-                        f"ConfigBits[{belConfigBitsCounter + bel.configBit}-1:"
-                        f"{belConfigBitsCounter}]",
-                    )
+        if bel.configBit > 0:
+            portsPairs.append(
+                (
+                    "ConfigBits",
+                    f"ConfigBits[{belConfigBitsCounter + bel.configBit}-1:"
+                    f"{belConfigBitsCounter}]",
                 )
-        elif config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN:
-            portsPairs.append(("MODE", "Mode"))
-            portsPairs.append(("CONFin", f"conf_data({belCounter})"))
-            portsPairs.append(("CONFout", f"conf_data({belCounter + 1})"))
-            portsPairs.append(("CLK", "CLK"))
+            )
 
         writer.addInstantiation(
             compName=bel.name,
@@ -479,13 +486,7 @@ def generateTile(
             portsPairs=portsPairs,
         )
 
-        # FIXME: Why is the belCounter increased here by 2 and afterwards by 1?
-        belCounter += 2
         belConfigBitsCounter += bel.configBit
-
-        # for the next BEL (if any) for cascading configuration chain
-        # (this information is also needed for chaining the switch matrix)
-        belCounter += 1
 
     portsPairs = []
     # normal input wire (excludes JUMP and SJUMP, which are handled separately;
@@ -566,25 +567,18 @@ def generateTile(
 
     portsPairs += list(zip(port, signal, strict=True))
 
-    if config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN:
-        portsPairs.append(("MODE", "Mode"))
-        portsPairs.append(("CONFin", f"conf_data({belCounter})"))
-        portsPairs.append(("CONFout", f"conf_data({belCounter + 1})"))
-        portsPairs.append(("CLK", "CLK"))
-
-    if config_bit_mode == ConfigBitMode.FRAME_BASED and tile.globalConfigBits > 0:
-        portsPairs.append(
-            (
-                "ConfigBits",
-                f"ConfigBits[{tile.globalConfigBits}-1:{belConfigBitsCounter}]",
-            )
+    portsPairs.append(
+        (
+            "ConfigBits",
+            f"ConfigBits[{tile.globalConfigBits}-1:{belConfigBitsCounter}]",
         )
-        portsPairs.append(
-            (
-                "ConfigBits_N",
-                f"ConfigBits_N[{tile.globalConfigBits}-1:{belConfigBitsCounter}]",
-            )
+    )
+    portsPairs.append(
+        (
+            "ConfigBits_N",
+            f"ConfigBits_N[{tile.globalConfigBits}-1:{belConfigBitsCounter}]",
         )
+    )
 
     writer.addInstantiation(
         compName=f"{tile.name}_switch_matrix",
@@ -594,6 +588,7 @@ def generateTile(
 
     writer.addDesignDescriptionEnd()
     writer.writeToFile()
+
 
 
 def generateSuperTile(

--- a/fabulous/fabric_generator/gen_fabric/gen_tile.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_tile.py
@@ -470,15 +470,14 @@ def generateTile(
         if userclk_pair is not None:
             ports_pairs.append(userclk_pair)
 
-        if config_bit_mode == ConfigBitMode.FRAME_BASED:
-            if bel.configBit > 0:
-                ports_pairs.append(
-                    (
-                        "ConfigBits",
-                        f"ConfigBits[{belConfigBitsCounter + bel.configBit}-1:"
-                        f"{belConfigBitsCounter}]",
-                    )
+        if bel.configBit > 0:
+            ports_pairs.append(
+                (
+                    "ConfigBits",
+                    f"ConfigBits[{belConfigBitsCounter + bel.configBit}-1:"
+                    f"{belConfigBitsCounter}]",
                 )
+            )
 
         writer.addInstantiation(
             compName=bel.name,

--- a/fabulous/fabric_generator/gen_fabric/gen_tile.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_tile.py
@@ -568,18 +568,19 @@ def generateTile(
 
     portsPairs += list(zip(port, signal, strict=True))
 
-    portsPairs.append(
-        (
-            "ConfigBits",
-            f"ConfigBits[{tile.globalConfigBits}-1:{belConfigBitsCounter}]",
+    if tile.switch_matrix.no_config_bits > 0:
+        portsPairs.append(
+            (
+                "ConfigBits",
+                f"ConfigBits[{tile.globalConfigBits}-1:{belConfigBitsCounter}]",
+            )
         )
-    )
-    portsPairs.append(
-        (
-            "ConfigBits_N",
-            f"ConfigBits_N[{tile.globalConfigBits}-1:{belConfigBitsCounter}]",
+        portsPairs.append(
+            (
+                "ConfigBits_N",
+                f"ConfigBits_N[{tile.globalConfigBits}-1:{belConfigBitsCounter}]",
+            )
         )
-    )
 
     writer.addInstantiation(
         compName=f"{tile.name}_switch_matrix",

--- a/fabulous/fabric_generator/gen_fabric/gen_tile.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_tile.py
@@ -473,7 +473,7 @@ def generateTile(
             portsPairs.append(userclk_pair)
 
         if bel.configBit > 0:
-            portsPairs.append(
+            ports_pairs.append(
                 (
                     "ConfigBits",
                     f"ConfigBits[{belConfigBitsCounter + bel.configBit}-1:"

--- a/fabulous/fabric_generator/gen_fabric/gen_tile.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_tile.py
@@ -563,7 +563,6 @@ def generateTile(
 
     if tile.switch_matrix.no_config_bits > 0:
         ports_pairs.append(
-
             (
                 "ConfigBits",
                 f"ConfigBits[{tile.globalConfigBits}-1:{belConfigBitsCounter}]",

--- a/fabulous/fabric_generator/gen_fabric/gen_top_wrapper.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_top_wrapper.py
@@ -9,6 +9,8 @@ interfaces.
 import re
 from pathlib import Path
 
+from loguru import logger
+
 from fabulous.fabric_definition.define import IO, ConfigBitMode
 from fabulous.fabric_definition.fabric import Fabric
 from fabulous.fabric_generator.code_generator.code_generator import CodeGenerator
@@ -27,6 +29,7 @@ def generateTopWrapper(writer: CodeGenerator, fabric: Fabric) -> None:
     This includes features that are not located inside the fabric such as BRAM.
     """
     if fabric.configBitMode == ConfigBitMode.FLIPFLOP_CHAIN:
+        logger.info("Notice: Top wrapper generation is skipped for FlipFlopChain mode.")
         return
 
     def split_port(p: str) -> tuple[tuple[int, int], tuple[int, ...], str]:

--- a/fabulous/fabric_generator/gen_fabric/gen_top_wrapper.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_top_wrapper.py
@@ -9,7 +9,7 @@ interfaces.
 import re
 from pathlib import Path
 
-from fabulous.fabric_definition.define import IO
+from fabulous.fabric_definition.define import IO, ConfigBitMode
 from fabulous.fabric_definition.fabric import Fabric
 from fabulous.fabric_generator.code_generator.code_generator import CodeGenerator
 from fabulous.fabric_generator.code_generator.code_generator_Verilog import (
@@ -26,6 +26,8 @@ def generateTopWrapper(writer: CodeGenerator, fabric: Fabric) -> None:
 
     This includes features that are not located inside the fabric such as BRAM.
     """
+    if fabric.configBitMode == ConfigBitMode.FLIPFLOP_CHAIN:
+        return
 
     def split_port(p: str) -> tuple[tuple[int, int], tuple[int, ...], str]:
         """Parse and split a port name into components for sorting and grouping.

--- a/fabulous/fabulous_api.py
+++ b/fabulous/fabulous_api.py
@@ -352,7 +352,6 @@ class FABulous_API:
             gen_super_tile_switch_matrix(
                 self.writer,
                 tile,
-                config_bit_mode=self.fabric.configBitMode,
                 multiplexer_style=self.fabric.multiplexerStyle,
                 default_pip_delay=self.fabric.generateDelayInSwitchMatrix,
             )

--- a/fabulous/fabulous_api.py
+++ b/fabulous/fabulous_api.py
@@ -233,7 +233,6 @@ class FABulous_API:
                 self.writer,
                 tile,
                 switch_matrix_debug_signal,
-                config_bit_mode=self.fabric.configBitMode,
                 multiplexer_style=self.fabric.multiplexerStyle,
                 default_pip_delay=self.fabric.generateDelayInSwitchMatrix,
             )

--- a/tests/gds_flow_test/flow_test/test_plugin_tile_flow.py
+++ b/tests/gds_flow_test/flow_test/test_plugin_tile_flow.py
@@ -172,7 +172,6 @@ class TestEmitTileVerilog:
         gen_sm.assert_called_once()
         # Config-bit mode and mux style flow through instead of being hard-coded.
         sm_kwargs = gen_sm.call_args.kwargs
-        assert sm_kwargs["config_bit_mode"] == ConfigBitMode.FLIPFLOP_CHAIN
         assert sm_kwargs["multiplexer_style"] == MultiplexerStyle.GENERIC
         gen_cm.assert_called_once_with(
             mock_writer,


### PR DESCRIPTION
**Summary:**
1. Updated the tile generation logic for `FlipFlopChain` config mode 
2. Updated the switch matrix generation logic for `FlipFlopChain` mode
3. Removed `addFlipFlopChain` and `addShiftRegister` generation modules, which will be unused after #976.


