### PR TITLE
fix(tools): enforce a supported version range per tool

### DIFF
--- a/docs/source/getting_started/installation/cad-tool.md
+++ b/docs/source/getting_started/installation/cad-tool.md
@@ -15,6 +15,10 @@ This will install the [`oss-cad-suit`](https://github.com/YosysHQ/oss-cad-suite-
 Do **not** use the latest nightly build of Yosys. Nightly builds after **29 June** are **not** compatible with current FABulous and will fail. Install Yosys **0.66**, or any build dated **before 29 June**, instead.
 :::
 
+:::{warning}
+VHDL projects need [GHDL](https://github.com/ghdl/ghdl/releases) **6.0.0 or newer**. FABulous carries a BEL definition in user-defined VHDL attributes, and GHDL propagates those through `--synth --out=verilog` only from 6.0.0; 5.1.1 warns `unhandled attribute` and emits none, which leaves the BelMap empty. FABulous refuses to run against an older GHDL rather than generate a broken fabric. Check with `ghdl --version`.
+:::
+
 :::{note}
 If you just want to install `yosys` using **apt**, make sure you have at least Ubuntu 23.10 (24.04 for the LTS versions) installed to meet the above requirement.
 :::

--- a/fabulous/custom_exception.py
+++ b/fabulous/custom_exception.py
@@ -64,3 +64,7 @@ class PipelineCommandError(Exception):
 
 class InvalidState(Exception):
     """Exception raised for invalid state during fabric generation."""
+
+
+class UnsupportedToolVersion(Exception):
+    """Exception raised when an external tool is too old to be usable."""

--- a/fabulous/tools/ghdl.py
+++ b/fabulous/tools/ghdl.py
@@ -1,6 +1,6 @@
 """GHDL tool wrapper.
 
-GHDL elaborates a VHDL design (``--synth --out=verilog``) and writes the resulting
+GHDL elaborates a VHDL design (`--synth --out=verilog`) and writes the resulting
 Verilog netlist to stdout. This wrapper captures that output so the VHDL-to-Verilog
 conversion no longer needs a raw subprocess call in the caller. Used as a singleton
 via `GhdlTool.synthesize_to_verilog(...)`; never instantiated.
@@ -9,12 +9,20 @@ via `GhdlTool.synthesize_to_verilog(...)`; never instantiated.
 import tempfile
 from pathlib import Path
 
+from packaging.version import Version
+
 from fabulous.fabulous_settings import get_context
 from fabulous.tools.tool import Tool
 
 
 class GhdlTool(Tool):
     """Wraps the GHDL executable to elaborate VHDL into a Verilog netlist."""
+
+    MINIMUM_VERSION = Version("6.0.0")
+    VERSION_HINT = (
+        "An older GHDL drops user-defined VHDL attributes from "
+        "--synth --out=verilog, so the BelMap of a VHDL BEL comes back empty."
+    )
 
     @classmethod
     def executable(cls) -> Path | str:
@@ -37,11 +45,11 @@ class GhdlTool(Tool):
         ----------
         vhdl_file : Path
             The VHDL source file to elaborate. Its stem is used as the
-            top-level entity name passed to ``-e``.
+            top-level entity name passed to `-e`.
         models_pack : Path
             The FABulous models package GHDL needs on its analysis path.
         std : str
-            The VHDL standard passed to ``--std`` (default "08").
+            The VHDL standard passed to `--std` (default "08").
 
         Returns
         -------

--- a/fabulous/tools/opensta.py
+++ b/fabulous/tools/opensta.py
@@ -21,6 +21,10 @@ class OpenStaTool(Tool):
     singleton: call the classmethods directly, never instantiate.
     """
 
+    # OpenSTA takes single-dash flags; `--version` reaches it as a file to source,
+    # so it prints its usage and exits 1.
+    VERSION_ARGS = ["-version"]
+
     @classmethod
     def executable(cls) -> Path | str:
         """Return the OpenSTA executable from the FABulous context.

--- a/fabulous/tools/tool.py
+++ b/fabulous/tools/tool.py
@@ -1,29 +1,38 @@
 """Abstract base for external EDA tool wrappers.
 
 `Tool` is the root of the tool catalogue. It is never instantiated: every tool is
-used as a singleton through classmethods (e.g. ``YosysTool.run(...)``). The base
+used as a singleton through classmethods (e.g. `YosysTool.run(...)`). The base
 owns the single subprocess entry point (`run`), so every concrete wrapper (Yosys,
 OpenSTA, GHDL, and future tools such as nextpnr or OpenROAD) shares one place for
 invocation and error handling, and no business-logic code calls `subprocess`
 directly. Each subclass resolves its own executable from the FABulous context via
 `executable`.
+
+`run` is also where a tool's supported version range is enforced, so a wrapper
+declares `MINIMUM_VERSION` or `MAXIMUM_VERSION` and no caller ever asks for the
+check. The check runs once per tool and executable and is skipped for a wrapper
+that declares neither bound.
 """
 
+import re
 import subprocess
 from abc import ABC, abstractmethod
 from functools import cache
 from pathlib import Path
-from typing import NoReturn
+from typing import ClassVar, NoReturn
 
 from jinja2 import Environment, PackageLoader, StrictUndefined
 from loguru import logger
+from packaging.version import InvalidVersion, Version
+
+from fabulous.custom_exception import UnsupportedToolVersion
 
 
 @cache
 def _template_env() -> Environment:
     """Return the shared Jinja environment for tool script templates.
 
-    Templates live in the ``fabulous/template`` package directory.
+    Templates live in the `fabulous/template` package directory.
     `StrictUndefined` makes a missing variable a render error rather than an
     empty string, so a malformed template surfaces immediately.
 
@@ -41,6 +50,21 @@ def _template_env() -> Environment:
     )
 
 
+@cache
+def _check_version_once(tool: type["Tool"], _executable: str) -> None:
+    """Run `tool`'s version check the first time an executable is used.
+
+    Parameters
+    ----------
+    tool : type[Tool]
+        The tool wrapper whose version range is enforced.
+    _executable : str
+        The resolved executable. Unused in the body; it is part of the cache
+        key so that repointing a tool at another binary re-checks it.
+    """
+    tool.check_version()
+
+
 class Tool(ABC):
     """Abstract base for every external tool wrapper.
 
@@ -49,6 +73,16 @@ class Tool(ABC):
     `executable` to resolve its command, then builds its argument list and stdin
     and calls `run`.
     """
+
+    MINIMUM_VERSION: ClassVar[Version | None] = None
+    MAXIMUM_VERSION: ClassVar[Version | None] = None
+    VERSION_ARGS: ClassVar[list[str]] = ["--version"]
+    # Anchored to the first line: a version further down a banner is some other
+    # tool's, such as the GNAT version GHDL prints on its second line.
+    VERSION_PATTERN: ClassVar[re.Pattern[str]] = re.compile(
+        r"\A[^\n]*?(\d+(?:\.\d+)+[\w.+-]*)"
+    )
+    VERSION_HINT: ClassVar[str] = ""
 
     def __new__(cls, *_args: object, **_kwargs: object) -> NoReturn:
         """Reject instantiation; tools are used only through their classmethods.
@@ -77,7 +111,7 @@ class Tool(ABC):
         Parameters
         ----------
         template_name : str
-            Template file name within the ``fabulous/template`` directory.
+            Template file name within the `fabulous/template` directory.
         **context : object
             Variables made available to the template.
 
@@ -100,10 +134,74 @@ class Tool(ABC):
         """
 
     @classmethod
+    def version(cls) -> Version | None:
+        """Return the version the tool reports, or None if it reports none.
+
+        A build made outside a release, such as one built straight from a
+        working tree, can print a banner with no version in it. That is not an
+        error: the caller is told nothing is known rather than being stopped.
+
+        Returns
+        -------
+        Version | None
+            The parsed version, or None if the banner carries no readable one.
+        """
+        banner = cls.run(cls.VERSION_ARGS, check_version=False).stdout
+        if not (match := cls.VERSION_PATTERN.search(banner)):
+            logger.warning(
+                f"{cls.__name__} could not read a version from "
+                f"{cls.executable()}, which reported {banner.strip()!r}. "
+                f"Skipping the version check."
+            )
+            return None
+        try:
+            return Version(match.group(1))
+        except InvalidVersion:
+            logger.warning(
+                f"{cls.__name__} read the unparseable version "
+                f"{match.group(1)!r} from {cls.executable()}. Skipping the "
+                f"version check."
+            )
+            return None
+
+    @classmethod
+    def check_version(cls) -> None:
+        """Reject an executable outside this tool's supported version range.
+
+        Raises
+        ------
+        UnsupportedToolVersion
+            If the executable is older than `MINIMUM_VERSION` or newer than
+            `MAXIMUM_VERSION`.
+        """
+        if cls.MINIMUM_VERSION is None and cls.MAXIMUM_VERSION is None:
+            return
+        found = cls.version()
+        if found is None:
+            return
+        # A bound names a release, so the local segment a build carries past that
+        # release is dropped before comparing: oss-cad-suite ships Yosys as
+        # `0.66+NN`, which PEP 440 otherwise sorts above the 0.66 ceiling. A
+        # pre-release keeps its ordering, since `6.0.0.dev0` really does come
+        # before the 6.0.0 a floor asks for.
+        compared = Version(found.public)
+        if cls.MINIMUM_VERSION is not None and compared < cls.MINIMUM_VERSION:
+            raise UnsupportedToolVersion(
+                f"{cls.__name__} needs version {cls.MINIMUM_VERSION} or newer, "
+                f"but {cls.executable()} is {found}. {cls.VERSION_HINT}".strip()
+            )
+        if cls.MAXIMUM_VERSION is not None and compared > cls.MAXIMUM_VERSION:
+            raise UnsupportedToolVersion(
+                f"{cls.__name__} needs version {cls.MAXIMUM_VERSION} or older, "
+                f"but {cls.executable()} is {found}. {cls.VERSION_HINT}".strip()
+            )
+
+    @classmethod
     def run(
         cls,
         args: list[str] | None = None,
         stdin_data: str = "",
+        check_version: bool = True,
     ) -> subprocess.CompletedProcess:
         """Run the tool executable, capturing output and raising on failure.
 
@@ -113,6 +211,9 @@ class Tool(ABC):
             Arguments passed to the executable.
         stdin_data : str
             Data piped to the executable's stdin.
+        check_version : bool
+            Whether to enforce the supported version range first. `version`
+            clears it so that asking the tool what it is does not ask again.
 
         Returns
         -------
@@ -126,6 +227,9 @@ class Tool(ABC):
         """
         if args is None:
             args = []
+
+        if check_version:
+            _check_version_once(cls, str(cls.executable()))
 
         command: list[str] = [str(cls.executable()), *args]
 

--- a/fabulous/tools/yosys.py
+++ b/fabulous/tools/yosys.py
@@ -6,6 +6,8 @@ Used as a singleton through classmethods (`YosysTool.convert_to_json(...)`,
 
 from pathlib import Path
 
+from packaging.version import Version
+
 from fabulous.fabulous_settings import get_context
 from fabulous.tools.tool import Tool
 
@@ -16,6 +18,12 @@ class YosysTool(Tool):
     Converts Verilog into Yosys's JSON netlist format. Used as a singleton: call
     the classmethods directly, never instantiate.
     """
+
+    MAXIMUM_VERSION = Version("0.66")
+    VERSION_HINT = (
+        "Yosys changed behaviour FABulous has not been adapted to after the "
+        "0.66 release; see the CAD tool installation guide."
+    )
 
     @classmethod
     def executable(cls) -> Path | str:

--- a/tests/tools_test/test_tool_templates.py
+++ b/tests/tools_test/test_tool_templates.py
@@ -1,20 +1,51 @@
 """Tests for the Jinja-rendered tool scripts and their Python-side wiring.
 
 Covers the Yosys synthesis and OpenSTA SDF templates directly (exact rendered
-text) and the `analyze` wrapper that normalizes its inputs and feeds the rendered
-script to the tool.
+text), the `analyze` wrapper that normalizes its inputs and feeds the rendered
+script to the tool, and the GHDL version gate that keeps a too-old GHDL from
+silently stripping the VHDL attributes a BEL definition is carried in.
 """
 
+import subprocess
 import tempfile
 from pathlib import Path
 
 import pytest
+from packaging.version import Version
 from pytest_mock import MockerFixture
 
+from fabulous.custom_exception import UnsupportedToolVersion
 from fabulous.tools.ghdl import GhdlTool
 from fabulous.tools.opensta import OpenStaTool
-from fabulous.tools.tool import Tool
+from fabulous.tools.tool import Tool, _check_version_once
 from fabulous.tools.yosys import YosysTool
+
+
+def _reporting(
+    mocker: MockerFixture, tool_cls: type[Tool], version_output: str
+) -> None:
+    """Make `tool_cls` report `version_output` as its version banner.
+
+    Patches the subprocess call rather than `run`, so that `run` and the
+    version check hanging off it stay under test.
+
+    Parameters
+    ----------
+    mocker : MockerFixture
+        The pytest-mock fixture used to patch the tool.
+    tool_cls : type[Tool]
+        The tool wrapper being faked.
+    version_output : str
+        The stdout the tool is pretended to write for its version arguments.
+    """
+    mocker.patch.object(tool_cls, "executable", return_value=Path("/tool"))
+    mocker.patch(
+        "subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=version_output, stderr=""
+        ),
+    )
+    _check_version_once.cache_clear()
 
 
 def test_yosys_template_minimal() -> None:
@@ -170,3 +201,109 @@ def test_tool_cannot_be_instantiated(tool_cls: type[Tool]) -> None:
     """Tool wrappers are classmethod-only singletons and reject instantiation."""
     with pytest.raises(TypeError, match="cannot be instantiated"):
         tool_cls()
+
+
+@pytest.mark.parametrize(
+    ("tool_cls", "version_output", "expected"),
+    [
+        (
+            GhdlTool,
+            "GHDL 6.0.0 (6.0.0.r0.ge589c698c) [Dunoon edition]\n",
+            Version("6.0.0"),
+        ),
+        (
+            GhdlTool,
+            "GHDL 5.1.1 (4.1.0.r775.g91725e47f) [Dunoon edition]\n",
+            Version("5.1.1"),
+        ),
+        (
+            YosysTool,
+            "Yosys 0.62 (git sha1 7326bb7d, clang++ 21.1.2 -fPIC -O3)\n",
+            Version("0.62"),
+        ),
+        (OpenStaTool, "2.7.0\n", Version("2.7.0")),
+    ],
+)
+def test_version_parsed(
+    mocker: MockerFixture,
+    tool_cls: type[Tool],
+    version_output: str,
+    expected: Version,
+) -> None:
+    """Every tool's real banner puts its version first on the first line."""
+    _reporting(mocker, tool_cls, version_output)
+    assert tool_cls.version() == expected
+
+
+@pytest.mark.parametrize(
+    "version_output",
+    [
+        "",
+        "GHDL nightly\n",
+        # The GNAT version on the second line is not GHDL's.
+        "GHDL (built from a working tree)\n Compiled with GNAT Version: 13.3.0\n",
+    ],
+)
+def test_unreadable_version_is_not_fatal(
+    mocker: MockerFixture, version_output: str
+) -> None:
+    """A build with no version number in its banner is used, not rejected."""
+    _reporting(mocker, GhdlTool, version_output)
+    assert GhdlTool.version() is None
+    GhdlTool.check_version()
+
+
+@pytest.mark.parametrize(
+    ("tool_cls", "version_output"),
+    [
+        (GhdlTool, "GHDL 6.0.0 (6.0.0.r0.ge589c698c) [Dunoon edition]\n"),
+        (GhdlTool, "GHDL 7.1.0\n"),
+        (YosysTool, "Yosys 0.62 (git sha1 7326bb7d)\n"),
+        (YosysTool, "Yosys 0.66 (git sha1 7326bb7d)\n"),
+        # oss-cad-suite builds Yosys from master, so a build of the ceiling
+        # release carries the commits since its tag as a local segment.
+        (YosysTool, "Yosys 0.66+42 (git sha1 7326bb7d)\n"),
+        (OpenStaTool, "2.7.0\n"),
+    ],
+)
+def test_supported_version_accepted(
+    mocker: MockerFixture, tool_cls: type[Tool], version_output: str
+) -> None:
+    _reporting(mocker, tool_cls, version_output)
+    tool_cls.check_version()
+
+
+@pytest.mark.parametrize(
+    ("tool_cls", "version_output", "expected_message"),
+    [
+        (GhdlTool, "GHDL 5.1.1 (4.1.0.r775.g91725e47f)\n", "6.0.0 or newer"),
+        (YosysTool, "Yosys 0.67 (git sha1 7326bb7d)\n", "0.66 or older"),
+        (YosysTool, "Yosys 0.67+3 (git sha1 7326bb7d)\n", "0.66 or older"),
+        # A pre-release keeps its ordering: it comes before the release the
+        # floor asks for, so it cannot carry what that release added.
+        (GhdlTool, "GHDL 6.0.0-dev (6.0.0.r0)\n", "6.0.0 or newer"),
+    ],
+)
+def test_unsupported_version_rejected(
+    mocker: MockerFixture,
+    tool_cls: type[Tool],
+    version_output: str,
+    expected_message: str,
+) -> None:
+    _reporting(mocker, tool_cls, version_output)
+    with pytest.raises(UnsupportedToolVersion, match=expected_message):
+        tool_cls.check_version()
+
+
+def test_run_checks_version_once(mocker: MockerFixture) -> None:
+    """The gate hangs off `run`, so no caller has to ask for it."""
+    _reporting(mocker, GhdlTool, "GHDL 5.1.1 (4.1.0.r775.g91725e47f)\n")
+    with pytest.raises(UnsupportedToolVersion, match="6.0.0 or newer"):
+        GhdlTool.synthesize_to_verilog(Path("/bel.vhdl"), Path("/models_pack.vhdl"))
+
+
+def test_opensta_is_asked_with_the_flag_it_has(mocker: MockerFixture) -> None:
+    """`--version` is not an OpenSTA flag: it prints usage and exits 1."""
+    _reporting(mocker, OpenStaTool, "2.7.0\n")
+    assert OpenStaTool.version() == Version("2.7.0")
+    assert subprocess.run.call_args.args[0] == ["/tool", "-version"]

--- a/tests/utils_test/test_yosys_obj.py
+++ b/tests/utils_test/test_yosys_obj.py
@@ -11,6 +11,7 @@ import pytest_mock
 
 from fabulous.custom_exception import InvalidFileType
 from fabulous.fabric_definition.yosys_obj import YosysJson
+from fabulous.tools.tool import _check_version_once
 
 
 def setup_mocks(
@@ -59,28 +60,29 @@ def setup_mocks(
     ),
     [
         (
+            # Two extra calls: GHDL and Yosys are each asked for a version.
             ".vhdl",
             {"FAB_PROJ_LANG": "VHDL"},
             '{"modules": {"test": {}}}',
             "entity test is end entity;",
-            2,
-            [(0, "ghdl"), (1, "yosys")],
+            4,
+            [(0, "ghdl"), (1, "--synth"), (2, "yosys"), (3, "read_verilog")],
         ),
         (
             ".sv",
             {},
             "{}",
             None,
-            1,
-            [(None, "read_verilog -sv")],
+            2,
+            [(0, "--version"), (1, "read_verilog -sv")],
         ),
         (
             ".v",
             {},
             "{}",
             None,
-            1,
-            [(None, "read_verilog")],
+            2,
+            [(0, "--version"), (1, "read_verilog")],
         ),
     ],
 )
@@ -97,6 +99,8 @@ def test_yosys_json_initialization_parametric(
 ) -> None:
     """Parametrized test for YosysJson initialization across HDL types."""
     # Mock external dependencies
+    # No version is readable out of this stdout, so no version gate fires.
+    _check_version_once.cache_clear()
     m = mocker.patch(
         "subprocess.run",
         return_value=type(


### PR DESCRIPTION
Closes #1014.

`FABulous create-project demo_vhdl -w vhdl` then `load_fabric` fails with `length of BelMap is 0, but with 19 config bits` on GHDL older than 6.0.0.

## Cause

A BEL definition is carried in user-defined VHDL attributes, and GHDL propagates those through `--synth --out=verilog` only from 6.0.0. Measured on the same project and commit:

| GHDL | `(* ... *)` blocks in the emitted Verilog | `load_fabric` |
|---|---|---|
| 5.1.1 | 0 (warns `unhandled attribute`) | the reported error |
| 6.0.0 | 3, including `BelMap`, `INIT*`, `IOmux` | `Complete` |

CI is green because Nix pins 6.0.0. The comment-based fallback in `yosys_obj.py` that was meant to backfill the BelMap never fired: its regex has no `re.DOTALL` and the comment spans four lines. It is left alone here.

## Change

`Tool.run` enforces a version range before invoking anything, so no caller asks for the check. A wrapper declares `MINIMUM_VERSION` or `MAXIMUM_VERSION`; the check runs once per tool and executable.

- `GhdlTool`: floor of 6.0.0.
- `YosysTool`: ceiling of 0.66, the version the installation guide already documents. The pinned toolchain builds exactly 0.66, so this is inert today — but a `yosys-src` bump past it will fail every job at the gate.
- `OpenStaTool`: no bound declared, never gated.

A banner with no readable version, which is what a build made outside a release prints, warns and skips the check rather than stopping the run.

```
GhdlTool needs version 6.0.0 or newer, but /nix/store/.../ghdl is 5.1.1. An older
GHDL drops user-defined VHDL attributes from --synth --out=verilog, so the BelMap
of a VHDL BEL comes back empty.
```

## Testing

- 15 tests over the gate across all three wrappers.
- Live: GHDL 5.1.1 rejected, GHDL 6.0.0 and Yosys 0.66 reach `Complete`.
- `tests/{tools,fabric_gen,utils,repl}_test`: 833 passed, 27 skipped.

## Not covered

`fabulous/fabric_cad/timing_model/tools/` holds a separate `SynthTool`/`StaTool` hierarchy that shells out to Yosys and OpenSTA on its own and stays ungated.