### PR TITLE
ci: stop stale-approval dismissal racing Dependabot's auto-approval

### DIFF
--- a/.github/workflows/dismiss-stale-approvals.yml
+++ b/.github/workflows/dismiss-stale-approvals.yml
@@ -13,7 +13,25 @@ jobs:
   dismiss-stale-approvals:
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        if: github.actor == 'dependabot[bot]'
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Skipped only for the pushes `dependabot-auto-merge.yml` re-approves, so
+      # this mirrors its `github.actor` guard rather than testing the pull
+      # request author: a human pushing to a Dependabot branch gets no
+      # re-approval and must still invalidate the old one. Its approval races
+      # this job, which dismisses on a pull request's first run because no
+      # baseline artifact exists yet. Major updates are never re-approved, so
+      # they keep the dismissal.
       - name: Dismiss stale pull request approvals
+        if: |
+          github.actor != 'dependabot[bot]' ||
+          steps.meta.outputs.dependency-group == 'major' ||
+          steps.meta.outputs.update-type == 'version-update:semver-major'
         uses: withgraphite/dismiss-stale-approvals@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Both workflows fire on `pull_request: opened`. The dismiss action has no baseline artifact on a PR's first run, so it dismisses, and whichever job finishes last decides whether the bot approval survives. When it loses, auto-merge stays enabled with no approval and the PR never reaches the merge queue.

Upstream: withgraphite/dismiss-stale-approvals#9. #918 has been stuck this way since July.