### PR TITLE
ci: authenticate the svlint release lookup and retry its rate limit

### DIFF
--- a/.github/workflows/pre-commit-hooks.yml
+++ b/.github/workflows/pre-commit-hooks.yml
@@ -21,6 +21,10 @@ jobs:
         uv sync --locked --all-extras --dev
 
     - name: run pre-commit
+      # svlint_wrapper resolves its pinned release through the GitHub API, which
+      # rate-limits unauthenticated runners off a shared IP.
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         uv run pre-commit install
         SKIP=no-commit-to-branch uv run pre-commit run --show-diff-on-failure --color=always --all-files

--- a/scripts/svlint_wrapper.py
+++ b/scripts/svlint_wrapper.py
@@ -107,6 +107,36 @@ def file_lock(path: Path) -> Iterator[None]:
             fcntl.flock(f, fcntl.LOCK_UN)
 
 
+def api_request(url: str) -> urllib.request.Request:
+    """Build a GitHub API request, authenticated when `GITHUB_TOKEN` is set.
+
+    Unauthenticated callers share a 60 requests per hour quota with everything
+    else on the same IP, which CI runners exhaust routinely. A token raises the
+    ceiling to 1000 per hour for the repository.
+    """
+    request = urllib.request.Request(  # noqa: S310
+        url, headers={"Accept": "application/vnd.github+json"}
+    )
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    return request
+
+
+def is_retryable(error: urllib.error.HTTPError) -> bool:
+    """Report whether another attempt could succeed.
+
+    GitHub answers an exhausted rate limit with 403 rather than 429, so a plain
+    status-set test never retries the case the loop exists for. The quota resets
+    on the hour, so the backoff rarely outlasts it on its own; the token in
+    `api_request` is what keeps this from failing. A 403 without the header is a
+    permission error and is not worth retrying.
+    """
+    if error.code in TRANSIENT_STATUSES:
+        return True
+    return error.code == 403 and error.headers.get("x-ratelimit-remaining") == "0"
+
+
 def fetch_json(url: str) -> dict[str, object]:
     """Fetch a JSON document, retrying transient errors."""
     last_exc: Exception | None = None
@@ -115,11 +145,11 @@ def fetch_json(url: str) -> dict[str, object]:
         msg += f"(attempt {attempt}/{DOWNLOAD_ATTEMPTS})\n"
         sys.stderr.write(msg)
         try:
-            with urllib.request.urlopen(url, timeout=60) as resp:
+            with urllib.request.urlopen(api_request(url), timeout=60) as resp:
                 return json.loads(resp.read().decode("utf-8"))
         except urllib.error.HTTPError as e:
             last_exc = e
-            if e.code not in TRANSIENT_STATUSES:
+            if not is_retryable(e):
                 raise
         except (urllib.error.URLError, TimeoutError, ConnectionError) as e:
             last_exc = e
@@ -148,7 +178,7 @@ def fetch_archive(url: str, dest_dir: Path) -> Path:
                 return Path(tmp.name)
         except urllib.error.HTTPError as e:
             last_exc = e
-            if e.code not in TRANSIENT_STATUSES:
+            if not is_retryable(e):
                 raise
         except (urllib.error.URLError, TimeoutError, ConnectionError) as e:
             last_exc = e


### PR DESCRIPTION
`pre-commit` failed on #1028 with `HTTP Error 403: rate limit exceeded` from the
svlint hook. Not caused by that PR, and it can hit any branch.

`svlint_wrapper` resolves its pinned release through an unauthenticated
api.github.com call, so it shares a 60 requests per hour quota with everything
else on the runner's IP, and nothing caches the binary between runs. The lookup
now sends `GITHUB_TOKEN`, which the workflow passes, for 1000 per hour instead.

The retry loop was also dead code for this case: GitHub reports an exhausted
rate limit as 403, which is not in `TRANSIENT_STATUSES`, so `fetch_json`
re-raised on attempt 1 of 5. The failing log shows exactly that. A 403 now
counts as transient when the response carries `x-ratelimit-remaining: 0`, and a
403 that is a real permission error still raises immediately.

Verified locally: cold `XDG_CACHE_HOME` downloads with and without a token, the
403 branch retries all 5 attempts, a bare 403 and a 404 still raise at once, and
`pre-commit run --all-files` passes.
